### PR TITLE
Add Perfectly Matched Layer (PML) for LinearEuler2D

### DIFF
--- a/docs/Models/linear-euler-2d-pml-model.md
+++ b/docs/Models/linear-euler-2d-pml-model.md
@@ -1,0 +1,115 @@
+# Linear Euler (2D) with Perfectly Matched Layer
+
+## Definition
+
+The [`SELF_LinearEuler2D_PML_t` module](../ford/module/self_lineareuler2d_pml_t.html) defines the [`LinearEuler2D_PML_t` class](../ford/type/lineareuler2d_pml_t.html), a type extension of [`LinearEuler2D_t`](./linear-euler-2d-model.md) that adds a Perfectly Matched Layer (PML) absorbing region for open-domain acoustic simulations.
+
+The interior dynamics are identical to the parent linear Euler 2D model. Inside the PML region the governing equations are augmented with damping coefficients $\sigma_x(x)$, $\sigma_y(y)$ and four auxiliary variables $\phi_\rho, \phi_u, \phi_v, \phi_P$ that together drive outgoing waves to zero with minimal reflection at the interior/PML interface.
+
+### Formulation
+
+We follow the unsplit auxiliary-differential-equation (ADE) form of the PML for the linearised Euler equations, after Hu (2001, *JCP* 173:455–480). The modified system is
+
+$$
+    \frac{\partial \vec{q}}{\partial t}
+    + A\,\frac{\partial \vec{q}}{\partial x}
+    + B\,\frac{\partial \vec{q}}{\partial y}
+    + (\sigma_x + \sigma_y)\,\vec{q}
+    + \sigma_x\,\sigma_y\,\vec{\phi}
+    = 0,
+    \qquad
+    \frac{\partial \vec{\phi}}{\partial t} = \vec{q}
+$$
+
+where $\vec{q} = (\rho, u, v, p)$ is the acoustic state, $\vec{\phi} = (\phi_\rho, \phi_u, \phi_v, \phi_P)$ is the auxiliary "memory" vector that integrates $\vec{q}$ in time, and $A$, $B$ are the linear-Euler flux Jacobians (see the [Linear Euler 2D reference](./linear-euler-2d-model.md)).
+
+In the interior we set $\sigma_x = \sigma_y = 0$ and the system reduces exactly to the standard linear Euler 2D model. The auxiliary $\vec{\phi}$ still integrates $\vec{q}$, but with the coupling coefficient $\sigma_x \sigma_y = 0$ it never feeds back into the dynamics and starts at $\vec{\phi}(t=0) = \vec{0}$.
+
+### Solution vector
+
+To accommodate the auxiliary $\vec{\phi}$, the PML model carries `nvar = 9`:
+
+| index | name      | meaning                                      |
+|-------|-----------|----------------------------------------------|
+| 1     | `rho`     | density perturbation (acoustic)              |
+| 2     | `u`       | $x$-velocity                                 |
+| 3     | `v`       | $y$-velocity                                 |
+| 4     | `P`       | pressure perturbation                        |
+| 5     | `c`       | sound speed (per-node, static)               |
+| 6     | `phi_rho` | $\int_0^t \rho\,dt$ (PML auxiliary)          |
+| 7     | `phi_u`   | $\int_0^t u\,dt$ (PML auxiliary)             |
+| 8     | `phi_v`   | $\int_0^t v\,dt$ (PML auxiliary)             |
+| 9     | `phi_P`   | $\int_0^t p\,dt$ (PML auxiliary)             |
+
+The auxiliary variables carry **identically zero flux** in both spatial directions. They are evolved exclusively by the source term above. Sound speed $c$ remains static (zero flux, zero source), as in the parent model.
+
+### Damping fields $\sigma_x$, $\sigma_y$
+
+`LinearEuler2D_PML_t` stores the per-node damping coefficients in two `MappedScalar2D` fields, `sigma_x` and `sigma_y` (one variable each). They are populated once by `SetPMLProfile` from a user-supplied interior bounding box, PML thickness, peak value, and polynomial ramp exponent, and are pushed to the GPU automatically when the GPU build is in use.
+
+The default ramp is a cubic polynomial that rises from zero at the interior/PML interface up to the requested $\sigma_\mathrm{max}$ at the outer edge of the layer:
+
+$$
+    \sigma_x(x) = \sigma_\mathrm{max}\,\left(\frac{d_x}{L}\right)^p,
+    \qquad
+    d_x = \max\bigl(0,\ x_\mathrm{min} - x,\ x - x_\mathrm{max}\bigr)
+$$
+
+and analogously for $\sigma_y$, where $L$ is `pml_width`, $p$ is `ramp_exponent` (default 3), and $[x_\mathrm{min}, x_\mathrm{max}] \times [y_\mathrm{min}, y_\mathrm{max}]$ is the interior box you want to leave undamped. Nodes outside elements tagged as PML always receive $\sigma = 0$, regardless of position.
+
+### Identifying PML elements
+
+PML elements are picked out of the mesh by material name. `SetPMLProfile` walks `mesh%elemMaterial` and `mesh%materialNames` and applies the damping ramp only to elements whose material name **starts with the configured prefix** (default `"pml"`). All other elements remain at $\sigma_x = \sigma_y = 0$.
+
+You can supply that tagging in two equivalent ways:
+
+* **Programmatic** — write directly to `mesh%elemMaterial` after calling `mesh%StructuredMesh`. This is the path used by the bundled example and test.
+* **HOHQMesh ISM-MM** — generate a `.mesh` file in which the outer regions are emitted with material name `pml` (or `pml_east`, `pml_corner_NE`, etc.). `mesh%Read_HOHQMesh` populates `elemMaterial`/`materialNames` from the file automatically.
+
+Both paths are covered step-by-step in the [PML tutorial](../Tutorials/LinearEuler2D/PerfectlyMatchedLayer.md).
+
+## Implementation
+
+`LinearEuler2D_PML_t` is implemented in [`src/SELF_LinearEuler2D_PML_t.f90`](https://github.com/FluidNumerics/SELF/blob/main/src/SELF_LinearEuler2D_PML_t.f90) as a type extension of [`LinearEuler2D_t`](./linear-euler-2d-model.md). It overrides
+
+* `SetNumberOfVariables` — declares `nvar = 9`.
+* `SetMetadata` — registers names and units for the four PML auxiliaries (plus `sigma_x`, `sigma_y`).
+* `AdditionalInit` — allocates `sigma_x` and `sigma_y` and registers PML-aware no-normal-flow and radiation boundary handlers.
+* `AdditionalFree` — releases the damping fields.
+* `flux2d`, `riemannflux2d` — reuse the parent linear-Euler flux for variables 1–5 and return zero for variables 6–9 (auxiliaries carry no flux).
+* `sourcemethod` — implements the ADE source term node-by-node. We override `sourcemethod` rather than `source2d` because the pure `source2d(s, dsdx)` signature has no access to the per-node $\sigma_x(i,j,iel)$, $\sigma_y(i,j,iel)$ lookups.
+
+A new procedure `SetPMLProfile(x_interior_min, x_interior_max, y_interior_min, y_interior_max, pml_width, sigma_max, ramp_exponent)` populates `sigma_x` and `sigma_y` from the per-element material tags and the geometric ramp.
+
+### Boundary conditions
+
+`LinearEuler2D_PML_t` re-registers both the **no-normal-flow** and **radiation** boundary handlers so that the auxiliary variables 6–9 are also handled at the boundary. Variables 1–5 are treated exactly as in the parent model:
+
+* `SELF_BC_NONORMALFLOW` — reflect $\vec{v}$ about the boundary normal; copy $\rho$, $p$, $c$; zero $\vec{\phi}$ in `extBoundary`.
+* `SELF_BC_RADIATION` — set $\rho = u = v = p = 0$ in the exterior state; copy $c$ from the interior side so the Riemann solver sees a consistent sound speed; zero $\vec{\phi}$.
+
+Because the auxiliary variables carry zero Riemann flux, their `extBoundary` value is mathematically irrelevant — we zero it purely for diagnostic cleanliness.
+
+`SELF_BC_PRESCRIBED` is *not* automatically registered. If you need it (e.g. driving a planewave in from one side while absorbing on the other), follow the same pattern as the prescribed-BC examples for the parent model and remember to fill `extBoundary(:,:,:,6:9)` (zero is the natural choice).
+
+## GPU acceleration
+
+When SELF is built with GPU support, the GPU-backed `LinearEuler2D_PML` type (in [`src/gpu/SELF_LinearEuler2D_PML.f90`](https://github.com/FluidNumerics/SELF/blob/main/src/gpu/SELF_LinearEuler2D_PML.f90) and [`src/gpu/SELF_LinearEuler2D_PML.cpp`](https://github.com/FluidNumerics/SELF/blob/main/src/gpu/SELF_LinearEuler2D_PML.cpp)) overrides
+
+* `BoundaryFlux` — launches a 9-variable PML-aware Riemann kernel.
+* `FluxMethod` — launches a 9-variable PML-aware interior-flux kernel.
+* `SourceMethod` — launches the PML source kernel that reads `sigma_x_gpu`, `sigma_y_gpu`, and `solution_gpu`.
+
+The GPU no-normal-flow and radiation BC handlers are re-registered to point to device-resident kernels (`hbc2d_*_lineareuler2d_pml_gpu`). `sigma_x` and `sigma_y` live on the device after `SetPMLProfile` calls `UpdateDevice`, so no host/device traffic is needed during time stepping unless prescribed BCs are enabled.
+
+## Example usage
+
+A complete worked example with on-the-fly programmatic PML tagging is provided at
+
+* [`examples/linear_euler2d_pml_planewave.f90`](https://github.com/FluidNumerics/SELF/blob/main/examples/linear_euler2d_pml_planewave.f90)
+
+and an absorption regression test (planar pulse, east-side PML, asserts >95% absorption) at
+
+* [`test/lineareuler2d_pml_absorption.f90`](https://github.com/FluidNumerics/SELF/blob/main/test/lineareuler2d_pml_absorption.f90).
+
+See the [PML tutorial](../Tutorials/LinearEuler2D/PerfectlyMatchedLayer.md) for an end-to-end walkthrough including both the programmatic and HOHQMesh ISM-MM workflows for tagging PML elements.

--- a/docs/Tutorials/LinearEuler2D/PerfectlyMatchedLayer.md
+++ b/docs/Tutorials/LinearEuler2D/PerfectlyMatchedLayer.md
@@ -1,0 +1,240 @@
+# Linear Euler 2D — Perfectly Matched Layer Tutorial
+
+This tutorial shows how to use the [`LinearEuler2D_PML`](../../Models/linear-euler-2d-pml-model.md) model to absorb outgoing acoustic waves with a Perfectly Matched Layer. It covers the two supported ways of declaring where the PML lives in your mesh:
+
+1. **Programmatic tagging** on a `StructuredMesh` (no external mesh tool needed).
+2. **Material tagging in a HOHQMesh ISM-MM `.mesh` file**, for unstructured geometries.
+
+The numerics and PML formulation are summarised in the [PML model reference](../../Models/linear-euler-2d-pml-model.md); this page focuses on the workflow.
+
+## What `LinearEuler2D_PML` adds
+
+`LinearEuler2D_PML` is a type extension of `LinearEuler2D`. Compared to the parent model it
+
+* extends `nvar` from 5 to 9 (the original acoustic state plus four PML auxiliary variables `phi_rho`, `phi_u`, `phi_v`, `phi_P`);
+* carries two per-node fields `sigma_x` and `sigma_y` that hold the PML damping coefficients;
+* registers PML-aware no-normal-flow and radiation boundary handlers automatically.
+
+You declare the PML region by tagging mesh elements with a material name that starts with `"pml"` (the prefix is configurable via `pml_material_prefix`). Inside those elements, `SetPMLProfile` builds a polynomial ramp so $\sigma$ rises smoothly from zero at the interior/PML interface to its peak value at the outer boundary.
+
+## Common setup
+
+Both workflows share the same initialisation skeleton:
+
+```fortran
+use self_data
+use self_lineareuler2d_pml
+use self_mesh_2d
+
+type(LinearEuler2D_PML) :: modelobj
+type(Lagrange),target   :: interp
+type(Mesh2D),target     :: mesh
+type(SEMQuad),target    :: geometry
+
+! ... build the mesh (the two workflows differ here) ...
+! ... ensure mesh%materialNames contains an entry beginning with "pml"
+!     and mesh%elemMaterial(iel) points to it for every PML element ...
+
+call interp%Init(N=5, controlNodeType=GAUSS, &
+                 M=10, targetNodeType=UNIFORM)
+
+call geometry%Init(interp, mesh%nElem)
+call geometry%GenerateFromMesh(mesh)
+
+call modelobj%Init(mesh, geometry)
+modelobj%rho0 = 1.0_prec
+
+call modelobj%SetPMLProfile(x_interior_min = 0.0_prec, &
+                            x_interior_max = 4.0_prec, &
+                            y_interior_min = 0.0_prec, &
+                            y_interior_max = 2.0_prec, &
+                            pml_width      = 2.0_prec, &
+                            sigma_max      = 20.0_prec, &
+                            ramp_exponent  = 3)
+```
+
+`SetPMLProfile` only writes non-zero $\sigma_x, \sigma_y$ into elements whose material name starts with the configured prefix; every other element is left at $\sigma = 0$. The interior bounding box `[x_interior_min, x_interior_max] × [y_interior_min, y_interior_max]` defines where you want the wave equation untouched — the ramp grows with distance *outside* that box.
+
+After this point the PML is fully active. Initial-condition setup, time integration, and IO follow the same patterns as the [parent `LinearEuler2D`](../../Models/linear-euler-2d-model.md).
+
+!!! note
+    Always set the four PML auxiliary variables to zero in your initial condition:
+
+    ```fortran
+    this%solution%interior(i,j,iel,6:9) = 0.0_prec
+    ```
+
+    Their initial value is the integral $\int_0^t \vec{q}\,dt$, so starting them at zero corresponds to "the simulation has just begun".
+
+## Workflow 1: programmatic tagging on a structured mesh
+
+This is the easiest path: build a tile mesh with `StructuredMesh`, then walk the element list and decide which elements are PML based on their centroid.
+
+```fortran
+integer  :: bcids(1:4), iel
+real(prec) :: xc
+real(prec),parameter :: x_interior_max = 4.0_prec
+
+bcids = [SELF_BC_NONORMALFLOW, & ! south
+         SELF_BC_NONORMALFLOW, & ! east (sits behind the PML)
+         SELF_BC_NONORMALFLOW, & ! north
+         SELF_BC_NONORMALFLOW]   ! west
+
+! 12 elements in x by 4 in y, each 0.5 wide. Interior is x in [0,4],
+! the east-side PML occupies x in [4,6] (4 elements, 2 units thick).
+call mesh%StructuredMesh(12, 4, 1, 1, 0.5_prec, 0.5_prec, bcids)
+
+! Replace the default single-material table with our own.
+if (allocated(mesh%materialNames)) deallocate(mesh%materialNames)
+mesh%nMaterials = 2
+allocate(mesh%materialNames(1:2))
+mesh%materialNames(1) = "interior"
+mesh%materialNames(2) = "pml"
+
+! Tag any element whose centroid sits east of x_interior_max as PML.
+do iel = 1, mesh%nElem
+  xc = sum(mesh%nodeCoords(1,:,:,iel)) / &
+       real(size(mesh%nodeCoords,2) * size(mesh%nodeCoords,3), prec)
+  if (xc > x_interior_max) then
+    mesh%elemMaterial(iel) = 2  ! pml
+  else
+    mesh%elemMaterial(iel) = 1  ! interior
+  end if
+end do
+```
+
+Things to know:
+
+* `StructuredMesh` initialises `materialNames` to a single entry `"default"` and points every element at it. Reallocating the table and rewriting `elemMaterial` is safe — nothing else in `LinearEuler2D_PML` depends on the original table.
+* The centroid is computed as a corner-node average. For the default linear (`nGeo = 1`) structured mesh this is exact; if you ever increase `nGeo` you should still average across the geometry nodes shown above.
+* For PML on multiple sides, just generalise the centroid test (e.g. `if (xc < x_min .or. xc > x_max .or. yc < y_min .or. yc > y_max) elemMaterial = 2`). All PML elements share one material name; `SetPMLProfile` figures out the per-direction damping from the node positions.
+
+The complete file is at [`examples/linear_euler2d_pml_planewave.f90`](https://github.com/FluidNumerics/SELF/blob/main/examples/linear_euler2d_pml_planewave.f90).
+
+### Outer boundaries behind the PML
+
+You still need a boundary condition on the outer edge of the PML elements — the PML attenuates but does not eliminate the outgoing wave entirely, and whatever is left will hit whatever you put behind it. The two natural choices are
+
+* `SELF_BC_NONORMALFLOW` (default in the example above) — anything that survives the PML reflects back into the PML, where it is damped on the return trip. Cheap and robust.
+* `SELF_BC_RADIATION` — sets the exterior acoustic state to zero, so the residual signal is mostly transmitted out instead of reflected. Slightly better absorption for thinner PMLs.
+
+A well-designed PML (a few elements thick with $\sigma_\mathrm{max}$ tuned to give one or two decades of decay) makes the choice essentially invisible.
+
+## Workflow 2: HOHQMesh ISM-MM mesh
+
+When you need a curved or unstructured geometry, generate the mesh with HOHQMesh and emit it in the **ISM-MM** format. ISM-MM associates a material-name string with every element, exactly as needed by `SetPMLProfile`.
+
+### Authoring the control file
+
+HOHQMesh control files assign one material per geometry block. Mark the outer absorbing region with a name that starts with `pml` (the prefix `LinearEuler2D_PML` looks for); any other name is treated as interior.
+
+A minimal sketch of a HOHQMesh control file with an interior disk surrounded by a PML annulus:
+
+```
+\begin{MODEL}
+   \begin{OUTER_BOUNDARY}
+      \begin{PARAMETRIC_EQUATION_CURVE}
+         name     = pml_outer
+         xEqn     = f(t) = R_out*cos(2*pi*t)
+         yEqn     = f(t) = R_out*sin(2*pi*t)
+         zEqn     = f(t) = 0.0
+      \end{PARAMETRIC_EQUATION_CURVE}
+   \end{OUTER_BOUNDARY}
+   \begin{INNER_BOUNDARIES}
+      \begin{CHAIN}
+         name     = pml_interface       % shared edge between interior and PML
+         \begin{PARAMETRIC_EQUATION_CURVE}
+            name = pml_interface
+            xEqn = f(t) = R_in*cos(2*pi*t)
+            yEqn = f(t) = R_in*sin(2*pi*t)
+            zEqn = f(t) = 0.0
+         \end{PARAMETRIC_EQUATION_CURVE}
+      \end{CHAIN}
+   \end{INNER_BOUNDARIES}
+\end{MODEL}
+
+\begin{MATERIALS}
+   \begin{MATERIAL}
+      material name = interior          % anything not starting with "pml"
+      material id   = 1
+   \end{MATERIAL}
+   \begin{MATERIAL}
+      material name = pml               % MUST start with the configured prefix
+      material id   = 2
+   \end{MATERIAL}
+\end{MATERIALS}
+```
+
+When HOHQMesh writes the resulting `.mesh` file in ISM-MM mode, every element block ends with the material name of the region it falls in. The reader picks it up automatically:
+
+```
+ISM-MM
+  <nNodes> <nEdges> <nElem> <polyOrder>
+  ... node coordinates ...
+  <c1> <c2> <c3> <c4>   pml          % corner IDs + material name
+  <curveFlag1> ... <curveFlag4>
+  ... (curve sample points for any curved sides) ...
+  <bdyName1> <bdyName2> <bdyName3> <bdyName4>
+  ...
+```
+
+You can also mark the outer-edge boundary segments (those that survive after the PML attenuates the wave) with a single name like `outer` and remap them in your Fortran setup with `mesh%ResetBoundaryConditionType(SELF_BC_NONORMALFLOW)` or `SELF_BC_RADIATION`, exactly like the [BoneAndMarrow example](https://github.com/FluidNumerics/SELF/blob/main/examples/linear_euler2d_boneandmarrow.f90) does for its single `outer` boundary.
+
+### Loading and configuring
+
+The Fortran setup is even shorter than the structured-mesh version, because `mesh%Read_HOHQMesh` already populates `materialNames` and `elemMaterial`:
+
+```fortran
+character(LEN=255) :: WORKSPACE
+
+call get_environment_variable("WORKSPACE", WORKSPACE)
+call mesh%Read_HOHQMesh(trim(WORKSPACE)//"/share/mesh/MyDomain/MyDomain.mesh")
+
+! All physical boundaries are behind the PML. Map them to a single
+! BC (radiation here; no-normal-flow is equally valid).
+call mesh%ResetBoundaryConditionType(SELF_BC_RADIATION)
+
+call interp%Init(N=5, controlNodeType=GAUSS, M=10, targetNodeType=UNIFORM)
+call geometry%Init(interp, mesh%nElem)
+call geometry%GenerateFromMesh(mesh)
+
+call modelobj%Init(mesh, geometry)
+modelobj%rho0 = 1.0_prec
+
+call modelobj%SetPMLProfile(x_interior_min = -R_in, x_interior_max = R_in, &
+                            y_interior_min = -R_in, y_interior_max = R_in, &
+                            pml_width      = R_out - R_in, &
+                            sigma_max      = 20.0_prec)
+```
+
+Things to know:
+
+* `Read_HOHQMesh` auto-detects ISM vs ISM-MM from the file header. Plain ISM files have no material strings, so every element ends up tagged as `"default"` and no PML is applied — make sure your mesh writer is set to ISM-MM.
+* You can use multiple `pml*` materials in the same mesh (`pml_east`, `pml_corner_NE`, etc.). `LinearEuler2D_PML` only cares about the prefix; it does not distinguish between them. The per-direction strength is set by the geometric position of each node, not by the material name.
+* The interior bounding box you pass to `SetPMLProfile` is purely a geometric construct. For an annular PML around a disk it is convenient to use a circumscribed square, as in the snippet above: $d_x = d_y = 0$ in the interior, and they grow as nodes move outward.
+
+## Verifying that the PML works
+
+Two quick sanity checks before running production simulations:
+
+1. **Stability.** Run the simulation long enough for the pulse to fully enter the PML and check that `entropy` is finite and non-increasing. The bundled regression test at [`test/lineareuler2d_pml_absorption.f90`](https://github.com/FluidNumerics/SELF/blob/main/test/lineareuler2d_pml_absorption.f90) does exactly this and is a good template.
+
+2. **Absorption.** Pull the solution back to the host and measure `max(abs(p))` over the interior elements (those with `xc <= x_interior_max`, etc.). After the wave has had time to traverse the PML, the residual should be a small fraction of the initial peak.
+
+If absorption is weaker than expected:
+
+* Make the PML thicker — three to four elements is a sensible starting point at $N = 5$.
+* Increase `sigma_max`. RK3 is stable for `dt * sigma_max < ~2.5`, so you can usually push $\sigma_\mathrm{max}$ up to $\mathcal{O}(10)$ relative to the inverse PML traversal time.
+* Use a smoother ramp (`ramp_exponent = 3` is the default; bump to 4 if you see interface reflections).
+
+If the simulation goes unstable, check first that you did *not* leave `phi_*` set to anything other than zero in the initial condition, that `dt * sigma_max` is well below the RK stability limit, and that the PML thickness is at least a couple of elements.
+
+## Running the bundled example
+
+The bundled example uses the programmatic tagging workflow. After [installing SELF](../../GettingStarted/install.md):
+
+```shell
+${SELF_ROOT}/examples/linear_euler2d_pml_planewave
+```
+
+This launches a 2D Gaussian acoustic pulse near the western interior, propagates it eastward into a PML zone, and writes `solution.*.h5` snapshots every 0.5 time units. Open them in PySELF or ParaView to watch the pulse decay smoothly through the PML.

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -65,6 +65,7 @@ add_fortran_tests (
   "linear_euler2d_spherical_soundwave_closeddomain.f90"
   "linear_euler2d_planewave_reflection.f90"
   "linear_euler2d_planewave_propagation.f90"
+  "linear_euler2d_pml_planewave.f90"
   "linear_euler2d_boneandmarrow.f90"
   "linear_shallow_water2d_nonormalflow.f90"
   "linear_shallow_water2d_planetaryrossby_wave.f90"

--- a/examples/linear_euler2d_pml_planewave.f90
+++ b/examples/linear_euler2d_pml_planewave.f90
@@ -1,0 +1,187 @@
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+!
+! Maintainers : support@fluidnumerics.com
+! Official Repository : https://github.com/FluidNumerics/self/
+!
+! Copyright © 2026 Fluid Numerics LLC
+!
+! Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+!
+! 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+!    the documentation and/or other materials provided with the distribution.
+!
+! 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+!    this software without specific prior written permission.
+!
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+module lineareuler2d_pml_planewave_model
+!! Right-going Gaussian acoustic pulse on a 2D domain with a perfectly
+!! matched layer (Hu 2001, unsplit form) on the east side. The pulse
+!! propagates into the PML region and is absorbed without producing a
+!! visible reflection back into the interior.
+
+  use self_lineareuler2d_pml
+
+  implicit none
+
+  type,extends(LinearEuler2D_PML) :: lineareuler2d_pml_planewave
+    real(prec) :: c = 1.0_prec ! Reference sound speed
+    real(prec) :: amp = 1.0e-3_prec ! Peak pressure amplitude
+    real(prec) :: x0 = 1.0_prec ! Pulse centre (x)
+    real(prec) :: y0 = 1.0_prec ! Pulse centre (y)
+    real(prec) :: L = 0.25_prec ! Gaussian halfwidth
+  contains
+    procedure :: setInitialCondition
+  endtype lineareuler2d_pml_planewave
+
+contains
+
+  subroutine setInitialCondition(this)
+    !! Right-going acoustic wave packet:
+    !!   p(x,y,0) = amp * exp(-((x-x0)^2 + (y-y0)^2)/L^2)
+    !!   rho      = p/c^2
+    !!   u        = p/(rho0*c)
+    !!   v        = 0
+    !! consistent with a planewave travelling in +x at sound speed c.
+    implicit none
+    class(lineareuler2d_pml_planewave),intent(inout) :: this
+    ! Local
+    integer :: i,j,iel
+    real(prec) :: x,y,r2,p_loc,rho_loc,u_loc
+
+    do concurrent(i=1:this%solution%N+1,j=1:this%solution%N+1, &
+                  iel=1:this%mesh%nElem)
+      x = this%geometry%x%interior(i,j,iel,1,1)
+      y = this%geometry%x%interior(i,j,iel,1,2)
+      r2 = (x-this%x0)**2+(y-this%y0)**2
+      p_loc = this%amp*exp(-r2/(this%L*this%L))
+      rho_loc = p_loc/(this%c*this%c)
+      u_loc = p_loc/(this%rho0*this%c)
+
+      this%solution%interior(i,j,iel,1) = rho_loc
+      this%solution%interior(i,j,iel,2) = u_loc
+      this%solution%interior(i,j,iel,3) = 0.0_prec
+      this%solution%interior(i,j,iel,4) = p_loc
+      this%solution%interior(i,j,iel,5) = this%c
+      ! PML auxiliaries start at zero
+      this%solution%interior(i,j,iel,6:9) = 0.0_prec
+    enddo
+
+    call this%solution%UpdateDevice()
+
+  endsubroutine setInitialCondition
+
+  subroutine tagPMLElements(mesh,x_interior_max)
+    !! Tag mesh elements whose centroid lies east of x_interior_max
+    !! with material name "pml". All other elements remain "interior".
+    !! Centroid is the corner-node average (linear elements: nGeo=1).
+    use SELF_Mesh_2D
+    implicit none
+    class(Mesh2D),intent(inout) :: mesh
+    real(prec),intent(in) :: x_interior_max
+    ! Local
+    integer :: iel
+    real(prec) :: xc
+
+    if(allocated(mesh%materialNames)) deallocate(mesh%materialNames)
+    mesh%nMaterials = 2
+    allocate(mesh%materialNames(1:2))
+    mesh%materialNames(1) = "interior"
+    mesh%materialNames(2) = "pml"
+
+    do iel = 1,mesh%nElem
+      xc = sum(mesh%nodeCoords(1,:,:,iel))/real(size(mesh%nodeCoords,2)*size(mesh%nodeCoords,3),prec)
+      if(xc > x_interior_max) then
+        mesh%elemMaterial(iel) = 2 ! pml
+      else
+        mesh%elemMaterial(iel) = 1 ! interior
+      endif
+    enddo
+
+  endsubroutine tagPMLElements
+
+endmodule lineareuler2d_pml_planewave_model
+
+program LinearEuler_PML_Example
+
+  use self_data
+  use lineareuler2d_pml_planewave_model
+
+  implicit none
+
+  character(SELF_INTEGRATOR_LENGTH),parameter :: integrator = 'rk3'
+  integer,parameter :: controlDegree = 5
+  integer,parameter :: targetDegree = 10
+  real(prec),parameter :: dt = 5.0e-3_prec
+  real(prec),parameter :: endtime = 4.0_prec
+  real(prec),parameter :: iointerval = 0.5_prec
+
+  ! Interior + PML layout (one element = 0.5 wide, total 12 elements in x)
+  !  Interior: x in [0, 4]   (8 elements)
+  !  PML east: x in [4, 6]   (4 elements, width 2)
+  real(prec),parameter :: x_interior_max = 4.0_prec
+  real(prec),parameter :: pml_width = 2.0_prec
+  real(prec),parameter :: sigma_max = 6.0_prec
+
+  type(lineareuler2d_pml_planewave) :: modelobj
+  type(Lagrange),target :: interp
+  type(Mesh2D),target :: mesh
+  type(SEMQuad),target :: geometry
+  integer :: bcids(1:4)
+  real(prec) :: e0,ef
+
+  ! Structured mesh: 12 elements in x, 4 in y, all 0.5 wide.
+  bcids(1:4) = [SELF_BC_NONORMALFLOW, & ! south
+                SELF_BC_NONORMALFLOW, & ! east  (behind the PML)
+                SELF_BC_NONORMALFLOW, & ! north
+                SELF_BC_NONORMALFLOW] ! west
+  call mesh%StructuredMesh(12,4,1,1,0.5_prec,0.5_prec,bcids)
+
+  ! Tag the eastern strip as the "pml" material.
+  call tagPMLElements(mesh,x_interior_max)
+
+  call interp%Init(N=controlDegree, &
+                   controlNodeType=GAUSS, &
+                   M=targetDegree, &
+                   targetNodeType=UNIFORM)
+
+  call geometry%Init(interp,mesh%nElem)
+  call geometry%GenerateFromMesh(mesh)
+
+  call modelobj%Init(mesh,geometry)
+  modelobj%prescribed_bcs_enabled = .false.
+  modelobj%rho0 = 1.0_prec
+
+  ! Configure the PML profile: damping ramps from 0 at x=x_interior_max
+  ! up to sigma_max at x=x_interior_max + pml_width with a cubic ramp.
+  call modelobj%SetPMLProfile(x_interior_min=0.0_prec, &
+                              x_interior_max=x_interior_max, &
+                              y_interior_min=0.0_prec, &
+                              y_interior_max=2.0_prec, &
+                              pml_width=pml_width, &
+                              sigma_max=sigma_max, &
+                              ramp_exponent=3)
+
+  call modelobj%setInitialCondition()
+
+  call modelobj%CalculateEntropy()
+  call modelobj%ReportEntropy()
+  e0 = modelobj%entropy
+
+  call modelobj%SetTimeIntegrator(integrator)
+  call modelobj%ForwardStep(endtime,dt,iointerval)
+  ef = modelobj%entropy
+
+  if(ef /= ef) then
+    print*,"Error: Final entropy is inf or nan",ef
+    stop 1
+  endif
+
+  call modelobj%free()
+  call mesh%free()
+  call geometry%free()
+  call interp%free()
+
+endprogram LinearEuler_PML_Example

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,6 +25,7 @@ nav:
       - Plane wave propagation: Tutorials/LinearEuler2D/PlaneWavePropagation.md
       - Plane wave reflection: Tutorials/LinearEuler2D/PlaneWaveReflection.md
       - Spherical sound wave: Tutorials/LinearEuler2D/SphericalSoundWave.md
+      - Perfectly Matched Layer: Tutorials/LinearEuler2D/PerfectlyMatchedLayer.md
   #    - Create your own model: Tutorials/CreateYourOwnModel.md
     - Linear Euler (3D):
       - Plane wave propagation: Tutorials/LinearEuler3D/PlaneWavePropagation.md
@@ -37,6 +38,7 @@ nav:
     - Boundary Conditions: Models/boundary-conditions.md
     - Viscous Burgers Equation: Models/burgers-equation-model.md
     - Linear Euler (2D) : Models/linear-euler-2d-model.md
+    - Linear Euler (2D) with PML : Models/linear-euler-2d-pml-model.md
     - Linear Euler (3D) : Models/linear-euler-3d-model.md
     - Linear Shallow Water (2D): Models/linear-shallow-water-model.md
 #    - Generic DG Models: Models/generic-dg-models.md

--- a/src/SELF_LinearEuler2D_PML_t.f90
+++ b/src/SELF_LinearEuler2D_PML_t.f90
@@ -1,0 +1,408 @@
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+!
+! Maintainers : support@fluidnumerics.com
+! Official Repository : https://github.com/FluidNumerics/self/
+!
+! Copyright © 2026 Fluid Numerics LLC
+!
+! Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+!
+! 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+!    the documentation and/or other materials provided with the distribution.
+!
+! 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+!    this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+! HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+! LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+! THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+! THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+!
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+
+module self_LinearEuler2D_PML_t
+!! Linear Euler 2D with a Perfectly Matched Layer (PML) absorbing region.
+!!
+!! Formulation: Hu (2001), "A Stable, Perfectly Matched Layer for Linearized
+!! Euler Equations in Unsplit Physical Variables" (JCP 173, 455-480), in the
+!! ADE (Auxiliary Differential Equation) form for the no-mean-flow case.
+!!
+!! In the PML region the dynamics for the acoustic state
+!! q = (rho', u, v, p) become
+!!
+!!   dq/dt + A dq/dx + B dq/dy + (sigma_x + sigma_y) q + sigma_x*sigma_y phi = 0
+!!   dphi/dt = q
+!!
+!! where phi = (phi_rho, phi_u, phi_v, phi_P) is a 4-component auxiliary
+!! that accumulates the time integral of q. The sigma_x(x), sigma_y(y)
+!! damping coefficients vanish in the interior and rise toward the outer
+!! boundary, leaving the original linear Euler 2D dynamics unaltered where
+!! sigma = 0.
+!!
+!! Solution layout (nvar = 9):
+!!   s(1) = rho     (density perturbation)
+!!   s(2) = u       (x-velocity)
+!!   s(3) = v       (y-velocity)
+!!   s(4) = P       (pressure perturbation)
+!!   s(5) = c       (sound speed, static; per-node)
+!!   s(6) = phi_rho (auxiliary; time-integral of rho)
+!!   s(7) = phi_u   (auxiliary; time-integral of u)
+!!   s(8) = phi_v   (auxiliary; time-integral of v)
+!!   s(9) = phi_P   (auxiliary; time-integral of P)
+!!
+!! The auxiliary variables phi_* have identically zero flux; they evolve
+!! only via the source term. Sound speed c is also static (zero flux,
+!! zero source) and is preserved from the parent LinearEuler2D model.
+!!
+!! PML elements are identified by a material name beginning with the
+!! configurable prefix (default "pml") in the mesh's material table.
+!! Non-PML elements always carry sigma_x = sigma_y = 0 and therefore
+!! reduce to the parent linear Euler 2D dynamics (modulo the inert
+!! auxiliary variables, which remain identically zero there).
+
+  use self_model
+  use self_dgmodel2d
+  use self_mesh
+  use self_lineareuler2d_t
+  use SELF_BoundaryConditions
+  use SELF_MappedScalar_2D
+
+  implicit none
+
+  type,extends(LinearEuler2D_t) :: LinearEuler2D_PML_t
+
+    type(MappedScalar2D) :: sigma_x ! sigma_x(x,y) damping coefficient, one variable per node
+    type(MappedScalar2D) :: sigma_y ! sigma_y(x,y) damping coefficient, one variable per node
+
+    ! PML region tagging and ramp parameters (set by SetPMLProfile)
+    real(prec) :: pml_x_min = 0.0_prec
+    real(prec) :: pml_x_max = 0.0_prec
+    real(prec) :: pml_y_min = 0.0_prec
+    real(prec) :: pml_y_max = 0.0_prec
+    real(prec) :: pml_width = 1.0_prec
+    real(prec) :: pml_sigma_max = 0.0_prec
+    integer :: pml_ramp_exponent = 3
+    character(LEN=SELF_MESH_MATNAME_LENGTH) :: pml_material_prefix = "pml"
+
+  contains
+    procedure :: SetNumberOfVariables => SetNumberOfVariables_LinearEuler2D_PML_t
+    procedure :: SetMetadata => SetMetadata_LinearEuler2D_PML_t
+    procedure :: AdditionalInit => AdditionalInit_LinearEuler2D_PML_t
+    procedure :: AdditionalFree => AdditionalFree_LinearEuler2D_PML_t
+    procedure :: flux2d => flux2d_LinearEuler2D_PML_t
+    procedure :: riemannflux2d => riemannflux2d_LinearEuler2D_PML_t
+    procedure :: sourcemethod => sourcemethod_LinearEuler2D_PML_t
+    procedure :: SetPMLProfile => SetPMLProfile_LinearEuler2D_PML_t
+
+  endtype LinearEuler2D_PML_t
+
+contains
+
+  subroutine SetNumberOfVariables_LinearEuler2D_PML_t(this)
+    implicit none
+    class(LinearEuler2D_PML_t),intent(inout) :: this
+
+    this%nvar = 9
+
+  endsubroutine SetNumberOfVariables_LinearEuler2D_PML_t
+
+  subroutine SetMetadata_LinearEuler2D_PML_t(this)
+    implicit none
+    class(LinearEuler2D_PML_t),intent(inout) :: this
+
+    ! Reuse parent metadata for the first five variables.
+    call SetMetadata_LinearEuler2D_t(this)
+
+    call this%solution%SetName(6,"phi_rho")
+    call this%solution%SetUnits(6,"kg⋅m⁻³⋅s")
+
+    call this%solution%SetName(7,"phi_u")
+    call this%solution%SetUnits(7,"m")
+
+    call this%solution%SetName(8,"phi_v")
+    call this%solution%SetUnits(8,"m")
+
+    call this%solution%SetName(9,"phi_P")
+    call this%solution%SetUnits(9,"kg⋅m⁻¹⋅s⁻¹")
+
+    call this%sigma_x%SetName(1,"sigma_x")
+    call this%sigma_x%SetUnits(1,"s⁻¹")
+    call this%sigma_y%SetName(1,"sigma_y")
+    call this%sigma_y%SetUnits(1,"s⁻¹")
+
+  endsubroutine SetMetadata_LinearEuler2D_PML_t
+
+  subroutine AdditionalInit_LinearEuler2D_PML_t(this)
+    implicit none
+    class(LinearEuler2D_PML_t),intent(inout) :: this
+    ! Local
+    procedure(SELF_bcMethod),pointer :: bcfunc
+
+    ! Allocate the per-node PML damping fields (single variable each).
+    call this%sigma_x%Init(this%geometry%x%interp,1,this%mesh%nElem)
+    call this%sigma_y%Init(this%geometry%x%interp,1,this%mesh%nElem)
+
+    ! Register PML-aware BC methods. The PML-aware versions reuse the
+    ! parent acoustic-side behaviour for variables 1-5 and zero the
+    ! auxiliary variables 6-9 in extBoundary so that interior-side
+    ! and exterior-side states are consistent with the zero-flux
+    ! treatment of phi_*.
+    bcfunc => hbc2d_NoNormalFlow_LinearEuler2D_PML
+    call this%hyperbolicBCs%RegisterBoundaryCondition( &
+      SELF_BC_NONORMALFLOW,"no_normal_flow",bcfunc)
+
+    bcfunc => hbc2d_Radiation_LinearEuler2D_PML
+    call this%hyperbolicBCs%RegisterBoundaryCondition( &
+      SELF_BC_RADIATION,"radiation",bcfunc)
+
+  endsubroutine AdditionalInit_LinearEuler2D_PML_t
+
+  subroutine AdditionalFree_LinearEuler2D_PML_t(this)
+    implicit none
+    class(LinearEuler2D_PML_t),intent(inout) :: this
+
+    call this%sigma_x%Free()
+    call this%sigma_y%Free()
+
+  endsubroutine AdditionalFree_LinearEuler2D_PML_t
+
+  subroutine SetPMLProfile_LinearEuler2D_PML_t(this,x_interior_min,x_interior_max, &
+                                               y_interior_min,y_interior_max, &
+                                               pml_width,sigma_max,ramp_exponent)
+    !! Populate the per-node sigma_x, sigma_y fields. Only nodes inside
+    !! elements whose material name starts with this%pml_material_prefix
+    !! receive non-zero damping; all other nodes are forced to zero so
+    !! the interior solution remains unmodified.
+    implicit none
+    class(LinearEuler2D_PML_t),intent(inout) :: this
+    real(prec),intent(in) :: x_interior_min,x_interior_max
+    real(prec),intent(in) :: y_interior_min,y_interior_max
+    real(prec),intent(in) :: pml_width
+    real(prec),intent(in) :: sigma_max
+    integer,intent(in),optional :: ramp_exponent
+    ! Local
+    integer :: i,j,iel,matid,p,prefix_len
+    real(prec) :: x,y,dx,dy,sx,sy
+    character(LEN=SELF_MESH_MATNAME_LENGTH) :: matname
+    logical :: is_pml
+
+    this%pml_x_min = x_interior_min
+    this%pml_x_max = x_interior_max
+    this%pml_y_min = y_interior_min
+    this%pml_y_max = y_interior_max
+    this%pml_width = pml_width
+    this%pml_sigma_max = sigma_max
+    if(present(ramp_exponent)) then
+      this%pml_ramp_exponent = ramp_exponent
+    endif
+    p = this%pml_ramp_exponent
+    prefix_len = len_trim(this%pml_material_prefix)
+
+    ! Default everything to zero, then fill the PML elements.
+    this%sigma_x%interior(:,:,:,1) = 0.0_prec
+    this%sigma_y%interior(:,:,:,1) = 0.0_prec
+
+    do iel = 1,this%mesh%nElem
+      matid = this%mesh%elemMaterial(iel)
+      matname = this%mesh%materialNames(matid)
+      is_pml = (len_trim(matname) >= prefix_len) .and. &
+               (matname(1:prefix_len) == this%pml_material_prefix(1:prefix_len))
+      if(.not. is_pml) cycle
+
+      do j = 1,this%solution%N+1
+        do i = 1,this%solution%N+1
+          x = this%geometry%x%interior(i,j,iel,1,1)
+          y = this%geometry%x%interior(i,j,iel,1,2)
+
+          ! Distance into PML measured from the interior box edge.
+          dx = max(0.0_prec,x_interior_min-x,x-x_interior_max)
+          dy = max(0.0_prec,y_interior_min-y,y-y_interior_max)
+
+          ! Polynomial ramp normalised by pml_width so sigma -> sigma_max
+          ! at the far edge of a layer of thickness pml_width.
+          sx = sigma_max*(dx/pml_width)**p
+          sy = sigma_max*(dy/pml_width)**p
+
+          this%sigma_x%interior(i,j,iel,1) = sx
+          this%sigma_y%interior(i,j,iel,1) = sy
+        enddo
+      enddo
+    enddo
+
+    call this%sigma_x%UpdateDevice()
+    call this%sigma_y%UpdateDevice()
+
+  endsubroutine SetPMLProfile_LinearEuler2D_PML_t
+
+  pure function flux2d_LinearEuler2D_PML_t(this,s,dsdx) result(flux)
+    !! Interior flux. Variables 1-5 use the parent linear Euler 2D
+    !! flux; auxiliary variables 6-9 carry zero flux in both directions
+    !! and are evolved purely by the PML source term.
+    class(LinearEuler2D_PML_t),intent(in) :: this
+    real(prec),intent(in) :: s(1:this%nvar)
+    real(prec),intent(in) :: dsdx(1:this%nvar,1:2)
+    real(prec) :: flux(1:this%nvar,1:2)
+
+    flux(1,1) = this%rho0*s(2) ! density, x flux ; rho0*u
+    flux(1,2) = this%rho0*s(3) ! density, y flux ; rho0*v
+    flux(2,1) = s(4)/this%rho0 ! x-velocity, x flux; p/rho0
+    flux(2,2) = 0.0_prec ! x-velocity, y flux; 0
+    flux(3,1) = 0.0_prec ! y-velocity, x flux; 0
+    flux(3,2) = s(4)/this%rho0 ! y-velocity, y flux; p/rho0
+    flux(4,1) = s(5)*s(5)*this%rho0*s(2) ! pressure, x flux : rho0*c^2*u
+    flux(4,2) = s(5)*s(5)*this%rho0*s(3) ! pressure, y flux : rho0*c^2*v
+    flux(5,1) = 0.0_prec ! sound speed, x flux; 0 (c held fixed in time)
+    flux(5,2) = 0.0_prec ! sound speed, y flux; 0
+    flux(6:9,1) = 0.0_prec ! PML auxiliaries evolve only via source term
+    flux(6:9,2) = 0.0_prec
+    if(.false.) flux(1,1) = flux(1,1)+dsdx(1,1) ! suppress unused-dummy-argument warning
+
+  endfunction flux2d_LinearEuler2D_PML_t
+
+  pure function riemannflux2d_LinearEuler2D_PML_t(this,sL,sR,dsdx,nhat) result(flux)
+    !! Impedance-matched Riemann flux for acoustic variables 1-5, with
+    !! zero flux returned for the auxiliary variables 6-9. The acoustic
+    !! formula is identical to the parent LinearEuler2D model; see
+    !! riemannflux2d_LinearEuler2D_t for the derivation.
+    class(LinearEuler2D_PML_t),intent(in) :: this
+    real(prec),intent(in) :: sL(1:this%nvar)
+    real(prec),intent(in) :: sR(1:this%nvar)
+    real(prec),intent(in) :: dsdx(1:this%nvar,1:2)
+    real(prec),intent(in) :: nhat(1:2)
+    real(prec) :: flux(1:this%nvar)
+    ! Local
+    real(prec) :: rho0,cL,cR,ZL,ZR,unL,unR,pL,pR,un_star,p_star,c2_avg
+
+    rho0 = this%rho0
+    cL = sL(5)
+    cR = sR(5)
+    ZL = rho0*cL
+    ZR = rho0*cR
+
+    unL = sL(2)*nhat(1)+sL(3)*nhat(2)
+    unR = sR(2)*nhat(1)+sR(3)*nhat(2)
+    pL = sL(4)
+    pR = sR(4)
+
+    un_star = (ZL*unL+ZR*unR+(pL-pR))/(ZL+ZR)
+    p_star = (ZR*pL+ZL*pR+ZL*ZR*(unL-unR))/(ZL+ZR)
+    c2_avg = 0.5_prec*(cL*cL+cR*cR)
+
+    flux(1) = rho0*un_star
+    flux(2) = p_star*nhat(1)/rho0
+    flux(3) = p_star*nhat(2)/rho0
+    flux(4) = rho0*c2_avg*un_star
+    flux(5) = 0.0_prec
+    flux(6:9) = 0.0_prec
+    if(.false.) flux(1) = flux(1)+dsdx(1,1) ! suppress unused-dummy-argument warning
+
+  endfunction riemannflux2d_LinearEuler2D_PML_t
+
+  subroutine sourcemethod_LinearEuler2D_PML_t(this)
+    !! Hu (2001) unsplit PML source term, evaluated per node. In the
+    !! interior (sigma_x = sigma_y = 0) this leaves the acoustic
+    !! variables untouched and the auxiliaries integrate q in time but
+    !! never re-enter the dynamics (since the coupling coefficient
+    !! sigma_x*sigma_y is zero). Inside the PML, the (sigma_x + sigma_y)
+    !! damping plus the sigma_x*sigma_y*phi term produce the correct
+    !! perfectly-matched behaviour for the linear Euler 2D system.
+    !!
+    !! Note: we override sourcemethod rather than source2d because the
+    !! per-node sigma_x(i,j,iel), sigma_y(i,j,iel) lookups are not
+    !! reachable from the pure source2d(s,dsdx) signature.
+    implicit none
+    class(LinearEuler2D_PML_t),intent(inout) :: this
+    ! Local
+    integer :: i,j,iel
+    real(prec) :: sx,sy
+    real(prec) :: s(1:this%nvar)
+
+    do concurrent(i=1:this%solution%N+1,j=1:this%solution%N+1, &
+                  iel=1:this%mesh%nElem)
+
+      sx = this%sigma_x%interior(i,j,iel,1)
+      sy = this%sigma_y%interior(i,j,iel,1)
+      s = this%solution%interior(i,j,iel,1:this%nvar)
+
+      this%source%interior(i,j,iel,1) = -(sx+sy)*s(1)-sx*sy*s(6)
+      this%source%interior(i,j,iel,2) = -(sx+sy)*s(2)-sx*sy*s(7)
+      this%source%interior(i,j,iel,3) = -(sx+sy)*s(3)-sx*sy*s(8)
+      this%source%interior(i,j,iel,4) = -(sx+sy)*s(4)-sx*sy*s(9)
+      this%source%interior(i,j,iel,5) = 0.0_prec
+      this%source%interior(i,j,iel,6) = s(1)
+      this%source%interior(i,j,iel,7) = s(2)
+      this%source%interior(i,j,iel,8) = s(3)
+      this%source%interior(i,j,iel,9) = s(4)
+
+    enddo
+
+  endsubroutine sourcemethod_LinearEuler2D_PML_t
+
+  subroutine hbc2d_NoNormalFlow_LinearEuler2D_PML(bc,mymodel)
+    !! No-normal-flow BC for the PML-augmented linear Euler model.
+    !! Variables 1-5 are treated identically to the parent
+    !! LinearEuler2D no-normal-flow BC. Auxiliary variables 6-9 are
+    !! given a zero exterior state; since they carry zero Riemann flux
+    !! the exterior value is mathematically irrelevant, but zeroing it
+    !! keeps the boundary state clean for diagnostics.
+    class(BoundaryCondition),intent(in) :: bc
+    class(Model),intent(inout) :: mymodel
+    ! Local
+    integer :: n,i,iEl,j
+    real(prec) :: nhat(1:2),s(1:5)
+
+    select type(m => mymodel)
+    class is(LinearEuler2D_PML_t)
+      do n = 1,bc%nBoundaries
+        iEl = bc%elements(n)
+        j = bc%sides(n)
+        do i = 1,m%solution%interp%N+1
+          nhat = m%geometry%nhat%boundary(i,j,iEl,1,1:2)
+          s = m%solution%boundary(i,j,iEl,1:5)
+          m%solution%extBoundary(i,j,iEl,1) = s(1) ! density
+          m%solution%extBoundary(i,j,iEl,2) = &
+            (nhat(2)**2-nhat(1)**2)*s(2)-2.0_prec*nhat(1)*nhat(2)*s(3) ! u
+          m%solution%extBoundary(i,j,iEl,3) = &
+            (nhat(1)**2-nhat(2)**2)*s(3)-2.0_prec*nhat(1)*nhat(2)*s(2) ! v
+          m%solution%extBoundary(i,j,iEl,4) = s(4) ! p
+          m%solution%extBoundary(i,j,iEl,5) = s(5) ! c
+          m%solution%extBoundary(i,j,iEl,6:9) = 0.0_prec ! PML auxiliaries
+        enddo
+      enddo
+    endselect
+
+  endsubroutine hbc2d_NoNormalFlow_LinearEuler2D_PML
+
+  subroutine hbc2d_Radiation_LinearEuler2D_PML(bc,mymodel)
+    !! Radiation BC for the PML-augmented linear Euler model: zero
+    !! acoustic perturbation in the exterior state, sound speed copied
+    !! from interior so the Riemann solver sees a consistent c, and
+    !! auxiliary variables set to zero.
+    class(BoundaryCondition),intent(in) :: bc
+    class(Model),intent(inout) :: mymodel
+    ! Local
+    integer :: n,i,iEl,j
+
+    select type(m => mymodel)
+    class is(LinearEuler2D_PML_t)
+      do n = 1,bc%nBoundaries
+        iEl = bc%elements(n)
+        j = bc%sides(n)
+        do i = 1,m%solution%interp%N+1
+          m%solution%extBoundary(i,j,iEl,1) = 0.0_prec
+          m%solution%extBoundary(i,j,iEl,2) = 0.0_prec
+          m%solution%extBoundary(i,j,iEl,3) = 0.0_prec
+          m%solution%extBoundary(i,j,iEl,4) = 0.0_prec
+          m%solution%extBoundary(i,j,iEl,5) = m%solution%boundary(i,j,iEl,5) ! c preserved
+          m%solution%extBoundary(i,j,iEl,6:9) = 0.0_prec
+        enddo
+      enddo
+    endselect
+
+  endsubroutine hbc2d_Radiation_LinearEuler2D_PML
+
+endmodule self_LinearEuler2D_PML_t

--- a/src/cpu/SELF_LinearEuler2D_PML.f90
+++ b/src/cpu/SELF_LinearEuler2D_PML.f90
@@ -1,0 +1,36 @@
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+!
+! Maintainers : support@fluidnumerics.com
+! Official Repository : https://github.com/FluidNumerics/self/
+!
+! Copyright © 2026 Fluid Numerics LLC
+!
+! Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+!
+! 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+!    the documentation and/or other materials provided with the distribution.
+!
+! 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+!    this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+! HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+! LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+! THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+! THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+!
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+
+module self_LinearEuler2D_PML
+
+  use self_LinearEuler2D_PML_t
+
+  implicit none
+
+  type,extends(LinearEuler2D_PML_t) :: LinearEuler2D_PML
+  endtype LinearEuler2D_PML
+
+endmodule self_LinearEuler2D_PML

--- a/src/gpu/SELF_LinearEuler2D_PML.cpp
+++ b/src/gpu/SELF_LinearEuler2D_PML.cpp
@@ -1,0 +1,288 @@
+/*
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+!
+! Maintainers : support@fluidnumerics.com
+! Official Repository : https://github.com/FluidNumerics/self/
+!
+! Copyright © 2026 Fluid Numerics LLC
+!
+! Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+!
+! 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+!    the documentation and/or other materials provided with the distribution.
+!
+! 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+!    this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+! HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+! LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+! THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+! THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+!
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+*/
+
+#include "SELF_GPU_Macros.h"
+
+
+// ============================================================
+// Riemann boundary-flux kernel (PML variant).
+// Acoustic variables 0..4 use the impedance-matched solver from
+// the parent LinearEuler2D kernel; auxiliary variables 5..8
+// (the PML phi fields) carry zero flux and are evolved purely by
+// the source term.
+// ============================================================
+__global__ void boundaryflux_LinearEuler2D_PML_kernel(real *fb, real *extfb, real *nhat, real *nmag, real *flux, real rho0, int ndof){
+  uint32_t idof = threadIdx.x + blockIdx.x*blockDim.x;
+
+  if( idof < ndof ){
+    real nx  = nhat[idof];
+    real ny  = nhat[idof+ndof];
+    real nm  = nmag[idof];
+
+    real cL  = fb[idof + 4*ndof];
+    real cR  = extfb[idof + 4*ndof];
+    real ZL  = rho0*cL;
+    real ZR  = rho0*cR;
+
+    real unL = fb[idof +     ndof]*nx + fb[idof + 2*ndof]*ny;
+    real unR = extfb[idof +  ndof]*nx + extfb[idof + 2*ndof]*ny;
+    real pL  = fb[idof + 3*ndof];
+    real pR  = extfb[idof + 3*ndof];
+
+    real un_star = (ZL*unL + ZR*unR + (pL - pR)) / (ZL + ZR);
+    real p_star  = (ZR*pL  + ZL*pR  + ZL*ZR*(unL - unR)) / (ZL + ZR);
+    real c2_avg  = 0.5*(cL*cL + cR*cR);
+
+    flux[idof]          = (rho0*un_star) * nm;          // density
+    flux[idof + ndof]   = (p_star*nx/rho0) * nm;        // u
+    flux[idof + 2*ndof] = (p_star*ny/rho0) * nm;        // v
+    flux[idof + 3*ndof] = (rho0*c2_avg*un_star) * nm;   // pressure
+    flux[idof + 4*ndof] = 0.0;                          // sound speed
+    flux[idof + 5*ndof] = 0.0;                          // phi_rho
+    flux[idof + 6*ndof] = 0.0;                          // phi_u
+    flux[idof + 7*ndof] = 0.0;                          // phi_v
+    flux[idof + 8*ndof] = 0.0;                          // phi_p
+  }
+}
+
+extern "C"
+{
+  void boundaryflux_LinearEuler2D_PML_gpu(real *fb, real *extfb, real *nhat, real *nmag, real *flux, real rho0, int N, int nel, int nvar){
+    int threads_per_block = 256;
+    uint32_t ndof = (N+1)*4*nel;
+    int nblocks_x = ndof/threads_per_block + 1;
+
+    dim3 nblocks(nblocks_x,1,1);
+    dim3 nthreads(threads_per_block,1,1);
+
+    boundaryflux_LinearEuler2D_PML_kernel<<<nblocks,nthreads>>>(fb,extfb,nhat,nmag,flux,rho0,ndof);
+  }
+}
+
+// ============================================================
+// Interior-flux kernel (PML variant). Acoustic variables 0..4
+// match the parent LinearEuler2D kernel; auxiliary variables 5..8
+// have zero flux in both directions.
+// ============================================================
+__global__ void fluxmethod_LinearEuler2D_PML_kernel(real *solution, real *flux, real rho0, int ndof, int nvar){
+  uint32_t idof = threadIdx.x + blockIdx.x*blockDim.x;
+
+  if( idof < ndof ){
+    real u = solution[idof +     ndof];
+    real v = solution[idof + 2*ndof];
+    real p = solution[idof + 3*ndof];
+    real c = solution[idof + 4*ndof];
+
+    flux[idof + ndof*(0 + nvar*0)] = rho0*u;   // rho, x-flux
+    flux[idof + ndof*(0 + nvar*1)] = rho0*v;   // rho, y-flux
+
+    flux[idof + ndof*(1 + nvar*0)] = p/rho0;   // u, x-flux
+    flux[idof + ndof*(1 + nvar*1)] = 0.0;      // u, y-flux
+
+    flux[idof + ndof*(2 + nvar*0)] = 0.0;      // v, x-flux
+    flux[idof + ndof*(2 + nvar*1)] = p/rho0;   // v, y-flux
+
+    flux[idof + ndof*(3 + nvar*0)] = c*c*rho0*u; // p, x-flux
+    flux[idof + ndof*(3 + nvar*1)] = c*c*rho0*v; // p, y-flux
+
+    flux[idof + ndof*(4 + nvar*0)] = 0.0;      // c, x-flux
+    flux[idof + ndof*(4 + nvar*1)] = 0.0;      // c, y-flux
+
+    // PML auxiliary variables 5..8 (phi_rho, phi_u, phi_v, phi_p)
+    // carry zero flux; they are evolved exclusively by the source.
+    for(int ivar = 5; ivar < 9; ivar++){
+      flux[idof + ndof*(ivar + nvar*0)] = 0.0;
+      flux[idof + ndof*(ivar + nvar*1)] = 0.0;
+    }
+  }
+}
+
+extern "C"
+{
+  void fluxmethod_LinearEuler2D_PML_gpu(real *solution, real *flux, real rho0, int N, int nel, int nvar){
+    int ndof = (N+1)*(N+1)*nel;
+    int threads_per_block = 256;
+    int nblocks_x = ndof/threads_per_block + 1;
+    fluxmethod_LinearEuler2D_PML_kernel<<<dim3(nblocks_x,1,1), dim3(threads_per_block,1,1), 0, 0>>>(solution,flux,rho0,ndof,nvar);
+  }
+}
+
+// ============================================================
+// Source-term kernel (Hu 2001 unsplit PML, ADE form).
+//
+// For acoustic variables (0..3) the PML adds:
+//   source = -(sigma_x + sigma_y) q - sigma_x sigma_y phi
+// For sound speed (4): source = 0 (held fixed in time).
+// For auxiliaries (5..8): source = q (so dphi/dt = q).
+//
+// sigma_x and sigma_y are single-variable MappedScalar2D fields,
+// so their device storage is exactly ndof reals each (one value
+// per spatial DOF).
+// ============================================================
+__global__ void sourcemethod_LinearEuler2D_PML_kernel(real *source, real *solution, real *sigma_x, real *sigma_y, int ndof){
+  uint32_t idof = threadIdx.x + blockIdx.x*blockDim.x;
+
+  if( idof < ndof ){
+    real sx = sigma_x[idof];
+    real sy = sigma_y[idof];
+    real rho     = solution[idof +     0*ndof];
+    real u       = solution[idof +     1*ndof];
+    real v       = solution[idof +     2*ndof];
+    real p       = solution[idof +     3*ndof];
+    // solution[idof + 4*ndof] is c (sound speed); not used here.
+    real phi_rho = solution[idof +     5*ndof];
+    real phi_u   = solution[idof +     6*ndof];
+    real phi_v   = solution[idof +     7*ndof];
+    real phi_p   = solution[idof +     8*ndof];
+
+    real sxy = sx + sy;
+    real sxsy = sx * sy;
+
+    source[idof + 0*ndof] = -sxy*rho - sxsy*phi_rho;
+    source[idof + 1*ndof] = -sxy*u   - sxsy*phi_u;
+    source[idof + 2*ndof] = -sxy*v   - sxsy*phi_v;
+    source[idof + 3*ndof] = -sxy*p   - sxsy*phi_p;
+    source[idof + 4*ndof] = 0.0;
+    source[idof + 5*ndof] = rho;
+    source[idof + 6*ndof] = u;
+    source[idof + 7*ndof] = v;
+    source[idof + 8*ndof] = p;
+  }
+}
+
+extern "C"
+{
+  void sourcemethod_LinearEuler2D_PML_gpu(real *source, real *solution, real *sigma_x, real *sigma_y, int N, int nel, int nvar){
+    int ndof = (N+1)*(N+1)*nel;
+    int threads_per_block = 256;
+    int nblocks_x = ndof/threads_per_block + 1;
+    sourcemethod_LinearEuler2D_PML_kernel<<<dim3(nblocks_x,1,1), dim3(threads_per_block,1,1), 0, 0>>>(source,solution,sigma_x,sigma_y,ndof);
+  }
+}
+
+// ============================================================
+// No-normal-flow BC (PML variant).
+// Variables 0..4 follow the parent LinearEuler2D no-normal-flow
+// behaviour; variables 5..8 (PML auxiliaries) are zeroed in
+// extBoundary for cleanliness (they have zero Riemann flux, so
+// their exterior state is mathematically irrelevant).
+// ============================================================
+__global__ void hbc2d_nonormalflow_lineareuler2d_pml_kernel(
+    real *extBoundary, real *boundary, real *nhat,
+    int *elements, int *sides,
+    int nBoundaries, int N, int nel)
+{
+  uint32_t idof = threadIdx.x + blockIdx.x*blockDim.x;
+  uint32_t total_dofs = nBoundaries * (N+1);
+
+  if(idof < total_dofs){
+    uint32_t i  = idof % (N+1);
+    uint32_t n  = idof / (N+1);
+    uint32_t e1 = elements[n] - 1;
+    uint32_t s1 = sides[n] - 1;
+
+    real u  = boundary[SCB_2D_INDEX(i,s1,e1,1,N,nel)];
+    real v  = boundary[SCB_2D_INDEX(i,s1,e1,2,N,nel)];
+    real nx = nhat[VEB_2D_INDEX(i,s1,e1,0,0,N,nel,1)];
+    real ny = nhat[VEB_2D_INDEX(i,s1,e1,0,1,N,nel,1)];
+
+    extBoundary[SCB_2D_INDEX(i,s1,e1,0,N,nel)] = boundary[SCB_2D_INDEX(i,s1,e1,0,N,nel)]; // density
+    extBoundary[SCB_2D_INDEX(i,s1,e1,1,N,nel)] = (ny*ny-nx*nx)*u - 2.0*nx*ny*v;            // u
+    extBoundary[SCB_2D_INDEX(i,s1,e1,2,N,nel)] = (nx*nx-ny*ny)*v - 2.0*nx*ny*u;            // v
+    extBoundary[SCB_2D_INDEX(i,s1,e1,3,N,nel)] = boundary[SCB_2D_INDEX(i,s1,e1,3,N,nel)]; // pressure
+    extBoundary[SCB_2D_INDEX(i,s1,e1,4,N,nel)] = boundary[SCB_2D_INDEX(i,s1,e1,4,N,nel)]; // c
+    extBoundary[SCB_2D_INDEX(i,s1,e1,5,N,nel)] = 0.0;                                     // phi_rho
+    extBoundary[SCB_2D_INDEX(i,s1,e1,6,N,nel)] = 0.0;                                     // phi_u
+    extBoundary[SCB_2D_INDEX(i,s1,e1,7,N,nel)] = 0.0;                                     // phi_v
+    extBoundary[SCB_2D_INDEX(i,s1,e1,8,N,nel)] = 0.0;                                     // phi_p
+  }
+}
+
+extern "C"
+{
+  void hbc2d_nonormalflow_lineareuler2d_pml_gpu(
+      real *extBoundary, real *boundary, real *nhat,
+      int *elements, int *sides,
+      int nBoundaries, int N, int nel)
+  {
+    int threads_per_block = 256;
+    int total_dofs = nBoundaries * (N+1);
+    int nblocks_x = total_dofs/threads_per_block + 1;
+    hbc2d_nonormalflow_lineareuler2d_pml_kernel<<<dim3(nblocks_x,1,1),
+      dim3(threads_per_block,1,1), 0, 0>>>(extBoundary, boundary, nhat,
+        elements, sides, nBoundaries, N, nel);
+  }
+}
+
+// ============================================================
+// Radiation BC (PML variant).
+// Zeros acoustic perturbations; preserves c from the interior
+// side so the Riemann solver sees a consistent sound speed;
+// zeros PML auxiliaries.
+// ============================================================
+__global__ void hbc2d_radiation_lineareuler2d_pml_kernel(
+    real *extBoundary, real *boundary,
+    int *elements, int *sides,
+    int nBoundaries, int N, int nel)
+{
+  uint32_t idof = threadIdx.x + blockIdx.x*blockDim.x;
+  uint32_t total_dofs = nBoundaries * (N+1);
+
+  if(idof < total_dofs){
+    uint32_t i  = idof % (N+1);
+    uint32_t n  = idof / (N+1);
+    uint32_t e1 = elements[n] - 1;
+    uint32_t s1 = sides[n] - 1;
+
+    extBoundary[SCB_2D_INDEX(i,s1,e1,0,N,nel)] = 0.0;
+    extBoundary[SCB_2D_INDEX(i,s1,e1,1,N,nel)] = 0.0;
+    extBoundary[SCB_2D_INDEX(i,s1,e1,2,N,nel)] = 0.0;
+    extBoundary[SCB_2D_INDEX(i,s1,e1,3,N,nel)] = 0.0;
+    extBoundary[SCB_2D_INDEX(i,s1,e1,4,N,nel)] = boundary[SCB_2D_INDEX(i,s1,e1,4,N,nel)]; // c preserved
+    extBoundary[SCB_2D_INDEX(i,s1,e1,5,N,nel)] = 0.0;
+    extBoundary[SCB_2D_INDEX(i,s1,e1,6,N,nel)] = 0.0;
+    extBoundary[SCB_2D_INDEX(i,s1,e1,7,N,nel)] = 0.0;
+    extBoundary[SCB_2D_INDEX(i,s1,e1,8,N,nel)] = 0.0;
+  }
+}
+
+extern "C"
+{
+  void hbc2d_radiation_lineareuler2d_pml_gpu(
+      real *extBoundary, real *boundary,
+      int *elements, int *sides,
+      int nBoundaries, int N, int nel)
+  {
+    int threads_per_block = 256;
+    int total_dofs = nBoundaries * (N+1);
+    int nblocks_x = total_dofs/threads_per_block + 1;
+    hbc2d_radiation_lineareuler2d_pml_kernel<<<dim3(nblocks_x,1,1),
+      dim3(threads_per_block,1,1), 0, 0>>>(extBoundary, boundary,
+        elements, sides, nBoundaries, N, nel);
+  }
+}

--- a/src/gpu/SELF_LinearEuler2D_PML.f90
+++ b/src/gpu/SELF_LinearEuler2D_PML.f90
@@ -1,0 +1,191 @@
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+!
+! Maintainers : support@fluidnumerics.com
+! Official Repository : https://github.com/FluidNumerics/self/
+!
+! Copyright © 2026 Fluid Numerics LLC
+!
+! Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+!
+! 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+!    the documentation and/or other materials provided with the distribution.
+!
+! 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+!    this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+! HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+! LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+! THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+! THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+!
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+
+module self_LinearEuler2D_PML
+
+  use self_LinearEuler2D_PML_t
+  use SELF_GPU
+  use SELF_BoundaryConditions
+
+  implicit none
+
+  type,extends(LinearEuler2D_PML_t) :: LinearEuler2D_PML
+  contains
+    procedure :: AdditionalInit => AdditionalInit_LinearEuler2D_PML
+    procedure :: boundaryflux => boundaryflux_LinearEuler2D_PML
+    procedure :: fluxmethod => fluxmethod_LinearEuler2D_PML
+    procedure :: sourcemethod => sourcemethod_LinearEuler2D_PML
+
+  endtype LinearEuler2D_PML
+
+  interface
+    subroutine hbc2d_nonormalflow_lineareuler2d_pml_gpu(extboundary,boundary,nhat, &
+                                                        elements,sides,nBoundaries,N,nel) &
+      bind(c,name="hbc2d_nonormalflow_lineareuler2d_pml_gpu")
+      use iso_c_binding
+      type(c_ptr),value :: extboundary,boundary,nhat,elements,sides
+      integer(c_int),value :: nBoundaries,N,nel
+    endsubroutine hbc2d_nonormalflow_lineareuler2d_pml_gpu
+  endinterface
+
+  interface
+    subroutine hbc2d_radiation_lineareuler2d_pml_gpu(extboundary,boundary, &
+                                                     elements,sides,nBoundaries,N,nel) &
+      bind(c,name="hbc2d_radiation_lineareuler2d_pml_gpu")
+      use iso_c_binding
+      type(c_ptr),value :: extboundary,boundary,elements,sides
+      integer(c_int),value :: nBoundaries,N,nel
+    endsubroutine hbc2d_radiation_lineareuler2d_pml_gpu
+  endinterface
+
+  interface
+    subroutine fluxmethod_LinearEuler2D_PML_gpu(solution,flux,rho0,N,nel,nvar) &
+      bind(c,name="fluxmethod_LinearEuler2D_PML_gpu")
+      use iso_c_binding
+      use SELF_Constants
+      type(c_ptr),value :: solution,flux
+      real(c_prec),value :: rho0
+      integer(c_int),value :: N,nel,nvar
+    endsubroutine fluxmethod_LinearEuler2D_PML_gpu
+  endinterface
+
+  interface
+    subroutine boundaryflux_LinearEuler2D_PML_gpu(fb,fextb,nhat,nscale,flux,rho0,N,nel,nvar) &
+      bind(c,name="boundaryflux_LinearEuler2D_PML_gpu")
+      use iso_c_binding
+      use SELF_Constants
+      type(c_ptr),value :: fb,fextb,flux,nhat,nscale
+      real(c_prec),value :: rho0
+      integer(c_int),value :: N,nel,nvar
+    endsubroutine boundaryflux_LinearEuler2D_PML_gpu
+  endinterface
+
+  interface
+    subroutine sourcemethod_LinearEuler2D_PML_gpu(source,solution,sigma_x,sigma_y,N,nel,nvar) &
+      bind(c,name="sourcemethod_LinearEuler2D_PML_gpu")
+      use iso_c_binding
+      type(c_ptr),value :: source,solution,sigma_x,sigma_y
+      integer(c_int),value :: N,nel,nvar
+    endsubroutine sourcemethod_LinearEuler2D_PML_gpu
+  endinterface
+
+contains
+
+  subroutine AdditionalInit_LinearEuler2D_PML(this)
+    implicit none
+    class(LinearEuler2D_PML),intent(inout) :: this
+    ! Local
+    procedure(SELF_bcMethod),pointer :: bcfunc
+
+    ! Initialise the parent (allocates sigma_x, sigma_y; registers
+    ! the CPU PML BC handlers). We immediately overwrite the BC
+    ! method pointers with GPU-resident wrappers below.
+    call AdditionalInit_LinearEuler2D_PML_t(this)
+
+    bcfunc => hbc2d_NoNormalFlow_LinearEuler2D_PML_GPU_wrapper
+    call this%hyperbolicBCs%RegisterBoundaryCondition( &
+      SELF_BC_NONORMALFLOW,"no_normal_flow",bcfunc)
+
+    bcfunc => hbc2d_Radiation_LinearEuler2D_PML_GPU_wrapper
+    call this%hyperbolicBCs%RegisterBoundaryCondition( &
+      SELF_BC_RADIATION,"radiation",bcfunc)
+
+  endsubroutine AdditionalInit_LinearEuler2D_PML
+
+  subroutine hbc2d_NoNormalFlow_LinearEuler2D_PML_GPU_wrapper(bc,mymodel)
+    class(BoundaryCondition),intent(in) :: bc
+    class(Model),intent(inout) :: mymodel
+
+    select type(m => mymodel)
+    class is(LinearEuler2D_PML)
+      if(bc%nBoundaries > 0) then
+        call hbc2d_nonormalflow_lineareuler2d_pml_gpu( &
+          m%solution%extBoundary_gpu, &
+          m%solution%boundary_gpu, &
+          m%geometry%nhat%boundary_gpu, &
+          bc%elements_gpu,bc%sides_gpu, &
+          bc%nBoundaries,m%solution%interp%N,m%solution%nElem)
+      endif
+    endselect
+
+  endsubroutine hbc2d_NoNormalFlow_LinearEuler2D_PML_GPU_wrapper
+
+  subroutine hbc2d_Radiation_LinearEuler2D_PML_GPU_wrapper(bc,mymodel)
+    class(BoundaryCondition),intent(in) :: bc
+    class(Model),intent(inout) :: mymodel
+
+    select type(m => mymodel)
+    class is(LinearEuler2D_PML)
+      if(bc%nBoundaries > 0) then
+        call hbc2d_radiation_lineareuler2d_pml_gpu( &
+          m%solution%extBoundary_gpu, &
+          m%solution%boundary_gpu, &
+          bc%elements_gpu,bc%sides_gpu, &
+          bc%nBoundaries,m%solution%interp%N,m%solution%nElem)
+      endif
+    endselect
+
+  endsubroutine hbc2d_Radiation_LinearEuler2D_PML_GPU_wrapper
+
+  subroutine sourcemethod_LinearEuler2D_PML(this)
+    implicit none
+    class(LinearEuler2D_PML),intent(inout) :: this
+
+    call sourcemethod_LinearEuler2D_PML_gpu( &
+      this%source%interior_gpu, &
+      this%solution%interior_gpu, &
+      this%sigma_x%interior_gpu, &
+      this%sigma_y%interior_gpu, &
+      this%solution%interp%N,this%solution%nelem,this%solution%nvar)
+
+  endsubroutine sourcemethod_LinearEuler2D_PML
+
+  subroutine boundaryflux_LinearEuler2D_PML(this)
+    implicit none
+    class(LinearEuler2D_PML),intent(inout) :: this
+
+    call boundaryflux_LinearEuler2D_PML_gpu(this%solution%boundary_gpu, &
+                                            this%solution%extBoundary_gpu, &
+                                            this%geometry%nhat%boundary_gpu, &
+                                            this%geometry%nscale%boundary_gpu, &
+                                            this%flux%boundarynormal_gpu, &
+                                            this%rho0,this%solution%interp%N, &
+                                            this%solution%nelem,this%solution%nvar)
+
+  endsubroutine boundaryflux_LinearEuler2D_PML
+
+  subroutine fluxmethod_LinearEuler2D_PML(this)
+    implicit none
+    class(LinearEuler2D_PML),intent(inout) :: this
+
+    call fluxmethod_LinearEuler2D_PML_gpu(this%solution%interior_gpu, &
+                                          this%flux%interior_gpu, &
+                                          this%rho0,this%solution%interp%N,this%solution%nelem, &
+                                          this%solution%nvar)
+
+  endsubroutine fluxmethod_LinearEuler2D_PML
+
+endmodule self_LinearEuler2D_PML

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -139,6 +139,7 @@ add_fortran_tests (
     "linear_shallow_water_2d_constant.f90"
     "linear_shallow_water_2d_nonormalflow.f90"
     "linear_shallow_water_2d_radiation.f90"
+    "lineareuler2d_pml_absorption.f90"
     "twopointvectordivergence_2d_constant.f90"
     "twopointvectordivergence_2d_linear.f90"
     "twopointvectordivergence_2d_rotational.f90"

--- a/test/lineareuler2d_pml_absorption.f90
+++ b/test/lineareuler2d_pml_absorption.f90
@@ -1,0 +1,185 @@
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+!
+! Maintainers : support@fluidnumerics.com
+! Official Repository : https://github.com/FluidNumerics/self/
+!
+! Copyright © 2026 Fluid Numerics LLC
+!
+! Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+!
+! 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+!    the documentation and/or other materials provided with the distribution.
+!
+! 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+!    this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+! HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+! LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+! THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+! THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+!
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+
+program LinearEuler2D_PML_Absorption
+!! Regression test for the Hu (2001) unsplit PML on the 2D linear
+!! Euler model. A right-going Gaussian acoustic pulse (uniform in y)
+!! is released near the western interior; it propagates as a planar
+!! wave into an eastern PML region and is absorbed. The uniform-in-y
+!! initial condition keeps the pulse planar so the only mechanism
+!! reducing the interior amplitude is the PML absorption (not 2D
+!! cylindrical spreading).
+!!
+!! Assertions:
+!!  (a) the model remains numerically stable: entropy stays finite
+!!      and does not exceed the initial value;
+!!  (b) by the final time, the acoustic perturbation in the interior
+!!      region (x <= x_interior_max) is below 5% of its initial peak,
+!!      i.e. the PML absorbed >= 95% of the energy that crossed
+!!      into it.
+
+  use self_data
+  use self_lineareuler2d_pml
+  use self_mesh_2d
+
+  implicit none
+
+  character(SELF_INTEGRATOR_LENGTH),parameter :: integrator = 'rk3'
+  integer,parameter :: controlDegree = 5
+  integer,parameter :: targetDegree = 10
+  real(prec),parameter :: dt = 5.0e-3_prec
+  real(prec),parameter :: endtime = 5.0_prec
+  real(prec),parameter :: iointerval = 1.0_prec
+  real(prec),parameter :: c0 = 1.0_prec
+  real(prec),parameter :: amp = 1.0e-3_prec
+  real(prec),parameter :: pulse_width = 0.5_prec ! Gaussian halfwidth in x
+  real(prec),parameter :: pulse_x0 = 1.5_prec
+  real(prec),parameter :: x_interior_max = 4.0_prec
+  real(prec),parameter :: pml_width = 2.0_prec
+  real(prec),parameter :: sigma_max = 20.0_prec
+  real(prec),parameter :: absorption_tol = 5.0e-2_prec
+
+  type(LinearEuler2D_PML) :: modelobj
+  type(Lagrange),target :: interp
+  type(Mesh2D),target :: mesh
+  type(SEMQuad),target :: geometry
+  integer :: bcids(1:4)
+  integer :: i,j,iel
+  real(prec) :: x,r2,p_loc,xmid
+  real(prec) :: e0,ef,p_max_initial,p_max_interior
+
+  ! Thin (in y) domain: 12 elements in x by 2 elements in y. The
+  ! initial condition is uniform in y so the no-normal-flow walls
+  ! on north/south sides preserve a planar wave.
+  bcids(1:4) = [SELF_BC_NONORMALFLOW, & ! south
+                SELF_BC_NONORMALFLOW, & ! east (behind PML)
+                SELF_BC_NONORMALFLOW, & ! north
+                SELF_BC_NONORMALFLOW] ! west
+  call mesh%StructuredMesh(12,2,1,1,0.5_prec,0.5_prec,bcids)
+
+  ! Tag the eastern strip (x > x_interior_max) as PML material.
+  if(allocated(mesh%materialNames)) deallocate(mesh%materialNames)
+  mesh%nMaterials = 2
+  allocate(mesh%materialNames(1:2))
+  mesh%materialNames(1) = "interior"
+  mesh%materialNames(2) = "pml"
+  do iel = 1,mesh%nElem
+    xmid = sum(mesh%nodeCoords(1,:,:,iel))/real(size(mesh%nodeCoords,2)*size(mesh%nodeCoords,3),prec)
+    if(xmid > x_interior_max) then
+      mesh%elemMaterial(iel) = 2
+    else
+      mesh%elemMaterial(iel) = 1
+    endif
+  enddo
+
+  call interp%Init(N=controlDegree, &
+                   controlNodeType=GAUSS, &
+                   M=targetDegree, &
+                   targetNodeType=UNIFORM)
+
+  call geometry%Init(interp,mesh%nElem)
+  call geometry%GenerateFromMesh(mesh)
+
+  call modelobj%Init(mesh,geometry)
+  modelobj%prescribed_bcs_enabled = .false.
+  modelobj%tecplot_enabled = .false.
+  modelobj%rho0 = 1.0_prec
+
+  ! Cubic ramp from 0 to sigma_max across the PML thickness.
+  call modelobj%SetPMLProfile(x_interior_min=0.0_prec, &
+                              x_interior_max=x_interior_max, &
+                              y_interior_min=0.0_prec, &
+                              y_interior_max=1.0_prec, &
+                              pml_width=pml_width, &
+                              sigma_max=sigma_max, &
+                              ramp_exponent=3)
+
+  ! Initial planar (uniform in y) right-going acoustic pulse:
+  !   p(x) = amp * exp(-((x-pulse_x0)/pulse_width)^2)
+  !   rho  = p/c^2,  u = p/(rho0*c),  v = 0
+  ! which is the right eigenvector of A for the linear Euler system.
+  do iel = 1,mesh%nElem
+    do j = 1,modelobj%solution%N+1
+      do i = 1,modelobj%solution%N+1
+        x = modelobj%geometry%x%interior(i,j,iel,1,1)
+        r2 = (x-pulse_x0)**2
+        p_loc = amp*exp(-r2/(pulse_width*pulse_width))
+        modelobj%solution%interior(i,j,iel,1) = p_loc/(c0*c0) ! rho
+        modelobj%solution%interior(i,j,iel,2) = p_loc/(modelobj%rho0*c0) ! u
+        modelobj%solution%interior(i,j,iel,3) = 0.0_prec ! v
+        modelobj%solution%interior(i,j,iel,4) = p_loc ! p
+        modelobj%solution%interior(i,j,iel,5) = c0 ! c
+        modelobj%solution%interior(i,j,iel,6:9) = 0.0_prec ! phi_*
+      enddo
+    enddo
+  enddo
+  call modelobj%solution%UpdateDevice()
+
+  p_max_initial = maxval(modelobj%solution%interior(:,:,:,4))
+  print*,"Initial max |p|: ",p_max_initial
+  call modelobj%CalculateEntropy()
+  e0 = modelobj%entropy
+  print*,"Initial entropy: ",e0
+
+  call modelobj%SetTimeIntegrator(integrator)
+  call modelobj%ForwardStep(endtime,dt,iointerval)
+  ef = modelobj%entropy
+  print*,"Final entropy:   ",ef
+
+  call modelobj%solution%UpdateHost()
+  p_max_interior = 0.0_prec
+  do iel = 1,mesh%nElem
+    xmid = sum(mesh%nodeCoords(1,:,:,iel))/real(size(mesh%nodeCoords,2)*size(mesh%nodeCoords,3),prec)
+    if(xmid > x_interior_max) cycle
+    do j = 1,modelobj%solution%N+1
+      do i = 1,modelobj%solution%N+1
+        p_max_interior = max(p_max_interior,abs(modelobj%solution%interior(i,j,iel,4)))
+      enddo
+    enddo
+  enddo
+  print*,"Max |p| in interior at final time: ",p_max_interior
+  print*,"Residual ratio:                    ",p_max_interior/p_max_initial
+
+  if(ef /= ef) then
+    print*,"Error: final entropy is NaN ",ef
+    stop 1
+  endif
+  if(ef > e0) then
+    print*,"Error: final entropy exceeds initial entropy (PML should dissipate) ",e0,ef
+    stop 1
+  endif
+  if(p_max_interior > absorption_tol*p_max_initial) then
+    print*,"Error: PML failed to absorb the pulse. Residual = ", &
+      p_max_interior/p_max_initial," > tol = ",absorption_tol
+    stop 1
+  endif
+
+  call modelobj%free()
+  call mesh%free()
+  call geometry%free()
+  call interp%free()
+
+endprogram LinearEuler2D_PML_Absorption


### PR DESCRIPTION
## Summary
- New `LinearEuler2D_PML` model: Hu (2001) unsplit ADE-form PML extending the existing 2D linear-Euler model. Adds 4 auxiliary variables (`phi_rho`, `phi_u`, `phi_v`, `phi_P`; `nvar` 5 → 9) and per-node `sigma_x`, `sigma_y` damping fields. Interior dynamics are unchanged where `sigma = 0`.
- PML elements are tagged by material-name prefix (`pml*`) in `mesh%elemMaterial`, supporting both programmatic tagging on a `StructuredMesh` and HOHQMesh ISM-MM input.
- Full CPU + GPU (HIP / CUDA) parity: PML-aware Riemann, interior-flux, source, no-normal-flow, and radiation kernels.
- New `SetPMLProfile` API builds a polynomial sigma ramp from a user-supplied interior box, PML thickness, peak value, and ramp exponent.
- Reference doc, tutorial covering both the programmatic and HOHQMesh ISM-MM workflows, mkdocs nav entries.

## Test plan
- [x] CPU build (`cmake --build`) clean (gfortran, debug)
- [x] GPU container build (`self-dev-gpu` / AMD ROCm HIP) clean — kernels and Fortran wrappers compile
- [x] `ctest -R lineareuler2d_pml_absorption` passes (planar pulse, east-side PML, residual ratio 7.3e-8 ≪ 5% tolerance)
- [x] Existing LinearEuler2D / LinearShallowWater2D regression tests still pass with `WORKSPACE` set (failures otherwise are pre-existing mesh-path issues)
- [x] fprettify clean across `src/`, `test/`, `examples/` (zero diffs)
- [ ] Visualise `examples/linear_euler2d_pml_planewave` snapshots in PySELF/ParaView to confirm clean absorption

## Notes
- Sound speed `c` continues to live in `solution(:,:,:,5)` and is preserved across the parent → PML model — the impedance-matched Riemann solver works unchanged through PML interfaces.
- Auxiliary variables `phi_*` carry zero flux and must be initialised to zero by user IC code; the example and test both demonstrate this.
- `SELF_BC_PRESCRIBED` is not auto-registered for the PML model — users registering their own prescribed handler need to fill `extBoundary(:,:,:,6:9)` (zero is the natural choice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)