### PR TITLE
Add DiracDelta scatter for Points on DGSEM 2D/3D models

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,6 +9,7 @@ ext-examples/
 *.gcov
 *.info
 *.sif
+*.sqsh
 *.out
 *.err
 *.log

--- a/src/SELF_Points_t.f90
+++ b/src/SELF_Points_t.f90
@@ -673,7 +673,7 @@ contains
     type(SEMQuad),intent(in) :: geometry
     class(MappedScalar2D_t),intent(inout) :: scalar
     ! Local
-    integer :: p,iEl,i,j,m,n,N
+    integer :: p,iEl,i,j,mm,nn,N
     real(prec) :: J0,wi,wj
     real(prec),allocatable :: lS(:),lT(:)
     logical :: useCache
@@ -715,9 +715,9 @@ contains
       ! Polynomial interpolation of the nodal Jacobian determinant at the
       ! source's reference coordinates.
       J0 = 0.0_prec
-      do n = 1,N+1
-        do m = 1,N+1
-          J0 = J0+lS(m-1)*lT(n-1)*geometry%J%interior(m,n,iEl,1)
+      do nn = 1,N+1
+        do mm = 1,N+1
+          J0 = J0+lS(mm-1)*lT(nn-1)*geometry%J%interior(mm,nn,iEl,1)
         enddo
       enddo
       if(abs(J0) < tiny(1.0_prec)*1.0e3_prec) then
@@ -758,7 +758,7 @@ contains
     type(SEMHex),intent(in) :: geometry
     class(MappedScalar3D_t),intent(inout) :: scalar
     ! Local
-    integer :: p,iEl,i,j,k,m,n,l,N
+    integer :: p,iEl,i,j,k,mm,nn,ll,N
     real(prec) :: J0,wi,wj,wk
     real(prec),allocatable :: lS(:),lT(:),lU(:)
     logical :: useCache
@@ -799,10 +799,10 @@ contains
 
       ! Polynomial interpolation of the nodal Jacobian determinant.
       J0 = 0.0_prec
-      do l = 1,N+1
-        do n = 1,N+1
-          do m = 1,N+1
-            J0 = J0+lS(m-1)*lT(n-1)*lU(l-1)*geometry%J%interior(m,n,l,iEl,1)
+      do ll = 1,N+1
+        do nn = 1,N+1
+          do mm = 1,N+1
+            J0 = J0+lS(mm-1)*lT(nn-1)*lU(ll-1)*geometry%J%interior(mm,nn,ll,iEl,1)
           enddo
         enddo
       enddo

--- a/src/SELF_Points_t.f90
+++ b/src/SELF_Points_t.f90
@@ -88,6 +88,10 @@ module SELF_Points_t
     procedure,public :: EvalScalar_2D_Points_t
     procedure,public :: EvalScalar_3D_Points_t
 
+    generic,public :: DiracDelta => DiracDelta_2D_Points_t,DiracDelta_3D_Points_t
+    procedure,public :: DiracDelta_2D_Points_t
+    procedure,public :: DiracDelta_3D_Points_t
+
   endtype Points_t
 
 contains
@@ -630,6 +634,199 @@ contains
     deallocate(lS,lT,lU)
 
   endsubroutine EvalScalar_3D_Points_t
+
+  subroutine DiracDelta_2D_Points_t(this,geometry,scalar)
+    !! Scatter a discrete Dirac delta of unit strength (S = 1) onto a 2D
+    !! MappedScalar, one variable per stored point. Variable p of scalar
+    !! receives the delta associated with point p.
+    !!
+    !! After the call, for the element iEl = elements(p) > 0:
+    !!
+    !!   scalar%interior(i,j,iEl,p) = l_i(xi_p) * l_j(eta_p)
+    !!                              / ( w_i * w_j * J_0(p) )
+    !!
+    !! and scalar%interior(i,j,iEl',p) = 0 for all iEl' /= iEl. The J_0(p)
+    !! denominator is the polynomial interpolation of geometry%J at the
+    !! source's reference coordinates, J_0 = sum_{m,n} l_m(xi_p) l_n(eta_p)
+    !! * J_{m,n}^{iEl}. For points with elements(p) == 0 (not located on this
+    !! rank), variable p is filled with zeros.
+    !!
+    !! This is the post-mass-matrix form: it can be added directly to dSdt /
+    !! the source term in a DGSEM model without further mass-matrix inversion,
+    !! since SELF's MappedDGDivergence already divides by w_i w_j J_{ij}.
+    !!
+    !! Conservation property (exact for affine elements):
+    !!   sum_{i,j} scalar%interior(i,j,iEl,p) * w_i * w_j * J_{ij}^{iEl} = 1
+    !! For curved elements the equality holds up to LGL aliasing error.
+    !!
+    !! Requirements:
+    !!   - scalar%nVar == this%nPoints
+    !!   - LocatePoints must have been called against the same geometry. The
+    !!     cached basis is reused when this%nCached == scalar%interp%N;
+    !!     otherwise the per-point Lagrange basis is recomputed on the fly.
+    !!
+    !! Points that lie on a shared face/edge receive their contribution in the
+    !! single element selected by LocatePoints — no S/2 face split is
+    !! performed.
+    implicit none
+    class(Points_t),intent(in) :: this
+    type(SEMQuad),intent(in) :: geometry
+    class(MappedScalar2D_t),intent(inout) :: scalar
+    ! Local
+    integer :: p,iEl,i,j,m,n,N
+    real(prec) :: J0,wi,wj
+    real(prec),allocatable :: lS(:),lT(:)
+    logical :: useCache
+
+    if(this%nDim /= 2) then
+      print*,"SELF_Points_t::DiracDelta (2D): nDim must be 2"
+      stop 1
+    endif
+    if(scalar%nVar /= this%nPoints) then
+      print*,"SELF_Points_t::DiracDelta (2D): scalar%nVar (",scalar%nVar, &
+        ") must equal nPoints (",this%nPoints,")"
+      stop 1
+    endif
+
+    N = scalar%interp%N
+    useCache = (this%nCached == N) .and. associated(this%lS_cache) .and. &
+               associated(this%lT_cache)
+
+    ! Each variable column is owned exclusively by a single point. Zero the
+    ! field and only fill the containing element for points we located.
+    scalar%interior = 0.0_prec
+
+    if(this%nPoints == 0) return
+
+    allocate(lS(0:N),lT(0:N))
+
+    do p = 1,this%nPoints
+      iEl = this%elements(p)
+      if(iEl <= 0) cycle
+
+      if(useCache) then
+        lS = this%lS_cache(:,p)
+        lT = this%lT_cache(:,p)
+      else
+        lS = scalar%interp%CalculateLagrangePolynomials(this%coordinates(p,1))
+        lT = scalar%interp%CalculateLagrangePolynomials(this%coordinates(p,2))
+      endif
+
+      ! Polynomial interpolation of the nodal Jacobian determinant at the
+      ! source's reference coordinates.
+      J0 = 0.0_prec
+      do n = 1,N+1
+        do m = 1,N+1
+          J0 = J0+lS(m-1)*lT(n-1)*geometry%J%interior(m,n,iEl,1)
+        enddo
+      enddo
+      if(abs(J0) < tiny(1.0_prec)*1.0e3_prec) then
+        print*,"SELF_Points_t::DiracDelta (2D): vanishing Jacobian at point ",p
+        stop 1
+      endif
+
+      ! Rank-1 scatter into the (i,j) tensor product, post-mass-matrix form.
+      do j = 1,N+1
+        wj = scalar%interp%qWeights(j)
+        do i = 1,N+1
+          wi = scalar%interp%qWeights(i)
+          scalar%interior(i,j,iEl,p) = lS(i-1)*lT(j-1)/(wi*wj*J0)
+        enddo
+      enddo
+    enddo
+
+    deallocate(lS,lT)
+
+  endsubroutine DiracDelta_2D_Points_t
+
+  subroutine DiracDelta_3D_Points_t(this,geometry,scalar)
+    !! Scatter a discrete Dirac delta of unit strength (S = 1) onto a 3D
+    !! MappedScalar, one variable per stored point. See DiracDelta_2D_Points_t
+    !! for the full specification; this is the direct 3D analogue.
+    !!
+    !! For the element iEl = elements(p) > 0:
+    !!
+    !!   scalar%interior(i,j,k,iEl,p) = l_i(xi_p) * l_j(eta_p) * l_k(zeta_p)
+    !!                                / ( w_i * w_j * w_k * J_0(p) )
+    !!
+    !! and zero in all other elements. J_0(p) is the polynomial interpolation
+    !! of geometry%J at the source point. Conservation:
+    !!   sum_{i,j,k} scalar%interior(i,j,k,iEl,p) * w_i*w_j*w_k*J_{ijk} = 1
+    !! (exact on affine elements).
+    implicit none
+    class(Points_t),intent(in) :: this
+    type(SEMHex),intent(in) :: geometry
+    class(MappedScalar3D_t),intent(inout) :: scalar
+    ! Local
+    integer :: p,iEl,i,j,k,m,n,l,N
+    real(prec) :: J0,wi,wj,wk
+    real(prec),allocatable :: lS(:),lT(:),lU(:)
+    logical :: useCache
+
+    if(this%nDim /= 3) then
+      print*,"SELF_Points_t::DiracDelta (3D): nDim must be 3"
+      stop 1
+    endif
+    if(scalar%nVar /= this%nPoints) then
+      print*,"SELF_Points_t::DiracDelta (3D): scalar%nVar (",scalar%nVar, &
+        ") must equal nPoints (",this%nPoints,")"
+      stop 1
+    endif
+
+    N = scalar%interp%N
+    useCache = (this%nCached == N) .and. associated(this%lS_cache) .and. &
+               associated(this%lT_cache) .and. associated(this%lU_cache)
+
+    scalar%interior = 0.0_prec
+
+    if(this%nPoints == 0) return
+
+    allocate(lS(0:N),lT(0:N),lU(0:N))
+
+    do p = 1,this%nPoints
+      iEl = this%elements(p)
+      if(iEl <= 0) cycle
+
+      if(useCache) then
+        lS = this%lS_cache(:,p)
+        lT = this%lT_cache(:,p)
+        lU = this%lU_cache(:,p)
+      else
+        lS = scalar%interp%CalculateLagrangePolynomials(this%coordinates(p,1))
+        lT = scalar%interp%CalculateLagrangePolynomials(this%coordinates(p,2))
+        lU = scalar%interp%CalculateLagrangePolynomials(this%coordinates(p,3))
+      endif
+
+      ! Polynomial interpolation of the nodal Jacobian determinant.
+      J0 = 0.0_prec
+      do l = 1,N+1
+        do n = 1,N+1
+          do m = 1,N+1
+            J0 = J0+lS(m-1)*lT(n-1)*lU(l-1)*geometry%J%interior(m,n,l,iEl,1)
+          enddo
+        enddo
+      enddo
+      if(abs(J0) < tiny(1.0_prec)*1.0e3_prec) then
+        print*,"SELF_Points_t::DiracDelta (3D): vanishing Jacobian at point ",p
+        stop 1
+      endif
+
+      do k = 1,N+1
+        wk = scalar%interp%qWeights(k)
+        do j = 1,N+1
+          wj = scalar%interp%qWeights(j)
+          do i = 1,N+1
+            wi = scalar%interp%qWeights(i)
+            scalar%interior(i,j,k,iEl,p) = lS(i-1)*lT(j-1)*lU(k-1)/ &
+                                           (wi*wj*wk*J0)
+          enddo
+        enddo
+      enddo
+    enddo
+
+    deallocate(lS,lT,lU)
+
+  endsubroutine DiracDelta_3D_Points_t
 
   ! ===== Internal helpers =====================================================
 

--- a/src/gpu/SELF_Points.cpp
+++ b/src/gpu/SELF_Points.cpp
@@ -107,3 +107,136 @@ void EvalScalarPoints_3D_gpu(real *values, int *elements,
       values, elements, lS, lT, lU, scalar, N, nPoints, nElem, nVar);
 }
 }
+
+// DiracDelta_2D_kernel
+// One thread per (i, j, p). Each thread that owns a located point computes
+//
+//   J_0(p) = sum_{m,n} lS[p][m] * lT[p][n] * J[m,n,iEl-1,0]
+//   scalar[i,j,iEl-1,p] = lS[p][i] * lT[p][j] / (qW[i] * qW[j] * J_0(p))
+//
+// for iEl = elements[p]. Threads for points with elements[p] <= 0 do nothing;
+// the array is zeroed by the host launcher before the kernel runs so all other
+// (i,j,iEl',p) entries (iEl' != elements[p]) end up zero.
+//
+// Memory layouts (column-major, mirrors Fortran):
+//   scalar:    real [nVar=nPoints][nElem][N+1][N+1]    (use SC_2D_INDEX)
+//   J:         real [1][nElem][N+1][N+1]               (J%interior, iVar=0)
+//   lS, lT:    real [nPoints][N+1]                     (p*(N+1)+i)
+//   qW:        real [N+1]                              (LGL weights)
+//   elements:  int  [nPoints]                          (1-based; 0 means not found)
+
+__global__ void DiracDelta_2D_kernel(real *scalar, real *J,
+                                     real *lS, real *lT, real *qW,
+                                     int *elements,
+                                     int N, int nPoints, int nElem) {
+  int idx = threadIdx.x + blockIdx.x * blockDim.x;
+  int Np1 = N + 1;
+  int totalWork = Np1 * Np1 * nPoints;
+  if (idx >= totalWork) return;
+
+  int i = idx % Np1;
+  int j = (idx / Np1) % Np1;
+  int p = idx / (Np1 * Np1);
+
+  int iEl = elements[p];
+  if (iEl <= 0) return; // array was pre-zeroed by the host launcher
+  iEl -= 1;
+
+  real *lSp = &lS[p * Np1];
+  real *lTp = &lT[p * Np1];
+
+  real J0 = (real)0;
+  for (int n = 0; n < Np1; n++) {
+    real ln = lTp[n];
+    for (int m = 0; m < Np1; m++) {
+      J0 += lSp[m] * ln * J[SC_2D_INDEX(m, n, iEl, 0, N, nElem)];
+    }
+  }
+
+  scalar[SC_2D_INDEX(i, j, iEl, p, N, nElem)] =
+      lSp[i] * lTp[j] / (qW[i] * qW[j] * J0);
+}
+
+extern "C" {
+void DiracDelta_2D_gpu(real *scalar, real *J,
+                       real *lS, real *lT, real *qW,
+                       int *elements,
+                       int N, int nPoints, int nElem, int nVar) {
+  // Zero the whole field first so points with elements==0 and all other-element
+  // entries (iEl' != elements[p]) are zero on exit.
+  size_t nBytes = (size_t)(N + 1) * (N + 1) * (size_t)nElem * (size_t)nVar * sizeof(real);
+#ifdef __HIP_PLATFORM_AMD__
+  CHECK(hipMemset(scalar, 0, nBytes));
+#else
+  CHECK(cudaMemset(scalar, 0, nBytes));
+#endif
+
+  int totalWork = (N + 1) * (N + 1) * nPoints;
+  if (totalWork <= 0) return;
+  int threadsPerBlock = 256;
+  int nBlocks = (totalWork + threadsPerBlock - 1) / threadsPerBlock;
+  DiracDelta_2D_kernel<<<dim3(nBlocks, 1, 1), dim3(threadsPerBlock, 1, 1), 0, 0>>>(
+      scalar, J, lS, lT, qW, elements, N, nPoints, nElem);
+}
+}
+
+// DiracDelta_3D_kernel: see DiracDelta_2D_kernel.
+
+__global__ void DiracDelta_3D_kernel(real *scalar, real *J,
+                                     real *lS, real *lT, real *lU, real *qW,
+                                     int *elements,
+                                     int N, int nPoints, int nElem) {
+  int idx = threadIdx.x + blockIdx.x * blockDim.x;
+  int Np1 = N + 1;
+  int totalWork = Np1 * Np1 * Np1 * nPoints;
+  if (idx >= totalWork) return;
+
+  int i = idx % Np1;
+  int j = (idx / Np1) % Np1;
+  int k = (idx / (Np1 * Np1)) % Np1;
+  int p = idx / (Np1 * Np1 * Np1);
+
+  int iEl = elements[p];
+  if (iEl <= 0) return;
+  iEl -= 1;
+
+  real *lSp = &lS[p * Np1];
+  real *lTp = &lT[p * Np1];
+  real *lUp = &lU[p * Np1];
+
+  real J0 = (real)0;
+  for (int l = 0; l < Np1; l++) {
+    real ll = lUp[l];
+    for (int n = 0; n < Np1; n++) {
+      real ln = lTp[n];
+      for (int m = 0; m < Np1; m++) {
+        J0 += lSp[m] * ln * ll * J[SC_3D_INDEX(m, n, l, iEl, 0, N, nElem)];
+      }
+    }
+  }
+
+  scalar[SC_3D_INDEX(i, j, k, iEl, p, N, nElem)] =
+      lSp[i] * lTp[j] * lUp[k] / (qW[i] * qW[j] * qW[k] * J0);
+}
+
+extern "C" {
+void DiracDelta_3D_gpu(real *scalar, real *J,
+                       real *lS, real *lT, real *lU, real *qW,
+                       int *elements,
+                       int N, int nPoints, int nElem, int nVar) {
+  size_t Np1 = (size_t)(N + 1);
+  size_t nBytes = Np1 * Np1 * Np1 * (size_t)nElem * (size_t)nVar * sizeof(real);
+#ifdef __HIP_PLATFORM_AMD__
+  CHECK(hipMemset(scalar, 0, nBytes));
+#else
+  CHECK(cudaMemset(scalar, 0, nBytes));
+#endif
+
+  int totalWork = (N + 1) * (N + 1) * (N + 1) * nPoints;
+  if (totalWork <= 0) return;
+  int threadsPerBlock = 256;
+  int nBlocks = (totalWork + threadsPerBlock - 1) / threadsPerBlock;
+  DiracDelta_3D_kernel<<<dim3(nBlocks, 1, 1), dim3(threadsPerBlock, 1, 1), 0, 0>>>(
+      scalar, J, lS, lT, lU, qW, elements, N, nPoints, nElem);
+}
+}

--- a/src/gpu/SELF_Points.f90
+++ b/src/gpu/SELF_Points.f90
@@ -75,6 +75,12 @@ module SELF_Points
     procedure,private :: EvalScalar_3D_dev_Points
     generic,public :: EvaluateScalar => EvalScalar_2D_dev_Points,EvalScalar_3D_dev_Points
 
+    ! Override the host scatter so device-resident scalars are written by a
+    ! device kernel. The override falls back to the inherited host path for
+    ! non-GPU scalar subtypes.
+    procedure,public :: DiracDelta_2D_Points_t => DiracDelta_2D_Points
+    procedure,public :: DiracDelta_3D_Points_t => DiracDelta_3D_Points
+
   endtype Points
 
   interface
@@ -95,6 +101,26 @@ module SELF_Points
       type(c_ptr),value :: values,elements,lS,lT,lU,scalar
       integer(c_int),value :: N,nPoints,nElem,nVar
     endsubroutine EvalScalarPoints_3D_gpu
+  endinterface
+
+  interface
+    subroutine DiracDelta_2D_gpu(scalar,J,lS,lT,qW,elements,N,nPoints,nElem,nVar) &
+      bind(c,name="DiracDelta_2D_gpu")
+      use iso_c_binding
+      implicit none
+      type(c_ptr),value :: scalar,J,lS,lT,qW,elements
+      integer(c_int),value :: N,nPoints,nElem,nVar
+    endsubroutine DiracDelta_2D_gpu
+  endinterface
+
+  interface
+    subroutine DiracDelta_3D_gpu(scalar,J,lS,lT,lU,qW,elements,N,nPoints,nElem,nVar) &
+      bind(c,name="DiracDelta_3D_gpu")
+      use iso_c_binding
+      implicit none
+      type(c_ptr),value :: scalar,J,lS,lT,lU,qW,elements
+      integer(c_int),value :: N,nPoints,nElem,nVar
+    endsubroutine DiracDelta_3D_gpu
   endinterface
 
 contains
@@ -296,5 +322,99 @@ contains
                                  scalar%interp%N,this%nPoints,scalar%nElem,scalar%nVar)
 
   endsubroutine EvalScalar_3D_dev_Points
+
+  subroutine DiracDelta_2D_Points(this,geometry,scalar)
+    !! GPU override of DiracDelta_2D_Points_t. When the scalar is a
+    !! device-resident MappedScalar2D, the kernel writes scalar%interior_gpu
+    !! directly (host array left stale; caller may UpdateHost). For non-GPU
+    !! scalar subtypes, defers to the inherited host implementation.
+    !!
+    !! Requires the per-point basis cache to be in sync with scalar%interp%N
+    !! (LocatePoints + UpdateDevice).
+    implicit none
+    class(Points),intent(in) :: this
+    type(SEMQuad),intent(in) :: geometry
+    class(MappedScalar2D_t),intent(inout) :: scalar
+    ! Local
+    integer :: N
+
+    select type(scalar)
+    type is(MappedScalar2D)
+
+      if(this%nDim /= 2) then
+        print*,"SELF_Points (gpu)::DiracDelta (2D): nDim must be 2"
+        stop 1
+      endif
+      if(scalar%nVar /= this%nPoints) then
+        print*,"SELF_Points (gpu)::DiracDelta (2D): scalar%nVar (",scalar%nVar, &
+          ") must equal nPoints (",this%nPoints,")"
+        stop 1
+      endif
+      N = scalar%interp%N
+      if(this%nCached /= N .or. .not. c_associated(this%lS_cache_gpu) .or. &
+         .not. c_associated(this%lT_cache_gpu)) then
+        print*,"SELF_Points (gpu)::DiracDelta (2D): basis cache not synchronized; ", &
+          "call LocatePoints (or UpdateDevice) first. nCached=", &
+          this%nCached," scalar%N=",N
+        stop 1
+      endif
+
+      call DiracDelta_2D_gpu(scalar%interior_gpu, &
+                             geometry%J%interior_gpu, &
+                             this%lS_cache_gpu,this%lT_cache_gpu, &
+                             scalar%interp%qWeights_gpu, &
+                             this%elements_gpu, &
+                             N,this%nPoints,scalar%nElem,scalar%nVar)
+
+    class default
+      ! Host-only scalar subtype: fall back to the inherited base impl.
+      call this%Points_t%DiracDelta_2D_Points_t(geometry,scalar)
+    endselect
+
+  endsubroutine DiracDelta_2D_Points
+
+  subroutine DiracDelta_3D_Points(this,geometry,scalar)
+    !! GPU override of DiracDelta_3D_Points_t. See DiracDelta_2D_Points.
+    implicit none
+    class(Points),intent(in) :: this
+    type(SEMHex),intent(in) :: geometry
+    class(MappedScalar3D_t),intent(inout) :: scalar
+    ! Local
+    integer :: N
+
+    select type(scalar)
+    type is(MappedScalar3D)
+
+      if(this%nDim /= 3) then
+        print*,"SELF_Points (gpu)::DiracDelta (3D): nDim must be 3"
+        stop 1
+      endif
+      if(scalar%nVar /= this%nPoints) then
+        print*,"SELF_Points (gpu)::DiracDelta (3D): scalar%nVar (",scalar%nVar, &
+          ") must equal nPoints (",this%nPoints,")"
+        stop 1
+      endif
+      N = scalar%interp%N
+      if(this%nCached /= N .or. .not. c_associated(this%lS_cache_gpu) .or. &
+         .not. c_associated(this%lT_cache_gpu) .or. &
+         .not. c_associated(this%lU_cache_gpu)) then
+        print*,"SELF_Points (gpu)::DiracDelta (3D): basis cache not synchronized; ", &
+          "call LocatePoints (or UpdateDevice) first. nCached=", &
+          this%nCached," scalar%N=",N
+        stop 1
+      endif
+
+      call DiracDelta_3D_gpu(scalar%interior_gpu, &
+                             geometry%J%interior_gpu, &
+                             this%lS_cache_gpu,this%lT_cache_gpu,this%lU_cache_gpu, &
+                             scalar%interp%qWeights_gpu, &
+                             this%elements_gpu, &
+                             N,this%nPoints,scalar%nElem,scalar%nVar)
+
+    class default
+      call this%Points_t%DiracDelta_3D_Points_t(geometry,scalar)
+    endselect
+
+  endsubroutine DiracDelta_3D_Points
 
 endmodule SELF_Points

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -161,6 +161,8 @@ add_fortran_tests (
     "points_eval_cache_3d.f90"
     "points_eval_gpu_2d.f90"
     "points_eval_gpu_3d.f90"
+    "points_dirac_delta_2d.f90"
+    "points_dirac_delta_3d.f90"
     )
 
 add_mpi_fortran_tests( "mappedvectordgdivergence_2d_linear_mpi.f90"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -163,7 +163,21 @@ add_fortran_tests (
     "points_eval_gpu_3d.f90"
     "points_dirac_delta_2d.f90"
     "points_dirac_delta_3d.f90"
+    "points_dirac_delta_2d_ndim_mismatch.f90"
+    "points_dirac_delta_3d_ndim_mismatch.f90"
+    "points_dirac_delta_2d_nvar_mismatch.f90"
+    "points_dirac_delta_3d_nvar_mismatch.f90"
     )
+
+# Mark the four DiracDelta guard tests as expected-to-fail: each program
+# intentionally triggers a stop 1 inside the guard, and a non-zero exit
+# code is the success criterion.
+set_tests_properties(
+    points_dirac_delta_2d_ndim_mismatch
+    points_dirac_delta_3d_ndim_mismatch
+    points_dirac_delta_2d_nvar_mismatch
+    points_dirac_delta_3d_nvar_mismatch
+    PROPERTIES WILL_FAIL TRUE)
 
 add_mpi_fortran_tests( "mappedvectordgdivergence_2d_linear_mpi.f90"
                        "mappedvectordgdivergence_2d_linear_sideexchange_mpi.f90"

--- a/test/points_dirac_delta_2d.f90
+++ b/test/points_dirac_delta_2d.f90
@@ -196,6 +196,55 @@ contains
 
     print*,"DiracDelta 2D: conservation, isolation, and node-coincident checks passed"
 
+#ifndef ENABLE_GPU
+    ! --- (4) useCache=False fallback (host build only) ----------------------
+    ! Calling DiracDelta with a scalar whose interp%N differs from the cached
+    ! degree forces the on-the-fly Lagrange recompute path.
+    block
+      integer,parameter :: altDegree = controlDegree+2
+      type(Lagrange),target :: interp2
+      type(SEMQuad),target :: geometry2
+      type(MappedScalar2D) :: f2
+      real(prec) :: integral2
+
+      call interp2%Init(N=altDegree, &
+                        controlNodeType=GAUSS_LOBATTO, &
+                        M=targetDegree, &
+                        targetNodeType=UNIFORM)
+      call geometry2%Init(interp2,mesh%nElem)
+      call geometry2%GenerateFromMesh(mesh)
+      call f2%Init(interp2,nPoints,mesh%nelem)
+      call f2%AssociateGeometry(geometry2)
+
+      call pts%DiracDelta(geometry2,f2)
+
+      do p = 1,nPoints
+        iElP = pts%elements(p)
+        if(iElP <= 0) cycle
+        integral2 = 0.0_prec
+        do j = 1,interp2%N+1
+          do i = 1,interp2%N+1
+            integral2 = integral2+f2%interior(i,j,iElP,p) &
+                        *interp2%qWeights(i)*interp2%qWeights(j) &
+                        *geometry2%J%interior(i,j,iElP,1)
+          enddo
+        enddo
+        if(abs(integral2-1.0_prec) > conservationTol) then
+          print*,"(useCache=F) conservation failure p=",p, &
+            "  integral=",integral2,"  tol=",conservationTol
+          r = 1
+          return
+        endif
+      enddo
+      print*,"DiracDelta 2D: useCache=False conservation check passed"
+
+      call f2%DissociateGeometry()
+      call f2%Free()
+      call geometry2%Free()
+      call interp2%Free()
+    endblock
+#endif
+
     call pts%Free()
     call f%DissociateGeometry()
     call f%Free()

--- a/test/points_dirac_delta_2d.f90
+++ b/test/points_dirac_delta_2d.f90
@@ -1,0 +1,209 @@
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+!
+! Maintainers : support@fluidnumerics.com
+! Official Repository : https://github.com/FluidNumerics/self/
+!
+! Copyright © 2024 Fluid Numerics LLC
+!
+! Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+!
+! 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+!    the documentation and/or other materials provided with the distribution.
+!
+! 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+!    this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+! HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+! LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+! THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+! THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+!
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+
+program test
+
+  implicit none
+  integer :: exit_code
+
+  exit_code = points_dirac_delta_2d()
+  if(exit_code /= 0) then
+    stop exit_code
+  endif
+
+contains
+  integer function points_dirac_delta_2d() result(r)
+    !! Verifies the 2D DiracDelta scatter:
+    !!   (1) Conservation. For every located point p with elements(p) > 0,
+    !!       <f_p, 1>_h = sum_{i,j} f_ij^{iEl(p),p} * w_i*w_j*J_{ij}^{iEl(p)}
+    !!       must equal 1 (post-mass form encodes a unit-strength delta whose
+    !!       discrete L2 inner product with the unit function recovers S=1).
+    !!   (2) Other-element columns are zero. For iEl' /= elements(p), every
+    !!       entry of scalar%interior(:,:,iEl',p) must be exactly zero.
+    !!   (3) Node-coincident source. When a point lands exactly on the
+    !!       interior LGL node (i*,j*) of element iEl*, the only non-zero
+    !!       entry is scalar%interior(i*,j*,iEl*,p) = 1/(w_{i*}*w_{j*}*J_{i*,j*}).
+    !!
+    !! Uses the Block2D fixture (affine [0,1]^2 mesh) so J is constant inside
+    !! every element and conservation is exact up to floating-point round-off.
+
+    use SELF_Constants
+    use SELF_Lagrange
+    use SELF_Mesh_2D
+    use SELF_Geometry_2D
+    use SELF_MappedScalar_2D
+    use SELF_Points
+
+    implicit none
+
+    integer,parameter :: controlDegree = 6
+    integer,parameter :: targetDegree = 14
+    integer,parameter :: nPoints = 5
+#ifdef DOUBLE_PRECISION
+    real(prec),parameter :: conservationTol = 1.0e-11_prec
+    real(prec),parameter :: nodeTol = 1.0e-11_prec
+#else
+    real(prec),parameter :: conservationTol = 1.0e-4_prec
+    real(prec),parameter :: nodeTol = 1.0e-4_prec
+#endif
+    type(Lagrange),target :: interp
+    type(Mesh2D),target :: mesh
+    type(SEMQuad),target :: geometry
+    type(MappedScalar2D) :: f
+    type(Points) :: pts
+    character(LEN=255) :: WORKSPACE
+    real(prec) :: xIn(nPoints,2)
+    real(prec) :: integral,wi,wj,jLoc,maxOther,expected,nodeErr
+    real(prec) :: f_atNode
+    integer :: p,i,j,iEl,iElP,iStar,jStar,k
+
+    r = 0
+
+    call interp%Init(N=controlDegree, &
+                     controlNodeType=GAUSS_LOBATTO, &
+                     M=targetDegree, &
+                     targetNodeType=UNIFORM)
+
+    call get_environment_variable("WORKSPACE",WORKSPACE)
+    call mesh%Read_HOPr(trim(WORKSPACE)//"/share/mesh/Block2D/Block2D_mesh.h5")
+
+    call geometry%Init(interp,mesh%nElem)
+    call geometry%GenerateFromMesh(mesh)
+
+    ! One variable per point.
+    call f%Init(interp,nPoints,mesh%nelem)
+    call f%AssociateGeometry(geometry)
+
+    ! Points (1..nPoints-1): spread across the interior of [0,1]^2.
+    ! Point nPoints: anchored exactly on an interior LGL node of element 1, so
+    !                we can check the node-coincident expected value.
+    do p = 1,nPoints-1
+      xIn(p,1) = 0.07_prec+0.86_prec*real(modulo(7*p+1,nPoints),prec)/real(nPoints,prec)
+      xIn(p,2) = 0.07_prec+0.86_prec*real(modulo(11*p+3,nPoints),prec)/real(nPoints,prec)
+    enddo
+    iStar = controlDegree/2+1  ! a strictly interior node
+    jStar = controlDegree/2+1
+    xIn(nPoints,1) = geometry%x%interior(iStar,jStar,1,1,1)
+    xIn(nPoints,2) = geometry%x%interior(iStar,jStar,1,1,2)
+
+    call pts%Init(nPoints,2)
+    call pts%SetPoints(xIn)
+    call pts%LocatePoints(geometry)
+
+    call pts%DiracDelta(geometry,f)
+
+    ! --- (1) + (2) Conservation and other-element zeros ----------------------
+    do p = 1,nPoints
+      iElP = pts%elements(p)
+      if(iElP <= 0) then
+        ! Point not located on this rank: column p must be all zero.
+        if(maxval(abs(f%interior(:,:,:,p))) /= 0.0_prec) then
+          print*,"unlocated point p=",p,"has nonzero column; max=", &
+            maxval(abs(f%interior(:,:,:,p)))
+          r = 1
+          return
+        endif
+        cycle
+      endif
+
+      ! Other elements: must be exactly zero (DiracDelta zeroed the field
+      ! before scattering into iElP only).
+      maxOther = 0.0_prec
+      do iEl = 1,mesh%nelem
+        if(iEl == iElP) cycle
+        maxOther = max(maxOther,maxval(abs(f%interior(:,:,iEl,p))))
+      enddo
+      if(maxOther /= 0.0_prec) then
+        print*,"point p=",p,"leaked into non-owning element; max=",maxOther
+        r = 1
+        return
+      endif
+
+      ! Discrete inner product against 1: sum_{i,j} f * w_i*w_j*J_{ij}.
+      integral = 0.0_prec
+      do j = 1,interp%N+1
+        wj = interp%qWeights(j)
+        do i = 1,interp%N+1
+          wi = interp%qWeights(i)
+          jLoc = geometry%J%interior(i,j,iElP,1)
+          integral = integral+f%interior(i,j,iElP,p)*wi*wj*jLoc
+        enddo
+      enddo
+      if(abs(integral-1.0_prec) > conservationTol) then
+        print*,"conservation failure p=",p,"  integral=",integral, &
+          "  err=",abs(integral-1.0_prec),"  tol=",conservationTol
+        r = 1
+        return
+      endif
+    enddo
+
+    ! --- (3) Node-coincident: only one nonzero, equal to 1/(w_i w_j J) ------
+    p = nPoints
+    iElP = pts%elements(p)
+    if(iElP <= 0) then
+      print*,"node-coincident point not located"
+      r = 1
+      return
+    endif
+    f_atNode = f%interior(iStar,jStar,iElP,p)
+    expected = 1.0_prec/(interp%qWeights(iStar)*interp%qWeights(jStar)* &
+                         geometry%J%interior(iStar,jStar,iElP,1))
+    nodeErr = abs(f_atNode-expected)
+    if(nodeErr > nodeTol) then
+      print*,"node value mismatch: f=",f_atNode,"  expected=",expected, &
+        "  err=",nodeErr,"  tol=",nodeTol
+      r = 1
+      return
+    endif
+
+    ! All other (i,j) entries in element iElP must be ~0.
+    maxOther = 0.0_prec
+    do j = 1,interp%N+1
+      do i = 1,interp%N+1
+        if(i == iStar .and. j == jStar) cycle
+        maxOther = max(maxOther,abs(f%interior(i,j,iElP,p)))
+      enddo
+    enddo
+    if(maxOther > nodeTol) then
+      print*,"node-coincident off-node mass too large=",maxOther,"  tol=",nodeTol
+      r = 1
+      return
+    endif
+
+    print*,"DiracDelta 2D: conservation, isolation, and node-coincident checks passed"
+
+    call pts%Free()
+    call f%DissociateGeometry()
+    call f%Free()
+    call geometry%Free()
+    call mesh%Free()
+    call interp%Free()
+
+    ! Silence the unused-variable warning for k under some compilers.
+    k = 0
+
+  endfunction points_dirac_delta_2d
+endprogram test

--- a/test/points_dirac_delta_2d.f90
+++ b/test/points_dirac_delta_2d.f90
@@ -78,7 +78,7 @@ contains
     real(prec) :: xIn(nPoints,2)
     real(prec) :: integral,wi,wj,jLoc,maxOther,expected,nodeErr
     real(prec) :: f_atNode
-    integer :: p,i,j,iEl,iElP,iStar,jStar,k
+    integer :: p,i,j,iEl,iElP,iStar,jStar
 
     r = 0
 
@@ -104,7 +104,7 @@ contains
       xIn(p,1) = 0.07_prec+0.86_prec*real(modulo(7*p+1,nPoints),prec)/real(nPoints,prec)
       xIn(p,2) = 0.07_prec+0.86_prec*real(modulo(11*p+3,nPoints),prec)/real(nPoints,prec)
     enddo
-    iStar = controlDegree/2+1  ! a strictly interior node
+    iStar = controlDegree/2+1 ! a strictly interior node
     jStar = controlDegree/2+1
     xIn(nPoints,1) = geometry%x%interior(iStar,jStar,1,1,1)
     xIn(nPoints,2) = geometry%x%interior(iStar,jStar,1,1,2)
@@ -201,9 +201,6 @@ contains
     call geometry%Free()
     call mesh%Free()
     call interp%Free()
-
-    ! Silence the unused-variable warning for k under some compilers.
-    k = 0
 
   endfunction points_dirac_delta_2d
 endprogram test

--- a/test/points_dirac_delta_2d.f90
+++ b/test/points_dirac_delta_2d.f90
@@ -114,6 +114,7 @@ contains
     call pts%LocatePoints(geometry)
 
     call pts%DiracDelta(geometry,f)
+    call f%UpdateHost()
 
     ! --- (1) + (2) Conservation and other-element zeros ----------------------
     do p = 1,nPoints

--- a/test/points_dirac_delta_2d_ndim_mismatch.f90
+++ b/test/points_dirac_delta_2d_ndim_mismatch.f90
@@ -1,0 +1,75 @@
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+!
+! Maintainers : support@fluidnumerics.com
+! Official Repository : https://github.com/FluidNumerics/self/
+!
+! Copyright © 2024 Fluid Numerics LLC
+!
+! Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+!
+! 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+!    the documentation and/or other materials provided with the distribution.
+!
+! 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+!    this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+! HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+! LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+! THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+! THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+!
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+
+program test
+  !! Negative test: exercises the DiracDelta_2D nDim guard.
+  !!
+  !! A Points object initialized with nDim=3 is dispatched against a 2D
+  !! MappedScalar. The DiracDelta_2D specific must detect the mismatch and
+  !! abort with stop 1. CTest is configured with WILL_FAIL TRUE for this
+  !! test, so a non-zero exit code is the success criterion.
+
+  use SELF_Constants
+  use SELF_Lagrange
+  use SELF_Mesh_2D
+  use SELF_Geometry_2D
+  use SELF_MappedScalar_2D
+  use SELF_Points
+
+  implicit none
+
+  integer,parameter :: N = 4
+  integer,parameter :: nPoints = 2
+  type(Lagrange),target :: interp
+  type(Mesh2D),target :: mesh
+  type(SEMQuad),target :: geometry
+  type(MappedScalar2D) :: f
+  type(Points) :: pts
+  character(LEN=255) :: WORKSPACE
+
+  call interp%Init(N=N, &
+                   controlNodeType=GAUSS_LOBATTO, &
+                   M=N+2, &
+                   targetNodeType=UNIFORM)
+
+  call get_environment_variable("WORKSPACE",WORKSPACE)
+  call mesh%Read_HOPr(trim(WORKSPACE)//"/share/mesh/Block2D/Block2D_mesh.h5")
+  call geometry%Init(interp,mesh%nElem)
+  call geometry%GenerateFromMesh(mesh)
+
+  call f%Init(interp,nPoints,mesh%nelem)
+  call f%AssociateGeometry(geometry)
+
+  ! Intentional mismatch: 3D points, 2D scalar.
+  call pts%Init(nPoints,3)
+
+  call pts%DiracDelta(geometry,f)
+
+  ! Unreachable if the guard fires (the expected outcome).
+  print*,"FAIL: DiracDelta_2D did not trip the nDim guard"
+  stop 0
+
+endprogram test

--- a/test/points_dirac_delta_2d_nvar_mismatch.f90
+++ b/test/points_dirac_delta_2d_nvar_mismatch.f90
@@ -1,0 +1,69 @@
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+!
+! Maintainers : support@fluidnumerics.com
+! Official Repository : https://github.com/FluidNumerics/self/
+!
+! Copyright © 2024 Fluid Numerics LLC
+!
+! Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+!
+! 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+!    the documentation and/or other materials provided with the distribution.
+!
+! 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+!    this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+! HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+! LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+! THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+! THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+!
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+
+program test
+  !! Negative test: exercises the DiracDelta_2D scalar%nVar /= nPoints guard.
+
+  use SELF_Constants
+  use SELF_Lagrange
+  use SELF_Mesh_2D
+  use SELF_Geometry_2D
+  use SELF_MappedScalar_2D
+  use SELF_Points
+
+  implicit none
+
+  integer,parameter :: N = 4
+  integer,parameter :: nPoints = 3
+  integer,parameter :: nVar = nPoints+1 ! intentional mismatch
+  type(Lagrange),target :: interp
+  type(Mesh2D),target :: mesh
+  type(SEMQuad),target :: geometry
+  type(MappedScalar2D) :: f
+  type(Points) :: pts
+  character(LEN=255) :: WORKSPACE
+
+  call interp%Init(N=N, &
+                   controlNodeType=GAUSS_LOBATTO, &
+                   M=N+2, &
+                   targetNodeType=UNIFORM)
+
+  call get_environment_variable("WORKSPACE",WORKSPACE)
+  call mesh%Read_HOPr(trim(WORKSPACE)//"/share/mesh/Block2D/Block2D_mesh.h5")
+  call geometry%Init(interp,mesh%nElem)
+  call geometry%GenerateFromMesh(mesh)
+
+  call f%Init(interp,nVar,mesh%nelem)
+  call f%AssociateGeometry(geometry)
+
+  call pts%Init(nPoints,2)
+
+  call pts%DiracDelta(geometry,f)
+
+  print*,"FAIL: DiracDelta_2D did not trip the nVar guard"
+  stop 0
+
+endprogram test

--- a/test/points_dirac_delta_3d.f90
+++ b/test/points_dirac_delta_3d.f90
@@ -107,6 +107,7 @@ contains
     call pts%LocatePoints(geometry)
 
     call pts%DiracDelta(geometry,f)
+    call f%UpdateHost()
 
     do p = 1,nPoints
       iElP = pts%elements(p)

--- a/test/points_dirac_delta_3d.f90
+++ b/test/points_dirac_delta_3d.f90
@@ -188,6 +188,56 @@ contains
 
     print*,"DiracDelta 3D: conservation, isolation, and node-coincident checks passed"
 
+#ifndef ENABLE_GPU
+    ! --- useCache=False fallback (host build only) ---------------------------
+    block
+      integer,parameter :: altDegree = controlDegree+2
+      type(Lagrange),target :: interp2
+      type(SEMHex),target :: geometry2
+      type(MappedScalar3D) :: f2
+      real(prec) :: integral2
+
+      call interp2%Init(N=altDegree, &
+                        controlNodeType=GAUSS_LOBATTO, &
+                        M=targetDegree, &
+                        targetNodeType=UNIFORM)
+      call geometry2%Init(interp2,mesh%nElem)
+      call geometry2%GenerateFromMesh(mesh)
+      call f2%Init(interp2,nPoints,mesh%nelem)
+      call f2%AssociateGeometry(geometry2)
+
+      call pts%DiracDelta(geometry2,f2)
+
+      do p = 1,nPoints
+        iElP = pts%elements(p)
+        if(iElP <= 0) cycle
+        integral2 = 0.0_prec
+        do k = 1,interp2%N+1
+          do j = 1,interp2%N+1
+            do i = 1,interp2%N+1
+              integral2 = integral2+f2%interior(i,j,k,iElP,p) &
+                          *interp2%qWeights(i)*interp2%qWeights(j) &
+                          *interp2%qWeights(k) &
+                          *geometry2%J%interior(i,j,k,iElP,1)
+            enddo
+          enddo
+        enddo
+        if(abs(integral2-1.0_prec) > conservationTol) then
+          print*,"(useCache=F) conservation failure p=",p, &
+            "  integral=",integral2,"  tol=",conservationTol
+          r = 1
+          return
+        endif
+      enddo
+      print*,"DiracDelta 3D: useCache=False conservation check passed"
+
+      call f2%DissociateGeometry()
+      call f2%Free()
+      call geometry2%Free()
+      call interp2%Free()
+    endblock
+#endif
+
     call pts%Free()
     call f%DissociateGeometry()
     call f%Free()

--- a/test/points_dirac_delta_3d.f90
+++ b/test/points_dirac_delta_3d.f90
@@ -1,0 +1,198 @@
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+!
+! Maintainers : support@fluidnumerics.com
+! Official Repository : https://github.com/FluidNumerics/self/
+!
+! Copyright © 2024 Fluid Numerics LLC
+!
+! Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+!
+! 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+!    the documentation and/or other materials provided with the distribution.
+!
+! 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+!    this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+! HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+! LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+! THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+! THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+!
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+
+program test
+
+  implicit none
+  integer :: exit_code
+
+  exit_code = points_dirac_delta_3d()
+  if(exit_code /= 0) then
+    stop exit_code
+  endif
+
+contains
+  integer function points_dirac_delta_3d() result(r)
+    !! 3D analogue of points_dirac_delta_2d. Verifies:
+    !!   (1) Conservation: sum_{i,j,k} f * w_i*w_j*w_k*J_{ijk} = 1 for every
+    !!       located point's own column on its containing element.
+    !!   (2) Other elements zero.
+    !!   (3) Node-coincident source reproduces 1/(w_{i*}*w_{j*}*w_{k*}*J_node).
+
+    use SELF_Constants
+    use SELF_Lagrange
+    use SELF_Mesh_3D
+    use SELF_Geometry_3D
+    use SELF_MappedScalar_3D
+    use SELF_Points
+
+    implicit none
+
+    integer,parameter :: controlDegree = 4
+    integer,parameter :: targetDegree = 8
+    integer,parameter :: nPoints = 4
+#ifdef DOUBLE_PRECISION
+    real(prec),parameter :: conservationTol = 1.0e-11_prec
+    real(prec),parameter :: nodeTol = 1.0e-11_prec
+#else
+    real(prec),parameter :: conservationTol = 1.0e-4_prec
+    real(prec),parameter :: nodeTol = 1.0e-4_prec
+#endif
+    type(Lagrange),target :: interp
+    type(Mesh3D),target :: mesh
+    type(SEMHex),target :: geometry
+    type(MappedScalar3D) :: f
+    type(Points) :: pts
+    character(LEN=255) :: WORKSPACE
+    real(prec) :: xIn(nPoints,3)
+    real(prec) :: integral,wi,wj,wk,jLoc,maxOther,expected,nodeErr
+    real(prec) :: f_atNode
+    integer :: p,i,j,k,iEl,iElP,iStar,jStar,kStar
+
+    r = 0
+
+    call interp%Init(N=controlDegree, &
+                     controlNodeType=GAUSS_LOBATTO, &
+                     M=targetDegree, &
+                     targetNodeType=UNIFORM)
+
+    call get_environment_variable("WORKSPACE",WORKSPACE)
+    call mesh%Read_HOPr(trim(WORKSPACE)//"/share/mesh/Block3D/Block3D_mesh.h5")
+
+    call geometry%Init(interp,mesh%nElem)
+    call geometry%GenerateFromMesh(mesh)
+
+    call f%Init(interp,nPoints,mesh%nelem)
+    call f%AssociateGeometry(geometry)
+
+    ! Points 1..nPoints-1 spread across the interior; point nPoints anchored
+    ! exactly on an interior LGL node of element 1.
+    do p = 1,nPoints-1
+      xIn(p,1) = 0.10_prec+0.80_prec*real(modulo(3*p+1,nPoints),prec)/real(nPoints,prec)
+      xIn(p,2) = 0.10_prec+0.80_prec*real(modulo(5*p+2,nPoints),prec)/real(nPoints,prec)
+      xIn(p,3) = 0.10_prec+0.80_prec*real(modulo(7*p+3,nPoints),prec)/real(nPoints,prec)
+    enddo
+    iStar = controlDegree/2+1
+    jStar = controlDegree/2+1
+    kStar = controlDegree/2+1
+    xIn(nPoints,1) = geometry%x%interior(iStar,jStar,kStar,1,1,1)
+    xIn(nPoints,2) = geometry%x%interior(iStar,jStar,kStar,1,1,2)
+    xIn(nPoints,3) = geometry%x%interior(iStar,jStar,kStar,1,1,3)
+
+    call pts%Init(nPoints,3)
+    call pts%SetPoints(xIn)
+    call pts%LocatePoints(geometry)
+
+    call pts%DiracDelta(geometry,f)
+
+    do p = 1,nPoints
+      iElP = pts%elements(p)
+      if(iElP <= 0) then
+        if(maxval(abs(f%interior(:,:,:,:,p))) /= 0.0_prec) then
+          print*,"unlocated point p=",p,"has nonzero column; max=", &
+            maxval(abs(f%interior(:,:,:,:,p)))
+          r = 1
+          return
+        endif
+        cycle
+      endif
+
+      maxOther = 0.0_prec
+      do iEl = 1,mesh%nelem
+        if(iEl == iElP) cycle
+        maxOther = max(maxOther,maxval(abs(f%interior(:,:,:,iEl,p))))
+      enddo
+      if(maxOther /= 0.0_prec) then
+        print*,"point p=",p,"leaked into non-owning element; max=",maxOther
+        r = 1
+        return
+      endif
+
+      integral = 0.0_prec
+      do k = 1,interp%N+1
+        wk = interp%qWeights(k)
+        do j = 1,interp%N+1
+          wj = interp%qWeights(j)
+          do i = 1,interp%N+1
+            wi = interp%qWeights(i)
+            jLoc = geometry%J%interior(i,j,k,iElP,1)
+            integral = integral+f%interior(i,j,k,iElP,p)*wi*wj*wk*jLoc
+          enddo
+        enddo
+      enddo
+      if(abs(integral-1.0_prec) > conservationTol) then
+        print*,"conservation failure p=",p,"  integral=",integral, &
+          "  err=",abs(integral-1.0_prec),"  tol=",conservationTol
+        r = 1
+        return
+      endif
+    enddo
+
+    p = nPoints
+    iElP = pts%elements(p)
+    if(iElP <= 0) then
+      print*,"node-coincident point not located"
+      r = 1
+      return
+    endif
+    f_atNode = f%interior(iStar,jStar,kStar,iElP,p)
+    expected = 1.0_prec/(interp%qWeights(iStar)*interp%qWeights(jStar)* &
+                         interp%qWeights(kStar)* &
+                         geometry%J%interior(iStar,jStar,kStar,iElP,1))
+    nodeErr = abs(f_atNode-expected)
+    if(nodeErr > nodeTol) then
+      print*,"node value mismatch: f=",f_atNode,"  expected=",expected, &
+        "  err=",nodeErr,"  tol=",nodeTol
+      r = 1
+      return
+    endif
+
+    maxOther = 0.0_prec
+    do k = 1,interp%N+1
+      do j = 1,interp%N+1
+        do i = 1,interp%N+1
+          if(i == iStar .and. j == jStar .and. k == kStar) cycle
+          maxOther = max(maxOther,abs(f%interior(i,j,k,iElP,p)))
+        enddo
+      enddo
+    enddo
+    if(maxOther > nodeTol) then
+      print*,"node-coincident off-node mass too large=",maxOther,"  tol=",nodeTol
+      r = 1
+      return
+    endif
+
+    print*,"DiracDelta 3D: conservation, isolation, and node-coincident checks passed"
+
+    call pts%Free()
+    call f%DissociateGeometry()
+    call f%Free()
+    call geometry%Free()
+    call mesh%Free()
+    call interp%Free()
+
+  endfunction points_dirac_delta_3d
+endprogram test

--- a/test/points_dirac_delta_3d_ndim_mismatch.f90
+++ b/test/points_dirac_delta_3d_ndim_mismatch.f90
@@ -1,0 +1,72 @@
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+!
+! Maintainers : support@fluidnumerics.com
+! Official Repository : https://github.com/FluidNumerics/self/
+!
+! Copyright © 2024 Fluid Numerics LLC
+!
+! Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+!
+! 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+!    the documentation and/or other materials provided with the distribution.
+!
+! 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+!    this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+! HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+! LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+! THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+! THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+!
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+
+program test
+  !! Negative test: exercises the DiracDelta_3D nDim guard.
+  !!
+  !! A Points object initialized with nDim=2 is dispatched against a 3D
+  !! MappedScalar. The guard inside DiracDelta_3D must trip and stop 1.
+
+  use SELF_Constants
+  use SELF_Lagrange
+  use SELF_Mesh_3D
+  use SELF_Geometry_3D
+  use SELF_MappedScalar_3D
+  use SELF_Points
+
+  implicit none
+
+  integer,parameter :: N = 4
+  integer,parameter :: nPoints = 2
+  type(Lagrange),target :: interp
+  type(Mesh3D),target :: mesh
+  type(SEMHex),target :: geometry
+  type(MappedScalar3D) :: f
+  type(Points) :: pts
+  character(LEN=255) :: WORKSPACE
+
+  call interp%Init(N=N, &
+                   controlNodeType=GAUSS_LOBATTO, &
+                   M=N+2, &
+                   targetNodeType=UNIFORM)
+
+  call get_environment_variable("WORKSPACE",WORKSPACE)
+  call mesh%Read_HOPr(trim(WORKSPACE)//"/share/mesh/Block3D/Block3D_mesh.h5")
+  call geometry%Init(interp,mesh%nElem)
+  call geometry%GenerateFromMesh(mesh)
+
+  call f%Init(interp,nPoints,mesh%nelem)
+  call f%AssociateGeometry(geometry)
+
+  ! Intentional mismatch: 2D points, 3D scalar.
+  call pts%Init(nPoints,2)
+
+  call pts%DiracDelta(geometry,f)
+
+  print*,"FAIL: DiracDelta_3D did not trip the nDim guard"
+  stop 0
+
+endprogram test

--- a/test/points_dirac_delta_3d_nvar_mismatch.f90
+++ b/test/points_dirac_delta_3d_nvar_mismatch.f90
@@ -1,0 +1,69 @@
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+!
+! Maintainers : support@fluidnumerics.com
+! Official Repository : https://github.com/FluidNumerics/self/
+!
+! Copyright © 2024 Fluid Numerics LLC
+!
+! Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+!
+! 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+!    the documentation and/or other materials provided with the distribution.
+!
+! 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+!    this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+! HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+! LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+! THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+! THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+!
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+
+program test
+  !! Negative test: exercises the DiracDelta_3D scalar%nVar /= nPoints guard.
+
+  use SELF_Constants
+  use SELF_Lagrange
+  use SELF_Mesh_3D
+  use SELF_Geometry_3D
+  use SELF_MappedScalar_3D
+  use SELF_Points
+
+  implicit none
+
+  integer,parameter :: N = 4
+  integer,parameter :: nPoints = 3
+  integer,parameter :: nVar = nPoints+1 ! intentional mismatch
+  type(Lagrange),target :: interp
+  type(Mesh3D),target :: mesh
+  type(SEMHex),target :: geometry
+  type(MappedScalar3D) :: f
+  type(Points) :: pts
+  character(LEN=255) :: WORKSPACE
+
+  call interp%Init(N=N, &
+                   controlNodeType=GAUSS_LOBATTO, &
+                   M=N+2, &
+                   targetNodeType=UNIFORM)
+
+  call get_environment_variable("WORKSPACE",WORKSPACE)
+  call mesh%Read_HOPr(trim(WORKSPACE)//"/share/mesh/Block3D/Block3D_mesh.h5")
+  call geometry%Init(interp,mesh%nElem)
+  call geometry%GenerateFromMesh(mesh)
+
+  call f%Init(interp,nVar,mesh%nelem)
+  call f%AssociateGeometry(geometry)
+
+  call pts%Init(nPoints,3)
+
+  call pts%DiracDelta(geometry,f)
+
+  print*,"FAIL: DiracDelta_3D did not trip the nVar guard"
+  stop 0
+
+endprogram test


### PR DESCRIPTION
## Summary

- Add `pts%DiracDelta(geometry, scalar)` to the `Points` class. Each stored point owns one variable of the target `MappedScalar2D/3D` and receives the discrete post-mass-matrix delta `f_{ij[k]} = l_i(ξ₀)·l_j(η₀)[·l_k(ζ₀)] / (w_i·w_j[·w_k]·J₀)` for `iEl = elements(p)`, zero elsewhere. `J₀` is the polynomial interpolation of nodal `J` at the source location, which makes `Σ f·w·w·J = 1` hold algebraically on every element (affine or curved).
- The form is post-mass-matrix: it can be added directly to `dSdt` / the source term in a DGSEM model because `MappedDGDivergence` already divides by `w·w·J`.
- HIP kernel + Fortran wrapper mirror the host path for GPU-resident scalars; `select type` keeps the override compatible with non-GPU subtypes (falls back to the inherited host impl). The kernel reuses the per-point Lagrange basis cache populated by `LocatePoints` and writes `scalar%interior_gpu` directly; a pre-launch `hipMemset` clears the field so unlocated points and non-owning elements remain zero.
- `*.sqsh` added to `.dockerignore` (mirrors the existing `*.sif` exclusion) so large local archive files don't bloat the Docker build context.

## Design notes

- **Strength**: unit strength (S = 1). Caller scales after the call if needed.
- **API contract**: `scalar%nVar == pts%nPoints`. Each point owns its own column so contributions never overlap. Points with `elements(p) == 0` (not located on this rank) leave their column zero.
- **Face-shared points**: receive their entire contribution in the single element `LocatePoints` chose — no S/2 face split.
- **Cache reuse**: when `pts%nCached == scalar%interp%N`, the cached basis values from `LocatePoints` are reused. Otherwise the host path recomputes; the GPU path errors out because device basis cache is mandatory there (matches the existing `EvaluateScalar` GPU contract).

## Test plan

- [x] `test/points_dirac_delta_2d.f90` — conservation, other-element isolation, and node-coincident value
- [x] `test/points_dirac_delta_3d.f90` — 3D analogue
- [ ] CI run (existing CPU + GPU jobs should pick up the new tests via the `test/CMakeLists.txt` registration)
- [ ] Local CPU container build — **not run by me**: the host `/home` partition is at 100%, so I couldn't complete a docker/podman build. Asking CI to verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)