### PR TITLE
Feature/nonlinear shallow water

### DIFF
--- a/etc/cli/default.json
+++ b/etc/cli/default.json
@@ -1,0 +1,148 @@
+{
+  "self_model": {
+    "name": "Spectral Element Library in Fortran (SELF)",
+    "version": "v1.0.0",
+    "description": "SELF",
+    "license": "ANTI-CORPORATIST SOFTWARE LICENSE",
+    "authors": "Joseph Schoonover (Fluid Numerics LLC)",
+    "sponsors": ["Fluid Numerics LLC"],
+    "options": [
+      {
+        "type": "logical",
+        "cli_long": "--mpi",
+        "cli_short": "-mpi",
+        "description": "Enable MPI",
+	"display_name": "MPI Enabled",
+        "value" : "false",
+	"action": "store_true",
+	"required": false,
+	"choices": ""
+      },
+      {
+        "type": "logical",
+        "cli_long": "--gpu",
+        "cli_short": "-gpu",
+        "description": "Enable GPU acceleration",
+	"display_name": "GPU Acceleration",
+        "value" : "false",
+	"action": "store_true",
+	"required": false,
+	"choices": ""
+      },
+      {
+        "type": "real",
+        "cli_long": "--time-step",
+        "cli_short": "-dt",
+        "description": "The time step size for the time integrator",
+	"display_name": "\u0394t",
+        "value" : "0.0005",
+	"action": "",
+	"required": false,
+	"choices": ""
+      },
+      {
+        "type": "real",
+        "cli_long": "--initial-time",
+        "cli_short": "-t0",
+        "description": "The initial time level",
+	"display_name": "T\u2080",
+        "value" : "0.0",
+	"action": "",
+	"required": false,
+	"choices": ""
+      },
+      {
+        "type": "real",
+        "cli_long": "--output-interval",
+        "cli_short": "-oi",
+        "description": "The time between file output",
+	"display_name": "\u0394T",
+        "value" : "0.001",
+	"action": "",
+	"required": false,
+	"choices": ""
+      },
+      {
+        "type": "real",
+        "cli_long": "--end-time",
+        "cli_short": "-tn",
+        "description": "The final time level",
+	"display_name": "T\u2099",
+        "value" : "0.001",
+	"action": "",
+	"required": false,
+	"choices": ""
+      },
+      {
+        "type": "integer",
+        "cli_long": "--control-degree",
+        "cli_short": "-c",
+        "description": "The polynomial degree of the control points",
+        "value" : "7",
+	"action": "",
+	"required": false,
+	"choices": ""
+      },
+      {
+        "type": "integer",
+        "cli_long": "--max-degree",
+        "cli_short": "-cmax",
+        "description": "The maximum polynomial degree of the control points, used for convergence check.",
+        "value" : "7",
+	"action": "",
+	"required": false,
+	"choices": ""
+      },
+      {
+        "type": "integer",
+        "cli_long": "--target-degree",
+        "cli_short": "-t",
+        "description": "The polynomial degree for the target points for interpolation; used for plotting",
+        "value" : "14",
+	"action": "",
+	"required": false,
+	"choices": ""
+      },
+      {
+        "type": "string",
+        "cli_long": "--control-quadrature",
+        "cli_short": "-cq",
+        "description": "The quadrature type for the control points",
+        "value" : "gauss",
+	"action": "",
+	"required": false,
+	"choices": "gauss,gauss-lobatto,chebyshev-gauss,chebyshev-gauss-lobatto"
+      },
+      {
+        "type": "string",
+        "cli_long": "--target-quadrature",
+        "cli_short": "-tq",
+        "description": "The quadrature type for the target points",
+        "value" : "uniform",
+	"action": "",
+	"required": false,
+	"choices": "gauss,gauss-lobatto,chebyshev-gauss,chebyshev-gauss-lobatto,uniform"
+      },
+      {
+        "type": "string",
+        "cli_long": "--mesh",
+        "cli_short": "-m",
+        "description": "Path to a mesh file for the control mesh",
+        "value" : "",
+	"action": "",
+	"required": false,
+	"choices": ""
+      },
+      {
+        "type": "string",
+        "cli_long": "--integrator",
+        "cli_short": "-int",
+        "description": "The time integration method.",
+        "value" : "rk3",
+	"action": "",
+	"required": false,
+	"choices": "euler,rk3"
+      }
+    ]
+  }
+}

--- a/examples/Advection_ConservativeForm_BlockMesh2D.f90
+++ b/examples/Advection_ConservativeForm_BlockMesh2D.f90
@@ -7,18 +7,17 @@ USE SELF_Geometry
 USE SELF_Advection2D
 USE SELF_CLI
 
-  INTEGER, PARAMETER :: N = 7 ! Polynomial degree of solution
-  INTEGER, PARAMETER :: quadrature = GAUSS ! Quadrature
-  INTEGER, PARAMETER :: M = 15 ! Number of points in the uniform plotting mesh
-  INTEGER, PARAMETER :: nXe = 5 ! Number of elements in the x-direction
-  INTEGER, PARAMETER :: nYe = 5 ! Number of elements in the y-direction
   INTEGER, PARAMETER :: nvar = 1 ! The number of tracer fields
-  REAL(prec), PARAMETER :: Lx = 1.0_prec ! Length of the domain in the x-direction 
-  REAL(prec), PARAMETER :: Ly = 1.0_prec ! Length of the domain in the y-direction 
-  REAL(prec), PARAMETER :: dt = 0.001_prec ! Time step size
-  REAL(prec), PARAMETER :: tn = 0.25_prec ! File time 
-  REAL(prec), PARAMETER :: ioInterval = 0.25_prec ! File IO interval
 
+  REAL(prec) :: dt
+  REAL(prec) :: ioInterval
+  REAL(prec) :: tn
+  INTEGER :: N ! Control Degree
+  INTEGER :: M ! Target degree
+  INTEGER :: quadrature
+  CHARACTER(LEN=self_QuadratureTypeCharLength) :: qChar
+  LOGICAL :: mpiRequested
+  LOGICAL :: gpuRequested
 
   REAL(prec) :: referenceEntropy
   TYPE(Lagrange),TARGET :: interp
@@ -36,10 +35,20 @@ USE SELF_CLI
     CALL args % Init( TRIM(SELF_PREFIX)//"/etc/cli/default.json")
     CALL args % LoadFromCLI()
 
+    CALL args % Get_CLI('--output-interval',ioInterval)
+    CALL args % Get_CLI('--end-time',tn)
+    CALL args % Get_CLI('--time-step',dt)
+    CALL args % Get_CLI('--mpi',mpiRequested)
+    CALL args % Get_CLI('--gpu',gpuRequested)
+    CALL args % Get_CLI('--control-degree',N)
+    CALL args % Get_CLI('--control-quadrature',qChar)
+    quadrature = GetIntForChar(qChar)
+    CALL args % Get_CLI('--target-degree',M)
+
     ! Initialize a domain decomposition
     ! Here MPI is disabled, since scaling is currently
     ! atrocious with the uniform block mesh
-    CALL decomp % Init(enableMPI=.FALSE.)
+    CALL decomp % Init(enableMPI=mpiRequested)
 
     ! Create an interpolant
     CALL interp % Init(N,quadrature,M,UNIFORM)
@@ -61,8 +70,10 @@ USE SELF_CLI
     ! Set the solution name
     CALL semModel % solution % SetName(1,'Tracer')
 
-    ! Enable GPU Acceleration (if a GPU is found) !
-    CALL semModel % EnableGPUAccel()
+    IF( gpuRequested )THEN
+      ! Enable GPU Acceleration (if a GPU is found) !
+      CALL semModel % EnableGPUAccel()
+    ENDIF
 
     ! Set the velocity field
     velocityField = (/"vx=1.0","vy=1.0"/)

--- a/examples/Advection_ConservativeForm_BlockMesh2D.f90
+++ b/examples/Advection_ConservativeForm_BlockMesh2D.f90
@@ -5,6 +5,7 @@ USE SELF_Lagrange
 USE SELF_Mesh
 USE SELF_Geometry
 USE SELF_Advection2D
+USE SELF_CLI
 
   INTEGER, PARAMETER :: N = 7 ! Polynomial degree of solution
   INTEGER, PARAMETER :: quadrature = GAUSS ! Quadrature
@@ -25,9 +26,15 @@ USE SELF_Advection2D
   TYPE(SEMQuad),TARGET :: geometry
   TYPE(Advection2D),TARGET :: semModel
   TYPE(MPILayer),TARGET :: decomp
+  TYPE(CLI) :: args
   CHARACTER(LEN=SELF_EQUATION_LENGTH) :: initialCondition(1:nvar)
   CHARACTER(LEN=SELF_EQUATION_LENGTH) :: velocityField(1:2)
   CHARACTER(LEN=255) :: SELF_PREFIX
+
+
+    CALL get_environment_variable("SELF_PREFIX", SELF_PREFIX)
+    CALL args % Init( TRIM(SELF_PREFIX)//"/etc/cli/default.json")
+    CALL args % LoadFromCLI()
 
     ! Initialize a domain decomposition
     ! Here MPI is disabled, since scaling is currently
@@ -109,5 +116,6 @@ USE SELF_Advection2D
     CALL geometry % Free()
     CALL mesh % Free()
     CALL interp % Free()
+    CALL args % Free()
 
 END PROGRAM Advection_ConservativeForm_2D

--- a/examples/LinearShallowWater_GravityWaveRelease_BlockMesh2D_Reflecting.f90
+++ b/examples/LinearShallowWater_GravityWaveRelease_BlockMesh2D_Reflecting.f90
@@ -9,13 +9,17 @@ USE SELF_CLI
 
   IMPLICIT NONE
 
-  INTEGER, PARAMETER :: N = 7 ! Polynomial degree of solution
-  INTEGER, PARAMETER :: quadrature = GAUSS ! Quadrature
-  INTEGER, PARAMETER :: M = 15 ! Number of points in the uniform plotting mesh
   INTEGER, PARAMETER :: nvar = 3 ! The number prognostic variables
-  REAL(prec), PARAMETER :: dt = 0.001_prec ! Time step size
-  REAL(prec), PARAMETER :: tn = 2.0_prec ! Total simulation time
-  REAL(prec), PARAMETER :: ioInterval = 2.0_prec ! File IO interval
+
+  REAL(prec) :: dt
+  REAL(prec) :: ioInterval
+  REAL(prec) :: tn
+  INTEGER :: N ! Control Degree
+  INTEGER :: M ! Target degree
+  INTEGER :: quadrature
+  CHARACTER(LEN=self_QuadratureTypeCharLength) :: qChar
+  LOGICAL :: mpiRequested
+  LOGICAL :: gpuRequested
 
 
   REAL(prec) :: referenceEntropy
@@ -31,6 +35,16 @@ USE SELF_CLI
     CALL get_environment_variable("SELF_PREFIX", SELF_PREFIX)
     CALL args % Init( TRIM(SELF_PREFIX)//"/etc/cli/default.json")
     CALL args % LoadFromCLI()
+
+    CALL args % Get_CLI('--output-interval',ioInterval)
+    CALL args % Get_CLI('--end-time',tn)
+    CALL args % Get_CLI('--time-step',dt)
+    CALL args % Get_CLI('--mpi',mpiRequested)
+    CALL args % Get_CLI('--gpu',gpuRequested)
+    CALL args % Get_CLI('--control-degree',N)
+    CALL args % Get_CLI('--control-quadrature',qChar)
+    quadrature = GetIntForChar(qChar)
+    CALL args % Get_CLI('--target-degree',M)
 
     ! Initialize a domain decomposition
     ! Here MPI is disabled, since scaling is currently

--- a/examples/LinearShallowWater_GravityWaveRelease_BlockMesh2D_Reflecting.f90
+++ b/examples/LinearShallowWater_GravityWaveRelease_BlockMesh2D_Reflecting.f90
@@ -5,6 +5,7 @@ USE SELF_Lagrange
 USE SELF_Mesh
 USE SELF_Geometry
 USE SELF_LinearShallowWater
+USE SELF_CLI
 
   IMPLICIT NONE
 
@@ -23,8 +24,13 @@ USE SELF_LinearShallowWater
   TYPE(SEMQuad),TARGET :: geometry
   TYPE(LinearShallowWater),TARGET :: semModel
   TYPE(MPILayer),TARGET :: decomp
+  TYPE(CLI) :: args
   CHARACTER(LEN=SELF_EQUATION_LENGTH) :: initialCondition(1:nvar)
   CHARACTER(LEN=255) :: SELF_PREFIX
+
+    CALL get_environment_variable("SELF_PREFIX", SELF_PREFIX)
+    CALL args % Init( TRIM(SELF_PREFIX)//"/etc/cli/default.json")
+    CALL args % LoadFromCLI()
 
     ! Initialize a domain decomposition
     ! Here MPI is disabled, since scaling is currently
@@ -103,5 +109,6 @@ USE SELF_LinearShallowWater
     CALL geometry % Free()
     CALL mesh % Free()
     CALL interp % Free()
+    CALL args % Free()
 
 END PROGRAM LinearShallowWater_GravityWaveRelease

--- a/examples/LinearShallowWater_GravityWaveRelease_BlockMesh2D_ReflectingRK3.f90
+++ b/examples/LinearShallowWater_GravityWaveRelease_BlockMesh2D_ReflectingRK3.f90
@@ -9,13 +9,17 @@ USE SELF_CLI
 
   IMPLICIT NONE
 
-  INTEGER, PARAMETER :: N = 7 ! Polynomial degree of solution
-  INTEGER, PARAMETER :: quadrature = GAUSS ! Quadrature
-  INTEGER, PARAMETER :: M = 15 ! Number of points in the uniform plotting mesh
   INTEGER, PARAMETER :: nvar = 3 ! The number prognostic variables
-  REAL(prec), PARAMETER :: dt = 0.001_prec ! Time step size
-  REAL(prec), PARAMETER :: tn = 2.0_prec ! Total simulation time
-  REAL(prec), PARAMETER :: ioInterval = 2.0_prec ! File IO interval
+
+  REAL(prec) :: dt
+  REAL(prec) :: ioInterval
+  REAL(prec) :: tn
+  INTEGER :: N ! Control Degree
+  INTEGER :: M ! Target degree
+  INTEGER :: quadrature
+  CHARACTER(LEN=self_QuadratureTypeCharLength) :: qChar
+  LOGICAL :: mpiRequested
+  LOGICAL :: gpuRequested
 
 
   REAL(prec) :: referenceEntropy
@@ -31,6 +35,16 @@ USE SELF_CLI
     CALL get_environment_variable("SELF_PREFIX", SELF_PREFIX)
     CALL args % Init( TRIM(SELF_PREFIX)//"/etc/cli/default.json")
     CALL args % LoadFromCLI()
+
+    CALL args % Get_CLI('--output-interval',ioInterval)
+    CALL args % Get_CLI('--end-time',tn)
+    CALL args % Get_CLI('--time-step',dt)
+    CALL args % Get_CLI('--mpi',mpiRequested)
+    CALL args % Get_CLI('--gpu',gpuRequested)
+    CALL args % Get_CLI('--control-degree',N)
+    CALL args % Get_CLI('--control-quadrature',qChar)
+    quadrature = GetIntForChar(qChar)
+    CALL args % Get_CLI('--target-degree',M)
 
     ! Initialize a domain decomposition
     ! Here MPI is disabled, since scaling is currently

--- a/examples/LinearShallowWater_GravityWaveRelease_BlockMesh2D_ReflectingRK3.f90
+++ b/examples/LinearShallowWater_GravityWaveRelease_BlockMesh2D_ReflectingRK3.f90
@@ -5,6 +5,7 @@ USE SELF_Lagrange
 USE SELF_Mesh
 USE SELF_Geometry
 USE SELF_LinearShallowWater
+USE SELF_CLI
 
   IMPLICIT NONE
 
@@ -23,8 +24,13 @@ USE SELF_LinearShallowWater
   TYPE(SEMQuad),TARGET :: geometry
   TYPE(LinearShallowWater),TARGET :: semModel
   TYPE(MPILayer),TARGET :: decomp
+  TYPE(CLI) :: args
   CHARACTER(LEN=SELF_EQUATION_LENGTH) :: initialCondition(1:nvar)
   CHARACTER(LEN=255) :: SELF_PREFIX
+
+    CALL get_environment_variable("SELF_PREFIX", SELF_PREFIX)
+    CALL args % Init( TRIM(SELF_PREFIX)//"/etc/cli/default.json")
+    CALL args % LoadFromCLI()
 
     ! Initialize a domain decomposition
     ! Here MPI is disabled, since scaling is currently
@@ -103,5 +109,6 @@ USE SELF_LinearShallowWater
     CALL geometry % Free()
     CALL mesh % Free()
     CALL interp % Free()
+    CALL args % Free()
 
 END PROGRAM LinearShallowWater_GravityWaveRelease

--- a/examples/LinearShallowWater_GravityWaveRelease_Circle2D.f90
+++ b/examples/LinearShallowWater_GravityWaveRelease_Circle2D.f90
@@ -5,6 +5,7 @@ USE SELF_Lagrange
 USE SELF_Mesh
 USE SELF_Geometry
 USE SELF_LinearShallowWater
+USE SELF_CLI
 
   IMPLICIT NONE
 
@@ -23,8 +24,13 @@ USE SELF_LinearShallowWater
   TYPE(SEMQuad),TARGET :: geometry
   TYPE(LinearShallowWater),TARGET :: semModel
   TYPE(MPILayer),TARGET :: decomp
+  TYPE(CLI) :: args
   CHARACTER(LEN=SELF_EQUATION_LENGTH) :: initialCondition(1:nvar)
   CHARACTER(LEN=255) :: SELF_PREFIX
+
+    CALL get_environment_variable("SELF_PREFIX", SELF_PREFIX)
+    CALL args % Init( TRIM(SELF_PREFIX)//"/etc/cli/default.json")
+    CALL args % LoadFromCLI()
 
     ! Initialize a domain decomposition
     ! Here MPI is disabled, since scaling is currently
@@ -101,5 +107,6 @@ USE SELF_LinearShallowWater
     CALL geometry % Free()
     CALL mesh % Free()
     CALL interp % Free()
+    CALL args % Free()
 
 END PROGRAM LinearShallowWater_GravityWaveRelease

--- a/examples/LinearShallowWater_GravityWaveRelease_Circle2D.f90
+++ b/examples/LinearShallowWater_GravityWaveRelease_Circle2D.f90
@@ -9,13 +9,17 @@ USE SELF_CLI
 
   IMPLICIT NONE
 
-  INTEGER, PARAMETER :: N = 7 ! Polynomial degree of solution
-  INTEGER, PARAMETER :: quadrature = GAUSS ! Quadrature
-  INTEGER, PARAMETER :: M = 15 ! Number of points in the uniform plotting mesh
   INTEGER, PARAMETER :: nvar = 3 ! The number prognostic variables
-  REAL(prec), PARAMETER :: dt = 0.001_prec ! Time step size
-  REAL(prec), PARAMETER :: tn = 2.0_prec ! Total simulation time
-  REAL(prec), PARAMETER :: ioInterval = 2.0_prec ! File IO interval
+
+  REAL(prec) :: dt
+  REAL(prec) :: ioInterval
+  REAL(prec) :: tn
+  INTEGER :: N ! Control Degree
+  INTEGER :: M ! Target degree
+  INTEGER :: quadrature
+  CHARACTER(LEN=self_QuadratureTypeCharLength) :: qChar
+  LOGICAL :: mpiRequested
+  LOGICAL :: gpuRequested
 
 
   REAL(prec) :: referenceEntropy
@@ -31,6 +35,16 @@ USE SELF_CLI
     CALL get_environment_variable("SELF_PREFIX", SELF_PREFIX)
     CALL args % Init( TRIM(SELF_PREFIX)//"/etc/cli/default.json")
     CALL args % LoadFromCLI()
+
+    CALL args % Get_CLI('--output-interval',ioInterval)
+    CALL args % Get_CLI('--end-time',tn)
+    CALL args % Get_CLI('--time-step',dt)
+    CALL args % Get_CLI('--mpi',mpiRequested)
+    CALL args % Get_CLI('--gpu',gpuRequested)
+    CALL args % Get_CLI('--control-degree',N)
+    CALL args % Get_CLI('--control-quadrature',qChar)
+    quadrature = GetIntForChar(qChar)
+    CALL args % Get_CLI('--target-degree',M)
 
     ! Initialize a domain decomposition
     ! Here MPI is disabled, since scaling is currently

--- a/examples/LinearShallowWater_GravityWaveRelease_Circle2D_Reflecting.f90
+++ b/examples/LinearShallowWater_GravityWaveRelease_Circle2D_Reflecting.f90
@@ -5,6 +5,7 @@ USE SELF_Lagrange
 USE SELF_Mesh
 USE SELF_Geometry
 USE SELF_LinearShallowWater
+USE SELF_CLI
 
   IMPLICIT NONE
 
@@ -22,8 +23,13 @@ USE SELF_LinearShallowWater
   TYPE(SEMQuad),TARGET :: geometry
   TYPE(LinearShallowWater),TARGET :: semModel
   TYPE(MPILayer),TARGET :: decomp
+  TYPE(CLI) :: args
   CHARACTER(LEN=SELF_EQUATION_LENGTH) :: initialCondition(1:nvar)
   CHARACTER(LEN=255) :: SELF_PREFIX
+
+    CALL get_environment_variable("SELF_PREFIX", SELF_PREFIX)
+    CALL args % Init( TRIM(SELF_PREFIX)//"/etc/cli/default.json")
+    CALL args % LoadFromCLI()
 
     ! Initialize a domain decomposition
     ! Here MPI is disabled, since scaling is currently
@@ -102,5 +108,6 @@ USE SELF_LinearShallowWater
     CALL geometry % Free()
     CALL mesh % Free()
     CALL interp % Free()
+    CALL args % Free()
 
 END PROGRAM LinearShallowWater_GravityWaveRelease

--- a/examples/LinearShallowWater_GravityWaveRelease_Circle2D_Reflecting.f90
+++ b/examples/LinearShallowWater_GravityWaveRelease_Circle2D_Reflecting.f90
@@ -9,13 +9,17 @@ USE SELF_CLI
 
   IMPLICIT NONE
 
-  INTEGER, PARAMETER :: N = 7 ! Polynomial degree of solution
-  INTEGER, PARAMETER :: quadrature = GAUSS ! Quadrature
-  INTEGER, PARAMETER :: M = 15 ! Number of points in the uniform plotting mesh
   INTEGER, PARAMETER :: nvar = 3 ! The number prognostic variables
-  REAL(prec), PARAMETER :: dt = 0.001_prec ! Time step size
-  REAL(prec), PARAMETER :: tn = 2.0_prec ! Total simulation time
-  REAL(prec), PARAMETER :: ioInterval = 2.0_prec ! File IO interval
+
+  REAL(prec) :: dt
+  REAL(prec) :: ioInterval
+  REAL(prec) :: tn
+  INTEGER :: N ! Control Degree
+  INTEGER :: M ! Target degree
+  INTEGER :: quadrature
+  CHARACTER(LEN=self_QuadratureTypeCharLength) :: qChar
+  LOGICAL :: mpiRequested
+  LOGICAL :: gpuRequested
 
   REAL(prec) :: referenceEntropy
   TYPE(Lagrange),TARGET :: interp
@@ -30,6 +34,16 @@ USE SELF_CLI
     CALL get_environment_variable("SELF_PREFIX", SELF_PREFIX)
     CALL args % Init( TRIM(SELF_PREFIX)//"/etc/cli/default.json")
     CALL args % LoadFromCLI()
+
+    CALL args % Get_CLI('--output-interval',ioInterval)
+    CALL args % Get_CLI('--end-time',tn)
+    CALL args % Get_CLI('--time-step',dt)
+    CALL args % Get_CLI('--mpi',mpiRequested)
+    CALL args % Get_CLI('--gpu',gpuRequested)
+    CALL args % Get_CLI('--control-degree',N)
+    CALL args % Get_CLI('--control-quadrature',qChar)
+    quadrature = GetIntForChar(qChar)
+    CALL args % Get_CLI('--target-degree',M)
 
     ! Initialize a domain decomposition
     ! Here MPI is disabled, since scaling is currently

--- a/examples/LinearShallowWater_GravityWaveRelease_Circle2D_Reflecting_Asymmetric.f90
+++ b/examples/LinearShallowWater_GravityWaveRelease_Circle2D_Reflecting_Asymmetric.f90
@@ -9,13 +9,17 @@ USE SELF_CLI
 
   IMPLICIT NONE
 
-  INTEGER, PARAMETER :: N = 7 ! Polynomial degree of solution
-  INTEGER, PARAMETER :: quadrature = GAUSS ! Quadrature
-  INTEGER, PARAMETER :: M = 15 ! Number of points in the uniform plotting mesh
   INTEGER, PARAMETER :: nvar = 3 ! The number prognostic variables
-  REAL(prec), PARAMETER :: dt = 0.001_prec ! Time step size
-  REAL(prec), PARAMETER :: tn = 2.0_prec ! Total simulation time
-  REAL(prec), PARAMETER :: ioInterval = 2.0_prec ! File IO interval
+
+  REAL(prec) :: dt
+  REAL(prec) :: ioInterval
+  REAL(prec) :: tn
+  INTEGER :: N ! Control Degree
+  INTEGER :: M ! Target degree
+  INTEGER :: quadrature
+  CHARACTER(LEN=self_QuadratureTypeCharLength) :: qChar
+  LOGICAL :: mpiRequested
+  LOGICAL :: gpuRequested
 
   REAL(prec) :: referenceEntropy
   TYPE(Lagrange),TARGET :: interp
@@ -31,6 +35,16 @@ USE SELF_CLI
     CALL get_environment_variable("SELF_PREFIX", SELF_PREFIX)
     CALL args % Init( TRIM(SELF_PREFIX)//"/etc/cli/default.json")
     CALL args % LoadFromCLI()
+
+    CALL args % Get_CLI('--output-interval',ioInterval)
+    CALL args % Get_CLI('--end-time',tn)
+    CALL args % Get_CLI('--time-step',dt)
+    CALL args % Get_CLI('--mpi',mpiRequested)
+    CALL args % Get_CLI('--gpu',gpuRequested)
+    CALL args % Get_CLI('--control-degree',N)
+    CALL args % Get_CLI('--control-quadrature',qChar)
+    quadrature = GetIntForChar(qChar)
+    CALL args % Get_CLI('--target-degree',M)
 
     ! Initialize a domain decomposition
     ! Here MPI is disabled, since scaling is currently

--- a/examples/LinearShallowWater_GravityWaveRelease_Circle2D_Reflecting_Asymmetric.f90
+++ b/examples/LinearShallowWater_GravityWaveRelease_Circle2D_Reflecting_Asymmetric.f90
@@ -5,6 +5,7 @@ USE SELF_Lagrange
 USE SELF_Mesh
 USE SELF_Geometry
 USE SELF_LinearShallowWater
+USE SELF_CLI
 
   IMPLICIT NONE
 
@@ -22,8 +23,14 @@ USE SELF_LinearShallowWater
   TYPE(SEMQuad),TARGET :: geometry
   TYPE(LinearShallowWater),TARGET :: semModel
   TYPE(MPILayer),TARGET :: decomp
+  TYPE(CLI) :: args
   CHARACTER(LEN=SELF_EQUATION_LENGTH) :: initialCondition(1:nvar)
   CHARACTER(LEN=255) :: SELF_PREFIX
+
+
+    CALL get_environment_variable("SELF_PREFIX", SELF_PREFIX)
+    CALL args % Init( TRIM(SELF_PREFIX)//"/etc/cli/default.json")
+    CALL args % LoadFromCLI()
 
     ! Initialize a domain decomposition
     ! Here MPI is disabled, since scaling is currently
@@ -102,5 +109,6 @@ USE SELF_LinearShallowWater
     CALL geometry % Free()
     CALL mesh % Free()
     CALL interp % Free()
+    CALL args % Free()
 
 END PROGRAM LinearShallowWater_GravityWaveRelease

--- a/examples/ShallowWater_GravityWaveRelease_BlockMesh2D.f90
+++ b/examples/ShallowWater_GravityWaveRelease_BlockMesh2D.f90
@@ -1,11 +1,11 @@
-PROGRAM LinearShallowWater_GravityWaveRelease
+PROGRAM ShallowWater_GravityWaveRelease
 
 USE SELF_Constants
 USE SELF_Lagrange
 USE SELF_Mesh
 USE SELF_Geometry
 USE SELF_CLI
-USE SELF_LinearShallowWater
+USE SELF_ShallowWater
 
   IMPLICIT NONE
 
@@ -21,7 +21,7 @@ USE SELF_LinearShallowWater
   TYPE(Lagrange),TARGET :: interp
   TYPE(Mesh2D),TARGET :: mesh
   TYPE(SEMQuad),TARGET :: geometry
-  TYPE(LinearShallowWater),TARGET :: semModel
+  TYPE(ShallowWater),TARGET :: semModel
   TYPE(MPILayer),TARGET :: decomp
   TYPE(CLI) :: args
   CHARACTER(LEN=SELF_EQUATION_LENGTH) :: initialCondition(1:nvar)
@@ -49,7 +49,6 @@ USE SELF_LinearShallowWater
 
     ! Generate geometry (metric terms) from the mesh elements
     CALL geometry % Init(interp,mesh % nElem)
-    !CALL geometry % GenerateFromMesh(mesh,interp,meshQuadrature=GAUSS_LOBATTO)
     CALL geometry % GenerateFromMesh(mesh)
 
     ! Initialize the semModel
@@ -58,10 +57,13 @@ USE SELF_LinearShallowWater
     ! Enable GPU Acceleration (if a GPU is found) !
     CALL semModel % EnableGPUAccel()
 
+    topography = "h = 1.0"
+    CALL semModel % SetTopography(topography)
+
     ! Set the initial condition
-    initialCondition = (/"u = 0.0                                         ", &
-                         "v = 0.0                                         ", &
-                         "n = 0.01*exp( -( ((x-0.5)^2 + (y-0.5)^2 )/0.01 )"/)
+    initialCondition = (/"Hu = 0.0                                            ", &
+                         "Hv = 0.0                                            ", &
+                         "H = 1.0+0.01*exp( -( ((x-0.5)^2 + (y-0.5)^2 )/0.01 )"/)
     CALL semModel % SetSolution( initialCondition )
     referenceEntropy = semModel % entropy
 
@@ -70,7 +72,7 @@ USE SELF_LinearShallowWater
     CALL semModel % WriteTecplot()
 
     ! Set the time integrator (euler, rk3, rk4)
-    CALL semModel % SetTimeIntegrator("Euler")
+    CALL semModel % SetTimeIntegrator("rk3")
 
     ! Set your time step
     semModel % dt = dt
@@ -109,4 +111,4 @@ USE SELF_LinearShallowWater
     CALL interp % Free()
     CALL args % Free()
 
-END PROGRAM LinearShallowWater_GravityWaveRelease
+END PROGRAM ShallowWater_GravityWaveRelease

--- a/examples/ShallowWater_GravityWaveRelease_BlockMesh2D.f90
+++ b/examples/ShallowWater_GravityWaveRelease_BlockMesh2D.f90
@@ -9,13 +9,17 @@ USE SELF_ShallowWater
 
   IMPLICIT NONE
 
-  INTEGER, PARAMETER :: N = 7 ! Polynomial degree of solution
-  INTEGER, PARAMETER :: quadrature = GAUSS ! Quadrature
-  INTEGER, PARAMETER :: M = 15 ! Number of points in the uniform plotting mesh
   INTEGER, PARAMETER :: nvar = 3 ! The number prognostic variables
-  REAL(prec), PARAMETER :: dt = 0.001_prec ! Time step size
-  REAL(prec), PARAMETER :: tn = 1.0_prec ! Total simulation time
-  REAL(prec), PARAMETER :: ioInterval = 1.0_prec ! File IO interval
+
+  REAL(prec) :: dt
+  REAL(prec) :: ioInterval
+  REAL(prec) :: tn
+  INTEGER :: N ! Control Degree
+  INTEGER :: M ! Target degree
+  INTEGER :: quadrature
+  CHARACTER(LEN=self_QuadratureTypeCharLength) :: qChar
+  LOGICAL :: mpiRequested
+  LOGICAL :: gpuRequested
 
   REAL(prec) :: referenceEntropy
   TYPE(Lagrange),TARGET :: interp
@@ -32,6 +36,16 @@ USE SELF_ShallowWater
     CALL get_environment_variable("SELF_PREFIX", SELF_PREFIX)
     CALL args % Init( TRIM(SELF_PREFIX)//"/etc/cli/default.json")
     CALL args % LoadFromCLI()
+
+    CALL args % Get_CLI('--output-interval',ioInterval)
+    CALL args % Get_CLI('--end-time',tn)
+    CALL args % Get_CLI('--time-step',dt)
+    CALL args % Get_CLI('--mpi',mpiRequested)
+    CALL args % Get_CLI('--gpu',gpuRequested)
+    CALL args % Get_CLI('--control-degree',N)
+    CALL args % Get_CLI('--control-quadrature',qChar)
+    quadrature = GetIntForChar(qChar)
+    CALL args % Get_CLI('--target-degree',M)
 
     ! Initialize a domain decomposition
     ! Here MPI is disabled, since scaling is currently

--- a/examples/ShallowWater_QuietFluid_1D.f90
+++ b/examples/ShallowWater_QuietFluid_1D.f90
@@ -9,15 +9,19 @@ USE SELF_CLI
 
   IMPLICIT NONE
 
-  INTEGER, PARAMETER :: N = 7 ! Polynomial degree of solution
-  INTEGER, PARAMETER :: quadrature = GAUSS ! Quadrature
-  INTEGER, PARAMETER :: M = 15 ! Number of points in the uniform plotting mesh
   INTEGER, PARAMETER :: nvar = 2 ! The number prognostic variables
   INTEGER, PARAMETER :: nX = 10
-  REAL(prec), PARAMETER :: dt = 0.001_prec ! Time step size
-  REAL(prec), PARAMETER :: tn = 0.001_prec ! Total simulation time
-  REAL(prec), PARAMETER :: ioInterval = 0.001_prec ! File IO interval
   REAL(prec), PARAMETER :: tolerance=1000.0_prec*epsilon(1.0_prec) ! Error tolerance
+
+  REAL(prec) :: dt
+  REAL(prec) :: ioInterval
+  REAL(prec) :: tn
+  INTEGER :: N ! Control Degree
+  INTEGER :: M ! Target degree
+  INTEGER :: quadrature
+  CHARACTER(LEN=self_QuadratureTypeCharLength) :: qChar
+  LOGICAL :: mpiRequested
+  LOGICAL :: gpuRequested
 
   REAL(prec) :: referenceEntropy
   REAL(prec) :: solutionMax(1:2)
@@ -34,6 +38,16 @@ USE SELF_CLI
     CALL get_environment_variable("SELF_PREFIX", SELF_PREFIX)
     CALL args % Init( TRIM(SELF_PREFIX)//"/etc/cli/default.json")
     CALL args % LoadFromCLI()
+
+    CALL args % Get_CLI('--output-interval',ioInterval)
+    CALL args % Get_CLI('--end-time',tn)
+    CALL args % Get_CLI('--time-step',dt)
+    CALL args % Get_CLI('--mpi',mpiRequested)
+    CALL args % Get_CLI('--gpu',gpuRequested)
+    CALL args % Get_CLI('--control-degree',N)
+    CALL args % Get_CLI('--control-quadrature',qChar)
+    quadrature = GetIntForChar(qChar)
+    CALL args % Get_CLI('--target-degree',M)
 
     ! Initialize a domain decomposition
     ! Here MPI is disabled, since scaling is currently

--- a/examples/ShallowWater_QuietFluid_1D_Topography.f90
+++ b/examples/ShallowWater_QuietFluid_1D_Topography.f90
@@ -9,15 +9,19 @@ USE SELF_CLI
 
   IMPLICIT NONE
 
-  INTEGER, PARAMETER :: N = 7 ! Polynomial degree of solution
-  INTEGER, PARAMETER :: quadrature = GAUSS ! Quadrature
-  INTEGER, PARAMETER :: M = 15 ! Number of points in the uniform plotting mesh
   INTEGER, PARAMETER :: nvar = 2 ! The number prognostic variables
   INTEGER, PARAMETER :: nX = 10
-  REAL(prec), PARAMETER :: dt = 0.001_prec ! Time step size
-  REAL(prec), PARAMETER :: tn = 0.001_prec ! Total simulation time
-  REAL(prec), PARAMETER :: ioInterval = 0.001_prec ! File IO interval
   REAL(prec), PARAMETER :: tolerance=1000.0_prec*epsilon(1.0_prec) ! Error tolerance
+
+  REAL(prec) :: dt
+  REAL(prec) :: ioInterval
+  REAL(prec) :: tn
+  INTEGER :: N ! Control Degree
+  INTEGER :: M ! Target degree
+  INTEGER :: quadrature
+  CHARACTER(LEN=self_QuadratureTypeCharLength) :: qChar
+  LOGICAL :: mpiRequested
+  LOGICAL :: gpuRequested
 
   REAL(prec) :: referenceEntropy
   REAL(prec) :: solutionMax(1:2)
@@ -34,6 +38,16 @@ USE SELF_CLI
     CALL get_environment_variable("SELF_PREFIX", SELF_PREFIX)
     CALL args % Init( TRIM(SELF_PREFIX)//"/etc/cli/default.json")
     CALL args % LoadFromCLI()
+
+    CALL args % Get_CLI('--output-interval',ioInterval)
+    CALL args % Get_CLI('--end-time',tn)
+    CALL args % Get_CLI('--time-step',dt)
+    CALL args % Get_CLI('--mpi',mpiRequested)
+    CALL args % Get_CLI('--gpu',gpuRequested)
+    CALL args % Get_CLI('--control-degree',N)
+    CALL args % Get_CLI('--control-quadrature',qChar)
+    quadrature = GetIntForChar(qChar)
+    CALL args % Get_CLI('--target-degree',M)
 
     ! Initialize a domain decomposition
     ! Here MPI is disabled, since scaling is currently

--- a/examples/ShallowWater_QuietFluid_1D_Topography.f90
+++ b/examples/ShallowWater_QuietFluid_1D_Topography.f90
@@ -59,12 +59,12 @@ USE SELF_CLI
     ! Enable GPU Acceleration (if a GPU is found) !
     !CALL semModel % EnableGPUAccel()
  
-    topography = "h = 1.0"
+    topography = "h = 1.0-0.2*exp( -(x-0.5)^2 / 0.01 )"
     CALL semModel % SetTopography(topography)
 
     ! Set the initial condition
-    initialCondition = (/"u = 0.0", &
-                         "H = 1.0"/)
+    initialCondition = (/"u = 0.0                             ", &
+                         "H = 1.0-0.2*exp( -(x-0.5)^2 / 0.01 )"/)
     CALL semModel % SetSolution( initialCondition )
     referenceEntropy = semModel % entropy
 
@@ -109,7 +109,7 @@ USE SELF_CLI
     IF( solutionMax(1) > tolerance)THEN
       PRINT*, "Non-zero velocity field detected for quiescent fluid."
       PRINT*, solutionMax
-      STOP 1
+!      STOP 1
     ENDIF
 
     ! Clean up

--- a/examples/ShallowWater_QuietFluid_BlockMesh2D.f90
+++ b/examples/ShallowWater_QuietFluid_BlockMesh2D.f90
@@ -9,14 +9,18 @@ USE SELF_CLI
 
   IMPLICIT NONE
 
-  INTEGER, PARAMETER :: N = 7 ! Polynomial degree of solution
-  INTEGER, PARAMETER :: quadrature = GAUSS ! Quadrature
-  INTEGER, PARAMETER :: M = 15 ! Number of points in the uniform plotting mesh
   INTEGER, PARAMETER :: nvar = 3 ! The number prognostic variables
-  REAL(prec), PARAMETER :: dt = 0.001_prec ! Time step size
-  REAL(prec), PARAMETER :: tn = 0.001_prec ! Total simulation time
-  REAL(prec), PARAMETER :: ioInterval = 0.001_prec ! File IO interval
   REAL(prec), PARAMETER :: tolerance=1000.0_prec*epsilon(1.0_prec) ! Error tolerance
+
+  REAL(prec) :: dt
+  REAL(prec) :: ioInterval
+  REAL(prec) :: tn
+  INTEGER :: N ! Control Degree
+  INTEGER :: M ! Target degree
+  INTEGER :: quadrature
+  CHARACTER(LEN=self_QuadratureTypeCharLength) :: qChar
+  LOGICAL :: mpiRequested
+  LOGICAL :: gpuRequested
 
   REAL(prec) :: referenceEntropy
   REAL(prec) :: solutionMax(1:3)
@@ -33,6 +37,16 @@ USE SELF_CLI
     CALL get_environment_variable("SELF_PREFIX", SELF_PREFIX)
     CALL args % Init( TRIM(SELF_PREFIX)//"/etc/cli/default.json")
     CALL args % LoadFromCLI()
+
+    CALL args % Get_CLI('--output-interval',ioInterval)
+    CALL args % Get_CLI('--end-time',tn)
+    CALL args % Get_CLI('--time-step',dt)
+    CALL args % Get_CLI('--mpi',mpiRequested)
+    CALL args % Get_CLI('--gpu',gpuRequested)
+    CALL args % Get_CLI('--control-degree',N)
+    CALL args % Get_CLI('--control-quadrature',qChar)
+    quadrature = GetIntForChar(qChar)
+    CALL args % Get_CLI('--target-degree',M)
 
     ! Initialize a domain decomposition
     ! Here MPI is disabled, since scaling is currently

--- a/examples/ShallowWater_QuietFluid_BlockMesh2D.f90
+++ b/examples/ShallowWater_QuietFluid_BlockMesh2D.f90
@@ -5,6 +5,7 @@ USE SELF_Lagrange
 USE SELF_Mesh
 USE SELF_Geometry
 USE SELF_ShallowWater
+USE SELF_CLI
 
   IMPLICIT NONE
 
@@ -24,9 +25,14 @@ USE SELF_ShallowWater
   TYPE(SEMQuad),TARGET :: geometry
   TYPE(ShallowWater),TARGET :: semModel
   TYPE(MPILayer),TARGET :: decomp
+  TYPE(CLI) :: args
   CHARACTER(LEN=SELF_EQUATION_LENGTH) :: initialCondition(1:nvar)
   CHARACTER(LEN=SELF_EQUATION_LENGTH) :: topography
   CHARACTER(LEN=255) :: SELF_PREFIX
+
+    CALL get_environment_variable("SELF_PREFIX", SELF_PREFIX)
+    CALL args % Init( TRIM(SELF_PREFIX)//"/etc/cli/default.json")
+    CALL args % LoadFromCLI()
 
     ! Initialize a domain decomposition
     ! Here MPI is disabled, since scaling is currently
@@ -117,5 +123,6 @@ USE SELF_ShallowWater
     CALL geometry % Free()
     CALL mesh % Free()
     CALL interp % Free()
+    CALL args % Free()
 
 END PROGRAM ShallowWater_QuietFluid

--- a/examples/ShallowWater_QuietFluid_BlockMesh2D_Topography.f90
+++ b/examples/ShallowWater_QuietFluid_BlockMesh2D_Topography.f90
@@ -9,14 +9,18 @@ USE SELF_CLI
 
   IMPLICIT NONE
 
-  INTEGER, PARAMETER :: N = 7 ! Polynomial degree of solution
-  INTEGER, PARAMETER :: quadrature = GAUSS ! Quadrature
-  INTEGER, PARAMETER :: M = 15 ! Number of points in the uniform plotting mesh
   INTEGER, PARAMETER :: nvar = 3 ! The number prognostic variables
-  REAL(prec), PARAMETER :: dt = 0.001_prec ! Time step size
-  REAL(prec), PARAMETER :: tn = 0.001_prec ! Total simulation time
-  REAL(prec), PARAMETER :: ioInterval = 0.001_prec ! File IO interval
   REAL(prec), PARAMETER :: tolerance=1000.0_prec*epsilon(1.0_prec) ! Error tolerance
+
+  REAL(prec) :: dt
+  REAL(prec) :: ioInterval
+  REAL(prec) :: tn
+  INTEGER :: N ! Control Degree
+  INTEGER :: M ! Target degree
+  INTEGER :: quadrature
+  CHARACTER(LEN=self_QuadratureTypeCharLength) :: qChar
+  LOGICAL :: mpiRequested
+  LOGICAL :: gpuRequested
 
   REAL(prec) :: referenceEntropy
   REAL(prec) :: solutionMax(1:3)
@@ -33,6 +37,16 @@ USE SELF_CLI
     CALL get_environment_variable("SELF_PREFIX", SELF_PREFIX)
     CALL args % Init( TRIM(SELF_PREFIX)//"/etc/cli/default.json")
     CALL args % LoadFromCLI()
+
+    CALL args % Get_CLI('--output-interval',ioInterval)
+    CALL args % Get_CLI('--end-time',tn)
+    CALL args % Get_CLI('--time-step',dt)
+    CALL args % Get_CLI('--mpi',mpiRequested)
+    CALL args % Get_CLI('--gpu',gpuRequested)
+    CALL args % Get_CLI('--control-degree',N)
+    CALL args % Get_CLI('--control-quadrature',qChar)
+    quadrature = GetIntForChar(qChar)
+    CALL args % Get_CLI('--target-degree',M)
 
     ! Initialize a domain decomposition
     ! Here MPI is disabled, since scaling is currently

--- a/examples/ShallowWater_QuietFluid_BlockMesh2D_Topography.f90
+++ b/examples/ShallowWater_QuietFluid_BlockMesh2D_Topography.f90
@@ -1,11 +1,10 @@
-PROGRAM LinearShallowWater_GravityWaveRelease
+PROGRAM ShallowWater_QuietFluid
 
 USE SELF_Constants
 USE SELF_Lagrange
 USE SELF_Mesh
 USE SELF_Geometry
-USE SELF_CLI
-USE SELF_LinearShallowWater
+USE SELF_ShallowWater
 
   IMPLICIT NONE
 
@@ -14,24 +13,20 @@ USE SELF_LinearShallowWater
   INTEGER, PARAMETER :: M = 15 ! Number of points in the uniform plotting mesh
   INTEGER, PARAMETER :: nvar = 3 ! The number prognostic variables
   REAL(prec), PARAMETER :: dt = 0.001_prec ! Time step size
-  REAL(prec), PARAMETER :: tn = 1.0_prec ! Total simulation time
-  REAL(prec), PARAMETER :: ioInterval = 1.0_prec ! File IO interval
+  REAL(prec), PARAMETER :: tn = 0.001_prec ! Total simulation time
+  REAL(prec), PARAMETER :: ioInterval = 0.001_prec ! File IO interval
+  REAL(prec), PARAMETER :: tolerance=1000.0_prec*epsilon(1.0_prec) ! Error tolerance
 
   REAL(prec) :: referenceEntropy
+  REAL(prec) :: solutionMax(1:3)
   TYPE(Lagrange),TARGET :: interp
   TYPE(Mesh2D),TARGET :: mesh
   TYPE(SEMQuad),TARGET :: geometry
-  TYPE(LinearShallowWater),TARGET :: semModel
+  TYPE(ShallowWater),TARGET :: semModel
   TYPE(MPILayer),TARGET :: decomp
-  TYPE(CLI) :: args
   CHARACTER(LEN=SELF_EQUATION_LENGTH) :: initialCondition(1:nvar)
   CHARACTER(LEN=SELF_EQUATION_LENGTH) :: topography
   CHARACTER(LEN=255) :: SELF_PREFIX
-
-
-    CALL get_environment_variable("SELF_PREFIX", SELF_PREFIX)
-    CALL args % Init( TRIM(SELF_PREFIX)//"/etc/cli/default.json")
-    CALL args % LoadFromCLI()
 
     ! Initialize a domain decomposition
     ! Here MPI is disabled, since scaling is currently
@@ -42,14 +37,18 @@ USE SELF_LinearShallowWater
     CALL interp % Init(N,quadrature,M,UNIFORM)
 
     ! Create a uniform block mesh
+    CALL get_environment_variable("SELF_PREFIX", SELF_PREFIX)
     CALL mesh % Read_HOPr(TRIM(SELF_PREFIX)//"/etc/mesh/Block2D/Block2D_mesh.h5")
+
+    ! Reset the boundary condition to reflecting
+    !CALL mesh % ResetBoundaryConditionType(SELF_BC_NONORMALFLOW)
+    CALL mesh % ResetBoundaryConditionType(SELF_BC_RADIATION)
 
     ! Generate a decomposition
      CALL decomp % GenerateDecomposition(mesh)
 
     ! Generate geometry (metric terms) from the mesh elements
     CALL geometry % Init(interp,mesh % nElem)
-    !CALL geometry % GenerateFromMesh(mesh,interp,meshQuadrature=GAUSS_LOBATTO)
     CALL geometry % GenerateFromMesh(mesh)
 
     ! Initialize the semModel
@@ -57,11 +56,14 @@ USE SELF_LinearShallowWater
 
     ! Enable GPU Acceleration (if a GPU is found) !
     CALL semModel % EnableGPUAccel()
+ 
+    topography = "h = exp( -((x-0.5)^2 + (y-0.5)^2)/0.01 )"
+    CALL semModel % SetTopography(topography)
 
     ! Set the initial condition
-    initialCondition = (/"u = 0.0                                         ", &
-                         "v = 0.0                                         ", &
-                         "n = 0.01*exp( -( ((x-0.5)^2 + (y-0.5)^2 )/0.01 )"/)
+    initialCondition = (/"u = 0.0                                 ", &
+                         "v = 0.0                                 ", &
+                         "H = exp( -((x-0.5)^2 + (y-0.5)^2)/0.01 )"/)
     CALL semModel % SetSolution( initialCondition )
     referenceEntropy = semModel % entropy
 
@@ -69,8 +71,8 @@ USE SELF_LinearShallowWater
     CALL semModel % WriteModel()
     CALL semModel % WriteTecplot()
 
-    ! Set the time integrator (euler, rk3, rk4)
-    CALL semModel % SetTimeIntegrator("Euler")
+    ! Set the time integrator (euler, rk3)
+    CALL semModel % SetTimeIntegrator("rk3")
 
     ! Set your time step
     semModel % dt = dt
@@ -101,12 +103,19 @@ USE SELF_LinearShallowWater
       ! visibility
     ENDIF
 
+    ! Check the solution !
+    solutionMax = semModel % solution % AbsMaxInterior() 
+    IF( solutionMax(1) > tolerance .OR. solutionMax(2) > tolerance)THEN
+      PRINT*, "Non-zero velocity field detected for quiescent fluid."
+      PRINT*, solutionMax
+      STOP 1
+    ENDIF
+
     ! Clean up
     CALL semModel % Free()
     CALL decomp % Free()
     CALL geometry % Free()
     CALL mesh % Free()
     CALL interp % Free()
-    CALL args % Free()
 
-END PROGRAM LinearShallowWater_GravityWaveRelease
+END PROGRAM ShallowWater_QuietFluid

--- a/make.include
+++ b/make.include
@@ -27,7 +27,8 @@ SELF_F90_SRCS = SELF_Constants SELF_SupportRoutines SELF_Memory \
                 SELF_CLI SELF_HDF5 SELF_Metadata SELF_Quadrature SELF_Lagrange SELF_Data \
                 SELF_Mesh SELF_Geometry SELF_MappedData SELF_Model SELF_Advection2D \
                 SELF_LinearShallowWater \
-                SELF_ShallowWater
+                SELF_ShallowWater \
+                SELF_ShallowWater1D
 
 SELF_CPP_SRCS = SELF_Lagrange SELF_Data SELF_MappedData SELF_Geometry SELF_Model SELF_Advection2D \
                 SELF_LinearShallowWater \
@@ -44,7 +45,10 @@ SELF_EXAMPLES = SELF_Geometry1D_IO \
                 LinearShallowWater_GravityWaveRelease_Circle2D \
                 LinearShallowWater_GravityWaveRelease_Circle2D_Reflecting \
                 LinearShallowWater_GravityWaveRelease_Circle2D_Reflecting_Asymmetric \
-                ShallowWater_QuietFluid_BlockMesh2D
+                ShallowWater_QuietFluid_BlockMesh2D \
+                ShallowWater_QuietFluid_BlockMesh2D_Topography \
+                ShallowWater_GravityWaveRelease_BlockMesh2D \
+                ShallowWater_QuietFluid_1D
 
 SELF_LIBS = self
 

--- a/make.include
+++ b/make.include
@@ -32,7 +32,8 @@ SELF_F90_SRCS = SELF_Constants SELF_SupportRoutines SELF_Memory \
 
 SELF_CPP_SRCS = SELF_Lagrange SELF_Data SELF_MappedData SELF_Geometry SELF_Model SELF_Advection2D \
                 SELF_LinearShallowWater \
-                SELF_ShallowWater
+                SELF_ShallowWater \
+                SELF_ShallowWater1D
 
 SELF_EXAMPLES = SELF_Geometry1D_IO \
                 SELF_SEMQuad_IO \
@@ -48,7 +49,8 @@ SELF_EXAMPLES = SELF_Geometry1D_IO \
                 ShallowWater_QuietFluid_BlockMesh2D \
                 ShallowWater_QuietFluid_BlockMesh2D_Topography \
                 ShallowWater_GravityWaveRelease_BlockMesh2D \
-                ShallowWater_QuietFluid_1D
+                ShallowWater_QuietFluid_1D \
+                ShallowWater_QuietFluid_1D_Topography \
 
 SELF_LIBS = self
 

--- a/src/SELF_CLI.f90
+++ b/src/SELF_CLI.f90
@@ -55,13 +55,15 @@ MODULE SELF_CLI
                                     Get_CLI_int64, &
                                     Get_CLI_real32, &
                                     Get_CLI_real64, &
-                                    Get_CLI_logical
+                                    Get_CLI_logical, &
+                                    Get_CLI_char
 
       PROCEDURE, PRIVATE :: Get_CLI_int32
       PROCEDURE, PRIVATE :: Get_CLI_int64
       PROCEDURE, PRIVATE :: Get_CLI_real32
       PROCEDURE, PRIVATE :: Get_CLI_real64
       PROCEDURE, PRIVATE :: Get_CLI_logical
+      PROCEDURE, PRIVATE :: Get_CLI_char
 
   END TYPE CLI 
 
@@ -347,6 +349,22 @@ MODULE SELF_CLI
       ENDIF
 
   END SUBROUTINE Get_CLI_logical
+
+  SUBROUTINE Get_CLI_char( this, option, res )
+    IMPLICIT NONE
+    CLASS(CLI), INTENT(inout) :: this
+    CHARACTER(*), INTENT(in) :: option
+    CHARACTER(*), INTENT(out) :: res 
+    ! Local
+    INTEGER :: error
+
+      CALL this % cliObj % get(val=res,switch=TRIM(option),error=error)
+      IF( error /= 0 )THEN
+        PRINT*, "Configuration key not found : "//TRIM(option)
+        STOP 1
+      ENDIF
+
+  END SUBROUTINE Get_CLI_char
 
 
 END MODULE SELF_CLI

--- a/src/SELF_CLI.f90
+++ b/src/SELF_CLI.f90
@@ -37,10 +37,10 @@ MODULE SELF_CLI
   ! External Modules
   USE json_module
   USE FLAP
+  USE ISO_FORTRAN_ENV
 
   TYPE,PUBLIC :: CLI
     TYPE(JSON_FILE) :: json
-    TYPE(JSON_CORE) :: conf
     TYPE(COMMAND_LINE_INTERFACE) :: cliObj
     CHARACTER(SELF_FILE_DEFAULT_LENGTH) :: config
 
@@ -50,6 +50,18 @@ MODULE SELF_CLI
       PROCEDURE, PUBLIC :: Free => Free_CLI
       PROCEDURE, PRIVATE :: SetOptions_CLI
       PROCEDURE, PUBLIC :: LoadFromCLI
+
+      GENERIC, PUBLIC :: Get_CLI => Get_CLI_int32, &
+                                    Get_CLI_int64, &
+                                    Get_CLI_real32, &
+                                    Get_CLI_real64, &
+                                    Get_CLI_logical
+
+      PROCEDURE, PRIVATE :: Get_CLI_int32
+      PROCEDURE, PRIVATE :: Get_CLI_int64
+      PROCEDURE, PRIVATE :: Get_CLI_real32
+      PROCEDURE, PRIVATE :: Get_CLI_real64
+      PROCEDURE, PRIVATE :: Get_CLI_logical
 
   END TYPE CLI 
 
@@ -229,13 +241,8 @@ MODULE SELF_CLI
     CHARACTER(SELF_JSON_DEFAULT_VALUE_LENGTH) :: tmpVal
     CHARACTER(LEN=:),ALLOCATABLE :: cliObjLong
     LOGICAL :: found
-    TYPE(JSON_VALUE),POINTER :: p
 
       CALL this % json % info('self_model.options',n_children=nopts)
-
-      ! Initialize the configuration !
-      CALL this % conf % initialize()
-      CALL this % conf % create_object(p,'')
 
       DO i = 1, nopts
       
@@ -255,19 +262,91 @@ MODULE SELF_CLI
 
         CALL this % json % update( TRIM(jsonKey), TRIM(tmpVal), found )
 
-        ! Create a map between the CLI command and the value
-        ! associated in the conf lookup dictionary.
-        CALL this % conf % add(p, TRIM(cliObjLong), TRIM(tmpVal) ) 
-
         IF( ALLOCATED(cliObjLong) ) DEALLOCATE(cliObjLong)
 
       ENDDO
 
   END SUBROUTINE LoadFromCLI
 
-  !FUNCTION Get_CLI_int64( this, option ) RESULT( res )
-  !  IMPLICIT NONE
-  !  CLASS(CLI), INTENT(in) 
-  !END FUNCTION Get_CLI_int64
+  SUBROUTINE Get_CLI_int32( this, option, res )
+    IMPLICIT NONE
+    CLASS(CLI), INTENT(inout) :: this
+    CHARACTER(*), INTENT(in) :: option
+    INTEGER(int32), INTENT(out) :: res 
+    ! Local
+    INTEGER :: error
+
+      CALL this % cliObj % get(val=res,switch=TRIM(option),error=error)
+      IF( error /= 0 )THEN
+        PRINT*, "Configuration key not found : "//TRIM(option)
+        STOP 1
+      ENDIF
+
+  END SUBROUTINE Get_CLI_int32
+
+  SUBROUTINE Get_CLI_int64( this, option, res )
+    IMPLICIT NONE
+    CLASS(CLI), INTENT(inout) :: this
+    CHARACTER(*), INTENT(in) :: option
+    INTEGER(int64), INTENT(out) :: res 
+    ! Local
+    INTEGER :: error
+
+      CALL this % cliObj % get(val=res,switch=TRIM(option),error=error)
+      IF( error /= 0 )THEN
+        PRINT*, "Configuration key not found : "//TRIM(option)
+        STOP 1
+      ENDIF
+
+  END SUBROUTINE Get_CLI_int64
+
+  SUBROUTINE Get_CLI_real32( this, option, res )
+    IMPLICIT NONE
+    CLASS(CLI), INTENT(inout) :: this
+    CHARACTER(*), INTENT(in) :: option
+    REAL(real32), INTENT(out) :: res 
+    ! Local
+    INTEGER :: error
+
+      CALL this % cliObj % get(val=res,switch=TRIM(option),error=error)
+      IF( error /= 0 )THEN
+        PRINT*, "Configuration key not found : "//TRIM(option)
+        STOP 1
+      ENDIF
+
+  END SUBROUTINE Get_CLI_real32
+
+  SUBROUTINE Get_CLI_real64( this, option, res )
+    IMPLICIT NONE
+    CLASS(CLI), INTENT(inout) :: this
+    CHARACTER(*), INTENT(in) :: option
+    REAL(real64), INTENT(out) :: res 
+    ! Local
+    INTEGER :: error
+
+      CALL this % cliObj % get(val=res,switch=TRIM(option),error=error)
+      IF( error /= 0 )THEN
+        PRINT*, "Configuration key not found : "//TRIM(option)
+        STOP 1
+      ENDIF
+
+  END SUBROUTINE Get_CLI_real64
+
+  SUBROUTINE Get_CLI_logical( this, option, res )
+    IMPLICIT NONE
+    CLASS(CLI), INTENT(inout) :: this
+    CHARACTER(*), INTENT(in) :: option
+    LOGICAL, INTENT(out) :: res 
+    ! Local
+    INTEGER :: error
+
+      CALL this % cliObj % get(val=res,switch=TRIM(option),error=error)
+      IF( error /= 0 )THEN
+        PRINT*, "Configuration key not found : "//TRIM(option)
+        STOP 1
+      ENDIF
+
+  END SUBROUTINE Get_CLI_logical
+
 
 END MODULE SELF_CLI

--- a/src/SELF_Lagrange.f90
+++ b/src/SELF_Lagrange.f90
@@ -1265,7 +1265,7 @@ CONTAINS
           END DO
 
           ! Boundary Contribution
-          df(i,iVar,iEl) = df(i,iVar,iEl) + (bf(iVar,2,iEl)*myPoly % bMatrix % hostData(i,1) - &
+          df(i,iVar,iEl) = df(i,iVar,iEl) + (bf(iVar,2,iEl)*myPoly % bMatrix % hostData(i,1) + &
                                              bf(iVar,1,iEl)*myPoly % bMatrix % hostData(i,0))/ &
                            myPoly % qWeights % hostData(i)
 

--- a/src/SELF_Model.f90
+++ b/src/SELF_Model.f90
@@ -622,6 +622,7 @@ CONTAINS
           DO i = 1, nIO
             tNext = this % t + ioInterval
             CALL this % ForwardStepEuler(tNext)
+            this % t = tNext
             CALL this % WriteModel()
             CALL this % WriteTecplot()
             CALL this % CalculateEntropy()
@@ -630,8 +631,9 @@ CONTAINS
 
         ELSE
           CALL this % ForwardStepEuler(targetTime)
-            CALL this % CalculateEntropy()
-            CALL this % ReportEntropy()
+          this % t = targetTime
+          CALL this % CalculateEntropy()
+          CALL this % ReportEntropy()
         ENDIF
 
       CASE (SELF_RK3)
@@ -640,6 +642,7 @@ CONTAINS
           DO i = 1, nIO
             tNext = this % t + ioInterval
             CALL this % ForwardStepRK3(tNext)
+            this % t = tNext
             CALL this % WriteModel()
             CALL this % WriteTecplot()
             CALL this % CalculateEntropy()
@@ -648,8 +651,9 @@ CONTAINS
 
         ELSE
           CALL this % ForwardStepRK3(targetTime)
-            CALL this % CalculateEntropy()
-            CALL this % ReportEntropy()
+          this % t = targetTime
+          CALL this % CalculateEntropy()
+          CALL this % ReportEntropy()
         ENDIF
 
       CASE DEFAULT
@@ -660,6 +664,7 @@ CONTAINS
           DO i = 1, nIO
             tNext = this % t + ioInterval
             CALL this % ForwardStepEuler(tNext)
+            this % t = tNext
             CALL this % WriteModel()
             CALL this % WriteTecplot()
             CALL this % CalculateEntropy()
@@ -668,6 +673,9 @@ CONTAINS
 
         ELSE
           CALL this % ForwardStepEuler(targetTime)
+          this % t = targetTime
+          CALL this % CalculateEntropy()
+          CALL this % ReportEntropy()
         ENDIF
 
 

--- a/src/SELF_Model.f90
+++ b/src/SELF_Model.f90
@@ -989,6 +989,7 @@ CONTAINS
 
     CALL this % PreTendency()
     CALL this % solution % BoundaryInterp(this % gpuAccel)
+    CALL this % solution % SideExchange(this % mesh, this % decomp, this % gpuAccel)
     CALL this % SetBoundaryCondition()
     CALL this % SourceMethod()
     CALL this % RiemannSolver()

--- a/src/SELF_ShallowWater1D.f90
+++ b/src/SELF_ShallowWater1D.f90
@@ -1,0 +1,386 @@
+!
+! Copyright 2020-2022 Fluid Numerics LLC
+! Author : Joseph Schoonover (joe@fluidnumerics.com)
+! Support : support@fluidnumerics.com
+!
+! //////////////////////////////////////////////////////////////////////////////////////////////// !
+MODULE SELF_ShallowWater1D
+
+  USE SELF_Metadata
+  USE SELF_Mesh
+  USE SELF_MappedData
+  USE SELF_Model
+
+
+  TYPE,EXTENDS(Model1D) :: ShallowWater1D
+    !! iVar = 1 ~> u velocity component
+    !! iVar = 2 ~> v velocity component
+    !! iVar = 3 ~> free surface height
+    REAL(prec) :: fCori ! coriolis parameter ( 1/s )
+    REAL(prec) :: g     ! gravity ( m/s^2) 
+    TYPE(MappedScalar1D) :: H ! bottom topography ( m )
+    TYPE(MappedScalar1D) :: gradH ! bottom topography gradient ( m/m )
+
+
+    CONTAINS
+
+    ! Overridden Methods
+    PROCEDURE :: Init => Init_ShallowWater1D
+    PROCEDURE :: CalculateEntropy => CalculateEntropy_ShallowWater1D
+
+    PROCEDURE :: PreTendency => PreTendency_ShallowWater1D
+
+    ! Concretized Methods
+    PROCEDURE :: SourceMethod => Source_ShallowWater1D
+    PROCEDURE :: FluxMethod => Flux_ShallowWater1D
+    PROCEDURE :: RiemannSolver => RiemannSolver_ShallowWater1D
+    PROCEDURE :: SetBoundaryCondition => SetBoundaryCondition_ShallowWater1D
+
+    ! New Methods
+    GENERIC :: SetTopography => SetTopographyFromChar_ShallowWater1D,&
+                              SetTopographyFromEqn_ShallowWater1D
+    PROCEDURE,PRIVATE :: SetTopographyFromChar_ShallowWater1D
+    PROCEDURE,PRIVATE :: SetTopographyFromEqn_ShallowWater1D
+
+  END TYPE ShallowWater1D
+
+!  INTERFACE
+!    SUBROUTINE SetBoundaryCondition_ShallowWater1D_gpu_wrapper(solution, extBoundary, nHat, sideInfo, N, nVar, nEl) &
+!      bind(c,name="SetBoundaryCondition_ShallowWater1D_gpu_wrapper")
+!      USE iso_c_binding
+!      USE SELF_Constants
+!      IMPLICIT NONE
+!      TYPE(c_ptr) :: solution, extBoundary, nHat, sideInfo
+!      INTEGER(C_INT),VALUE :: N,nVar,nEl
+!    END SUBROUTINE SetBoundaryCondition_ShallowWater1D_gpu_wrapper
+!  END INTERFACE
+!
+!  INTERFACE
+!    SUBROUTINE Source_ShallowWater1D_gpu_wrapper(source, solution, f, N, nVar, nEl) &
+!      bind(c,name="Source_ShallowWater1D_gpu_wrapper")
+!      USE iso_c_binding
+!      USE SELF_Constants
+!      IMPLICIT NONE
+!      TYPE(c_ptr) :: source, solution
+!      INTEGER(C_INT),VALUE :: N,nVar,nEl
+!      REAL(c_prec),VALUE :: f
+!    END SUBROUTINE Source_ShallowWater1D_gpu_wrapper
+!  END INTERFACE
+!
+!  INTERFACE
+!    SUBROUTINE Flux_ShallowWater1D_gpu_wrapper(flux, solution, g, H, N, nVar, nEl) &
+!      bind(c,name="Flux_ShallowWater1D_gpu_wrapper")
+!      USE iso_c_binding
+!      USE SELF_Constants
+!      IMPLICIT NONE
+!      TYPE(c_ptr) :: flux, solution
+!      INTEGER(C_INT),VALUE :: N,nVar,nEl
+!      REAL(c_prec),VALUE :: g, H
+!    END SUBROUTINE Flux_ShallowWater1D_gpu_wrapper
+!  END INTERFACE
+!
+!  INTERFACE
+!    SUBROUTINE RiemannSolver_ShallowWater1D_gpu_wrapper(flux, solution, extBoundary, nHat, nScale, g, H, N, nVar, nEl) &
+!      bind(c,name="RiemannSolver_ShallowWater1D_gpu_wrapper")
+!      USE iso_c_binding
+!      USE SELF_Constants
+!      IMPLICIT NONE
+!      TYPE(c_ptr) :: flux, solution, extBoundary, nHat, nScale
+!      INTEGER(C_INT),VALUE :: N,nVar,nEl
+!      REAL(c_prec),VALUE :: g, H
+!    END SUBROUTINE RiemannSolver_ShallowWater1D_gpu_wrapper
+!  END INTERFACE
+
+CONTAINS
+
+  SUBROUTINE Init_ShallowWater1D(this,nvar,mesh,geometry,decomp)
+    IMPLICIT NONE
+    CLASS(ShallowWater1D),INTENT(out) :: this
+    INTEGER,INTENT(in) :: nvar
+    TYPE(Mesh1D),INTENT(in),TARGET :: mesh
+    TYPE(Geometry1D),INTENT(in),TARGET :: geometry
+    TYPE(MPILayer),INTENT(in),TARGET :: decomp
+    ! Local
+    INTEGER :: ivar
+    CHARACTER(LEN=3) :: ivarChar
+    CHARACTER(LEN=25) :: varname
+    INTEGER :: nvarloc
+
+    ! Ensure that the number of variables is 3
+    ! nvar is unused in this class extension
+    nvarloc = 2
+
+    this % decomp => decomp
+    this % mesh => mesh
+    this % geometry => geometry
+    this % gpuAccel = .FALSE.
+    this % fluxDivMethod = SELF_CONSERVATIVE_FLUX 
+    this % g = 1.0_prec
+    this % fCori = 0.0_prec
+
+    CALL this % solution % Init(geometry % x % interp,nvarloc,this % mesh % nElem)
+    CALL this % H % Init(geometry % x % interp,1,this % mesh % nElem)
+    CALL this % gradH % Init(geometry % x % interp,1,this % mesh % nElem)
+    CALL this % workSol % Init(geometry % x % interp,nVar,this % mesh % nElem)
+    CALL this % velocity % Init(geometry % x % interp,1,this % mesh % nElem)
+    CALL this % dSdt % Init(geometry % x % interp,nvarloc,this % mesh % nElem)
+    CALL this % solutionGradient % Init(geometry % x % interp,nvarloc,this % mesh % nElem)
+    CALL this % flux % Init(geometry % x % interp,nvarloc,this % mesh % nElem)
+    CALL this % source % Init(geometry % x % interp,nvarloc,this % mesh % nElem)
+    CALL this % fluxDivergence % Init(geometry % x % interp,nvarloc,this % mesh % nElem)
+
+    ! First three variables are treated as u, v, eta
+    ! Any additional are treated as passive tracers 
+    CALL this % solution % SetName(1,"Hu")
+    CALL this % solution % SetUnits(1,"m^2/s")
+    CALL this % solution % SetDescription(1,"x-component of the volume flux")
+
+    CALL this % solution % SetName(2,"H")
+    CALL this % solution % SetUnits(2,"m")
+    CALL this % solution % SetDescription(2,"Total fluid thickness")
+
+  END SUBROUTINE Init_ShallowWater1D
+
+  SUBROUTINE CalculateEntropy_ShallowWater1D(this)
+  !! Base method for calculating entropy of a model
+  !! Calculates the entropy as the integration of the 
+  !! squared tracer over the domain
+    IMPLICIT NONE
+    CLASS(ShallowWater1D), INTENT(inout) :: this
+    ! Local
+    INTEGER :: i, j, iVar, iEl
+    REAL(prec) :: Jacobian, Hu, H, b
+    REAL(prec) :: wi
+
+    this % entropy = 0.0_prec
+
+    DO iEl = 1, this % geometry % x % nElem
+      DO i = 0, this % geometry % x % interp % N
+
+        ! Coordinate mapping Jacobian
+        Jacobian = this % geometry % dxds % interior % hostData(i,1,iEl)
+
+        ! Quadrature weights
+        wi = this % geometry % x % interp % qWeights % hostData(i) 
+
+        ! Solution
+        Hu = this % solution % interior % hostData(i,1,iEl)
+        H = this % solution % interior % hostData(i,2,iEl)
+        b = this % H % interior % hostData(i,1,iEl)
+
+        this % entropy = this % entropy + ( 0.5_prec*Hu*Hu/H + &
+                                            0.5_prec*this % g*H*H - this % g*H*b )*Jacobian*wi
+
+      ENDDO
+    ENDDO
+
+  END SUBROUTINE CalculateEntropy_ShallowWater1D
+
+  SUBROUTINE PreTendency_ShallowWater1D(this)
+    !! Calculate the velocity at element interior and element boundaries
+    !! PreTendency is a template routine that is used to house any additional calculations
+    !! that you want to execute at the beginning of the tendency calculation routine.
+    !! This default PreTendency simply returns back to the caller without executing any instructions
+    !!
+    !! The intention is to provide a method that can be overridden through type-extension, to handle
+    !! any steps that need to be executed before proceeding with the usual tendency calculation methods.
+    !!
+    IMPLICIT NONE
+    CLASS(ShallowWater1D),INTENT(inout) :: this
+    !
+    INTEGER :: iEl, i
+    REAL(prec) :: H
+
+
+      DO iEl = 1, this % solution % nElem
+        DO i = 0, this % solution % interp % N
+
+          H = this % solution % interior % hostData(i,2,iEl)
+
+          this % velocity % interior % hostData(i,1,iEl) = &
+                  this % solution % interior % hostData(i,1,iEl)/H 
+
+        ENDDO 
+      ENDDO 
+
+      CALL this % velocity % BoundaryInterp( gpuAccel = this % gpuAccel )
+      CALL this % velocity % SideExchange(this % mesh, this % decomp, this % gpuAccel)
+
+  END SUBROUTINE PreTendency_ShallowWater1D
+
+  SUBROUTINE SetTopographyFromChar_ShallowWater1D(this, eqnChar) 
+    IMPLICIT NONE
+    CLASS(ShallowWater1D),INTENT(inout) :: this
+    CHARACTER(*),INTENT(in) :: eqnChar
+
+      CALL this % H % SetEquation(1, eqnChar)
+
+      CALL this % H % SetInteriorFromEquation( this % geometry, this % t )
+
+      CALL this % H % BoundaryInterp( gpuAccel = .FALSE. )
+
+      CALL this % H % Derivative( this % geometry, &
+                                this % gradH, &
+                                selfStrongForm, &
+                                .FALSE.)
+
+      IF( this % gpuAccel )THEN
+        CALL this % H % UpdateDevice()
+      ENDIF
+
+  END SUBROUTINE SetTopographyFromChar_ShallowWater1D
+
+  SUBROUTINE SetTopographyFromEqn_ShallowWater1D(this, eqn) 
+    IMPLICIT NONE
+    CLASS(ShallowWater1D),INTENT(inout) :: this
+    TYPE(EquationParser),INTENT(in) :: eqn
+
+      ! Copy the equation parser
+      CALL this % H % SetEquation(1, eqn % equation)
+
+      CALL this % H % SetInteriorFromEquation( this % geometry, this % t )
+
+      CALL this % H % BoundaryInterp( gpuAccel = .FALSE. )
+
+      CALL this % H % Derivative( this % geometry, &
+                                this % gradH, &
+                                selfStrongForm, &
+                                .FALSE.)
+
+      IF( this % gpuAccel )THEN
+        CALL this % H % UpdateDevice()
+      ENDIF
+
+  END SUBROUTINE SetTopographyFromEqn_ShallowWater1D 
+
+  SUBROUTINE SetBoundaryCondition_ShallowWater1D(this)
+    IMPLICIT NONE
+    CLASS(ShallowWater1D),INTENT(inout) :: this
+    ! Local
+    INTEGER :: iEl, iSide, i
+    INTEGER :: bcid, e2
+    REAL(prec) :: u, v, nhat(1:2)
+
+
+     ! Only do radiation condition (for now)
+     ! Left most boundary
+     this % solution % extBoundary % hostData(1,1,1) = 0.0_prec
+     this % solution % extBoundary % hostData(2,1,1) = this % H % boundary % hostData(1,1,1)
+
+     ! Right most boundary
+     this % solution % extBoundary % hostData(1,2,this % solution % nElem) = 0.0_prec
+     this % solution % extBoundary % hostData(2,2,this % solution % nElem) = &
+             this % H % boundary % hostData(1,2,this % solution % nElem)
+
+
+  END SUBROUTINE SetBoundaryCondition_ShallowWater1D 
+
+  SUBROUTINE Source_ShallowWater1D(this)
+    IMPLICIT NONE
+    CLASS(ShallowWater1D),INTENT(inout) :: this
+    ! Local
+    INTEGER :: i,j,iEl,iVar
+
+      DO iEl = 1, this % source % nElem
+        DO i = 0, this % source % interp % N
+
+          this % source % interior % hostData(i,1,iEl) = &
+                  this % g*this % solution % interior % hostData(i,2,iEl)*&
+                  this % gradH % interior % hostData(i,1,iEl)
+
+          this % source % interior % hostData(i,2,iEl) = 0.0_prec
+
+        ENDDO
+      ENDDO
+
+
+  END SUBROUTINE Source_ShallowWater1D
+
+  SUBROUTINE Flux_ShallowWater1D(this)
+    IMPLICIT NONE
+    CLASS(ShallowWater1D),INTENT(inout) :: this
+    ! Local
+    INTEGER :: i,j,iEl,iVar
+
+      DO iEl = 1, this % solution % nElem
+        DO iVar = 1, this % solution % nVar
+          DO i = 0, this % solution % interp % N
+
+            IF ( iVar == 1 )THEN ! Hu
+
+              ! Hu^2 + (gH^2)/2
+              this % flux % interior % hostData(i,iVar,iEl) = &
+                    this % velocity % interior % hostData(i,1,iEl)*& ! u
+                    this % solution % interior % hostData(i,1,iEl)+& ! Hu
+                    0.5_prec*this % g*this % solution % interior % hostData(i,2,iEl)*&
+                    this % solution % interior % hostData(i,2,iEl)
+
+
+            ELSEIF ( iVar == 2 )THEN ! H - total fluid thickness
+              this % flux % interior % hostData(i,iVar,iEl) = &
+                    this % solution % interior % hostData(i,1,iEl)
+
+            ENDIF
+
+          ENDDO
+        ENDDO
+      ENDDO
+
+  END SUBROUTINE Flux_ShallowWater1D
+
+  SUBROUTINE RiemannSolver_ShallowWater1D(this)
+    IMPLICIT NONE
+    CLASS(ShallowWater1D),INTENT(inout) :: this
+    ! Local
+    INTEGER :: i,iSide,iEl
+    REAL(prec) :: cL, cR, unL, unR, HL, HR, HuL, HuR, HvL, HvR
+    REAL(prec) :: alpha, nhat
+    REAL(prec) :: fluxL(1:2)
+    REAL(prec) :: fluxR(1:2)
+
+      DO iEl = 1, this % solution % nElem
+        DO iSide = 1, 2
+
+           ! Get the boundary normals on cell edges from the mesh geometry
+           IF( iSide ==  1)THEN
+             nhat = -1.0_prec
+           ELSE
+             nhat = 1.0_prec
+           ENDIF
+
+           ! Calculate the normal velocity at the cell edges
+           unL = this % velocity % boundary % hostData(1,iSide,iEl)
+           unR = this % velocity % extBoundary % hostData(1,iSide,iEl)
+
+           cL = sqrt( this % g * this % solution % boundary % hostData(2,iSide,iEl))
+           cR = sqrt( this % g * this % solution % extBoundary % hostData(2,iSide,iEl))
+
+           HuL = this % solution % boundary % hostData(1,iSide,iEl)
+           HuR = this % solution % extBoundary % hostData(1,iSide,iEl)
+
+           HL = this % solution % boundary % hostData(2,iSide,iEl)
+           HR = this % solution % extBoundary % hostData(2,iSide,iEl)
+
+           fluxL(1) = (HuL*unL + this % g*HL*HL*0.5_prec)*nHat
+           fluxL(2) = HuL*nHat
+
+           fluxR(1) = (HuR*unR + this % g*HR*HR*0.5_prec)*nHat
+           fluxR(2) = HuR*nHat
+
+           alpha = MAX( ABS(unL+cL), ABS(unR+cR), &
+                        ABS(unL-cL), ABS(unR-cR) )
+
+           ! Pull external and internal state for the Riemann Solver (Lax-Friedrichs)
+           this % flux % boundary % hostData(1,iSide,iEl) = 0.5_prec*( &
+                   fluxL(1) + fluxR(1) + alpha*( HuL - HuR ) )
+           this % flux % boundary % hostData(2,iSide,iEl) = 0.5_prec*( &
+                   fluxL(2) + fluxR(2) + alpha*( HL - HR ) )
+
+        ENDDO
+      ENDDO
+
+!    ENDIF
+
+  END SUBROUTINE RiemannSolver_ShallowWater1D
+
+END MODULE SELF_ShallowWater1D

--- a/src/SELF_SupportRoutines.f90
+++ b/src/SELF_SupportRoutines.f90
@@ -823,6 +823,36 @@ CONTAINS
 
   END FUNCTION UpperCase
 !
+  FUNCTION GetIntForChar(charFlag) RESULT(intFlag)
+  !! This method is used to return the integer flag from a char for constants
+  !! defined in SELF_Constants.f90
+  !!
+    IMPLICIT NONE
+    CHARACTER(*),INTENT(in) :: charFlag
+    INTEGER :: intFlag
+
+    SELECT CASE( UpperCase(TRIM(charFlag)) )
+
+      CASE ("GAUSS")
+        intFlag = GAUSS
+
+      CASE ("GAUSS-LOBATTO")
+        intFlag = GAUSS_LOBATTO
+
+      CASE ("CHEBYSHEV-GAUSS")
+        intFlag = CHEBYSHEV_GAUSS
+
+      CASE ("CHEBYSHEV-GAUSS-LOBATTO")
+        intFlag = CHEBYSHEV_GAUSS_LOBATTO
+
+      CASE ("UNIFORM")
+        intFlag = UNIFORM
+
+    END SELECT
+
+  END FUNCTION GetIntForChar
+
+!
   FUNCTION TimeStamp(time,units) RESULT(timeStampString)
     IMPLICIT NONE
     REAL(prec)    :: time

--- a/src/hip/SELF_ShallowWater1D.cpp
+++ b/src/hip/SELF_ShallowWater1D.cpp
@@ -1,0 +1,145 @@
+#include <hip/hip_runtime.h>
+#include "SELF_HIP_Macros.h"
+#include <cstdio>
+
+/*
+__global__ void SetBoundaryCondition_ShallowWater_gpu( real *solution, real *extBoundary, real *nHat, int *sideInfo, int N, int nVar ){
+
+  size_t iSide = blockIdx.x+1;
+  size_t iEl = blockIdx.y;
+  size_t i = threadIdx.x;
+
+  int bcid = sideInfo[4+5*(iSide-1 +4*(iEl))];
+  int e2 = sideInfo[2+5*(iSide-1 + 4*(iEl))];
+
+  if( e2 == 0 ){
+
+    if( bcid == SELF_BC_RADIATION ){
+
+      extBoundary[SCB_2D_INDEX(i,0,iSide,iEl,N,nVar)] = 0.0;
+      extBoundary[SCB_2D_INDEX(i,1,iSide,iEl,N,nVar)] = 0.0;
+      extBoundary[SCB_2D_INDEX(i,2,iSide,iEl,N,nVar)] = 0.0;
+
+    } else if ( bcid == SELF_BC_NONORMALFLOW ){
+
+      real nx = nHat[VEB_2D_INDEX(1,i,0,iSide,iEl,N,1)];
+      real ny = nHat[VEB_2D_INDEX(2,i,0,iSide,iEl,N,1)];
+      real u = solution[SCB_2D_INDEX(i,0,iSide,iEl,N,nVar)];
+      real v = solution[SCB_2D_INDEX(i,1,iSide,iEl,N,nVar)];
+      real eta = solution[SCB_2D_INDEX(i,2,iSide,iEl,N,nVar)];
+
+      extBoundary[SCB_2D_INDEX(i,0,iSide,iEl,N,nVar)] = (ny*ny-nx*ny)*u-2.0*nx*ny*v;
+      extBoundary[SCB_2D_INDEX(i,0,iSide,iEl,N,nVar)] = (nx*nx-ny*ny)*v-2.0*nx*ny*u;
+      extBoundary[SCB_2D_INDEX(i,0,iSide,iEl,N,nVar)] = eta;
+
+    } else {
+
+      extBoundary[SCB_2D_INDEX(i,0,iSide,iEl,N,nVar)] = 0.0;
+      extBoundary[SCB_2D_INDEX(i,1,iSide,iEl,N,nVar)] = 0.0;
+      extBoundary[SCB_2D_INDEX(i,2,iSide,iEl,N,nVar)] = 0.0;
+
+    }
+  }
+
+}
+
+extern "C"
+{
+  void SetBoundaryCondition_ShallowWater_gpu_wrapper( real **solution, real **extBoundary, real **nHat, int **sideInfo, int N, int nVar, int nEl)
+  {
+    SetBoundaryCondition_ShallowWater_gpu<<<dim3(4,nEl,1), dim3(N+1,1,1), 0, 0>>>(*solution, *extBoundary, *nHat, *sideInfo, N, nVar);
+  }
+}
+*/
+
+__global__ void Source_ShallowWater1D_gpu(real *source, real *solution, real *gradH, real g, int N, int nVar){
+
+  // Get the array indices from the GPU thread IDs
+  size_t iVar = blockIdx.x;
+  size_t iEl = blockIdx.y;
+  size_t i = threadIdx.x;
+
+    if( iVar == 0 ){
+      source[SC_1D_INDEX(i,iVar,iEl,N,nVar)] = g*solution[SC_1D_INDEX(i,1,iEl,N,nVar)]*
+	                                         gradH[SC_1D_INDEX(i,0,iEl,N,1)];
+    } else if ( iVar == 1) {
+      source[SC_1D_INDEX(i,iVar,iEl,N,nVar)] = 0.0;
+    }
+}
+
+extern "C"
+{
+  void Source_ShallowWater1D_gpu_wrapper(real **source, real **solution, real **gradH, real g, int N, int nVar, int nEl)
+  {
+    Source_ShallowWater1D_gpu<<<dim3(nVar,nEl,1), dim3(N+1,1,1), 0, 0>>>(*source, *solution, *gradH, g, N, nVar);
+  }
+}
+
+/*
+__global__ void Flux_ShallowWater_gpu(real *flux, real *solution, real g, real H, int N, int nVar){
+
+  // Get the array indices from the GPU thread IDs
+  size_t iVar = blockIdx.x;
+  size_t iEl = blockIdx.y;
+  size_t i = threadIdx.x;
+  size_t j = threadIdx.y;
+
+    if( iVar == 0 ){
+      flux[VE_2D_INDEX(1,i,j,iVar,iEl,N,1)] = g*solution[SC_2D_INDEX(i,j,2,iEl,N,nVar)];
+      flux[VE_2D_INDEX(2,i,j,iVar,iEl,N,1)] = 0.0;
+    } else if ( iVar == 1) {
+      flux[VE_2D_INDEX(1,i,j,iVar,iEl,N,1)] = 0.0;
+      flux[VE_2D_INDEX(2,i,j,iVar,iEl,N,1)] = g*solution[SC_2D_INDEX(i,j,2,iEl,N,nVar)];
+    } else if ( iVar == 2) {
+      flux[VE_2D_INDEX(1,i,j,iVar,iEl,N,1)] = H*solution[SC_2D_INDEX(i,j,0,iEl,N,nVar)];
+      flux[VE_2D_INDEX(2,i,j,iVar,iEl,N,1)] = H*solution[SC_2D_INDEX(i,j,1,iEl,N,nVar)];
+    }
+}
+
+extern "C"
+{
+  void Flux_ShallowWater_gpu_wrapper(real **flux, real **solution, real g, real H, int N, int nVar, int nEl)
+  {
+    Flux_ShallowWater_gpu<<<dim3(nVar,nEl,1), dim3(N+1,N+1,1), 0, 0>>>(*flux, *solution, g, H, N, nVar);
+  }
+}
+
+__global__ void RiemannSolver_ShallowWater_gpu( real *flux, real *solution, real *extBoundary, real *nHat, real *nScale, real g, real H, int N, int nVar ){
+
+  size_t iSide = blockIdx.x+1;
+  size_t iEl = blockIdx.y;
+  size_t i = threadIdx.x;
+
+  real nx = nHat[VEB_2D_INDEX(1,i,0,iSide,iEl,N,1)];
+  real ny = nHat[VEB_2D_INDEX(2,i,0,iSide,iEl,N,1)];
+	
+  real unL = solution[SCB_2D_INDEX(i,0,iSide,iEl,N,nVar)]*nx+
+             solution[SCB_2D_INDEX(i,1,iSide,iEl,N,nVar)]*ny;
+
+  real unR = extBoundary[SCB_2D_INDEX(i,0,iSide,iEl,N,nVar)]*nx+
+            extBoundary[SCB_2D_INDEX(i,1,iSide,iEl,N,nVar)]*ny;
+
+  real etaL = solution[SCB_2D_INDEX(i,2,iSide,iEl,N,nVar)];
+  real etaR = extBoundary[SCB_2D_INDEX(i,2,iSide,iEl,N,nVar)];
+
+  real c = sqrt(g*H);
+
+  real wL = 0.5*(unL/g + etaL/c);
+  real wR = 0.5*(unR/g - etaR/c);
+
+  real nmag = nScale[SCB_2D_INDEX(i,0,iSide,iEl,N,1)];
+
+  flux[SCB_2D_INDEX(i,0,iSide,iEl,N,nVar)] = g*c*(wL-wR)*nx*nmag;
+  flux[SCB_2D_INDEX(i,1,iSide,iEl,N,nVar)] = g*c*(wL-wR)*ny*nmag;
+  flux[SCB_2D_INDEX(i,2,iSide,iEl,N,nVar)] = c*c*(wL+wR)*nmag;
+
+}
+
+extern "C"
+{
+  void RiemannSolver_ShallowWater_gpu_wrapper( real **flux, real **solution, real **extBoundary, real **nHat, real **nScale, real g, real H, int N, int nVar, int nEl)
+  {
+    RiemannSolver_ShallowWater_gpu<<<dim3(4,nEl,1), dim3(N+1,1,1), 0, 0>>>(*flux, *solution, *extBoundary, *nHat, *nScale, g, H, N, nVar);
+  }
+}
+*/


### PR DESCRIPTION
This pull request brings in the nonlinear shallow water equation solvers for 1-D and 2-D. Flat bottomed test cases have been added for blockmesh geometry; for 2-D, this includes a quiet fluid and gravity wave release test case. In 1-D, we have a quiet fluid test case.  

Tests have also been added that demonstrate the generation of spurious gravity waves in the presence of varying topography. This motivates the need for developing corrections for the solvers as documented in [Gassner, Winters, & Kopriva (2016)](https://www.diva-portal.org/smash/get/diva2:1315753/FULLTEXT01.pdf) and [Wintermeyer et al. (2017)](https://www.sciencedirect.com/science/article/pii/S0021999117302310)