### PR TITLE
Feature/poststep hook

### DIFF
--- a/docs/Models/model-hooks.md
+++ b/docs/Models/model-hooks.md
@@ -1,0 +1,123 @@
+# Model Hooks
+
+SELF models expose a small set of **overridable hook methods** that let you
+inject custom work into the time-integration loop without modifying the
+integrators or the core tendency calculation. Every hook has a default
+no-op implementation on the base `Model` type, so overriding them is
+entirely optional and existing models are unaffected.
+
+You override a hook the same way you override any other type-bound
+procedure: by extending a concrete model type and binding your own
+implementation.
+
+## Available Hooks
+
+| Hook | When it fires | Cadence | Typical use |
+|------|---------------|---------|-------------|
+| `PreStepHook`     | Immediately **before** a time step is taken (before any Runge-Kutta stages) | Once per **time step** | Per-step setup; refresh quantities that are constant across the step |
+| `PreTendencyHook` | At the **start of every tendency evaluation** (`CalculateTendency`) | Once per **RK stage** (e.g. 3× per step for RK3) | Recompute derived fields the flux/source needs before each stage |
+| `PostStepHook`    | Immediately **after** a completed time step (after `t` advances by `dt`) | Once per **time step** | Record receiver samples, accumulate diagnostics, on-the-fly output |
+
+!!! note "Step vs. stage cadence"
+    `PreStepHook` and `PostStepHook` fire **once per time step**, while
+    `PreTendencyHook` fires **once per Runge-Kutta stage** — three times per
+    step for the default `rk3` integrator, five for `rk4`. Choose the hook
+    whose cadence matches your intent: use a step hook for work that should
+    happen once per step, and `PreTendencyHook` only for work the tendency
+    calculation depends on at every stage.
+
+## Where the hooks fire
+
+All four time integrators (`euler`, `rk2`, `rk3`, `rk4`) follow the same
+pattern. Schematically, a single step of the low-storage RK3 integrator is:
+
+```fortran
+do while(this%t < tn)
+  t0 = this%t
+  call this%PreStepHook()              ! <-- once per step (start)
+  do m = 1, 3
+    call this%CalculateTendency()      !     PreTendencyHook() fires inside,
+    call this%UpdateGRK3(m)            !     at the start of CalculateTendency
+    this%t = t0 + rk3_b(m)*this%dt
+  enddo
+  this%t = t0 + this%dt
+  call this%PostStepHook()             ! <-- once per step (end)
+enddo
+```
+
+`PreTendencyHook` is invoked from within each model's `CalculateTendency`
+(before the boundary exchange / flux / divergence work), so it runs once for
+every stage `m`.
+
+## Overriding a hook
+
+Bind your implementation in the `contains` block of your extended type:
+
+```fortran
+module my_model_module
+
+  use self_lineareuler2d
+
+  implicit none
+
+  type, extends(LinearEuler2D) :: my_model
+    ! ... your model data (e.g. receiver buffers) ...
+  contains
+    procedure :: PostStepHook => PostStepHook_my_model
+  endtype my_model
+
+contains
+
+  subroutine PostStepHook_my_model(this)
+    implicit none
+    class(my_model), intent(inout) :: this
+    ! ... per-step work, e.g. sample the device-resident solution ...
+  endsubroutine PostStepHook_my_model
+
+endmodule my_model_module
+```
+
+The hook receives the model instance (`class(Model)`-compatible) and is
+called automatically by the integrator — you do not call it yourself.
+
+## Why hooks instead of stepping manually
+
+A common reason to reach for a hook is **per-step receiver sampling or
+output**. It is tempting to drive the integrator one step at a time from the
+host:
+
+```fortran
+do k = 1, nsteps
+  call modelobj%ForwardStep(t + dt, dt, dt)   ! NOT recommended for this
+  ! ... sample here ...
+enddo
+```
+
+but `ForwardStep` performs the entropy diagnostic, metric reporting, and
+`WriteModel` file I/O on every interval — including device-to-host copies of
+the full solution — which is wasteful when you only want a few sampled
+values. Doing the work in `PostStepHook` keeps it **inside the native
+time-stepping loop**, so the bulk solution stays resident on the device and
+you copy back only what you need.
+
+```fortran
+subroutine PostStepHook_my_model(this)
+  implicit none
+  class(my_model), intent(inout) :: this
+  ! Interpolate the device-resident solution at receiver points (on device)
+  ! and copy back only the sampled values, not the whole field.
+  call this%receivers%EvaluateScalar(this%solution, this%rxvals_dev)
+  ! ... copy rxvals_dev -> host, store into a trace buffer ...
+endsubroutine PostStepHook_my_model
+```
+
+## Guidelines
+
+- **Keep hooks lightweight.** They run inside the time loop; expensive work
+  (especially host/device transfers) directly inflates runtime per step.
+- **Prefer device-resident operations.** Operate on the `*_gpu` buffers and
+  copy back only small, sampled quantities.
+- **Match the cadence.** Use `PreStepHook`/`PostStepHook` for once-per-step
+  work and `PreTendencyHook` for work the tendency depends on every stage.
+- **Hooks are optional.** The base-class defaults are no-ops; override only
+  the hooks you need.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,6 +41,7 @@ nav:
     - Linear Euler (2D) with PML : Models/linear-euler-2d-pml-model.md
     - Linear Euler (3D) : Models/linear-euler-3d-model.md
     - Linear Shallow Water (2D): Models/linear-shallow-water-model.md
+    - Model Hooks: Models/model-hooks.md
 #    - Generic DG Models: Models/generic-dg-models.md
   - Mesh Generation:
     - Overview: MeshGeneration/Overview.md
@@ -99,7 +100,6 @@ markdown_extensions:
 
 extra_javascript:
   - javascripts/mathjax.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
 
 

--- a/src/SELF_DGModel1D_t.f90
+++ b/src/SELF_DGModel1D_t.f90
@@ -529,7 +529,7 @@ contains
     call this%solution%BoundaryInterp()
     call this%solution%SideExchange(this%mesh)
 
-    call this%PreTendency() ! User-supplied
+    call this%PreTendencyHook() ! User-supplied
     call this%SetBoundaryCondition() ! User-supplied
 
     if(this%gradient_enabled) then

--- a/src/SELF_DGModel2D_t.f90
+++ b/src/SELF_DGModel2D_t.f90
@@ -571,7 +571,7 @@ contains
     call this%solution%BoundaryInterp()
     call this%solution%SideExchange(this%mesh)
 
-    call this%PreTendency() ! User-supplied
+    call this%PreTendencyHook() ! User-supplied
     call this%SetBoundaryCondition() ! User-supplied
 
     if(this%gradient_enabled) then

--- a/src/SELF_DGModel3D_t.f90
+++ b/src/SELF_DGModel3D_t.f90
@@ -562,7 +562,7 @@ contains
     call this%solution%BoundaryInterp()
     call this%solution%SideExchange(this%mesh)
 
-    call this%PreTendency() ! User-supplied
+    call this%PreTendencyHook() ! User-supplied
     call this%SetBoundaryCondition() ! User-supplied
 
     if(this%gradient_enabled) then

--- a/src/SELF_ECDGModel2D_t.f90
+++ b/src/SELF_ECDGModel2D_t.f90
@@ -182,7 +182,7 @@ contains
     call this%solution%BoundaryInterp()
     call this%solution%SideExchange(this%mesh)
 
-    call this%PreTendency()
+    call this%PreTendencyHook()
     call this%SetBoundaryCondition()
 
     if(this%gradient_enabled) then

--- a/src/SELF_ECDGModel3D_t.f90
+++ b/src/SELF_ECDGModel3D_t.f90
@@ -162,7 +162,7 @@ contains
     call this%solution%BoundaryInterp()
     call this%solution%SideExchange(this%mesh)
 
-    call this%PreTendency()
+    call this%PreTendencyHook()
     call this%SetBoundaryCondition()
 
     if(this%gradient_enabled) then

--- a/src/SELF_ESAtmo2D_t.f90
+++ b/src/SELF_ESAtmo2D_t.f90
@@ -716,7 +716,7 @@ contains
     call this%solution%BoundaryInterp()
     call this%solution%SideExchange(this%mesh)
 
-    call this%PreTendency()
+    call this%PreTendencyHook()
     call this%SetBoundaryCondition()
 
     if(this%gradient_enabled) then

--- a/src/SELF_ESAtmo3D_t.f90
+++ b/src/SELF_ESAtmo3D_t.f90
@@ -802,7 +802,7 @@ contains
     call this%solution%BoundaryInterp()
     call this%solution%SideExchange(this%mesh)
 
-    call this%PreTendency()
+    call this%PreTendencyHook()
     call this%SetBoundaryCondition()
 
     if(this%gradient_enabled) then

--- a/src/SELF_Model.f90
+++ b/src/SELF_Model.f90
@@ -137,6 +137,7 @@ module SELF_Model
     procedure(UpdateGRK),deferred :: UpdateGRK4
 
     procedure :: PreTendency => PreTendency_Model
+    procedure :: PostStepHook => PostStepHook_Model
     procedure :: entropy_func => entropy_func_Model
 
     procedure :: flux1D => flux1d_Model
@@ -295,6 +296,23 @@ contains
     if(.false.) this%nvar = this%nvar ! suppress unused-dummy-argument warning
 
   endsubroutine PreTendency_Model
+
+  subroutine PostStepHook_Model(this)
+    !! PostStepHook is a template routine invoked by the time integrators once
+    !! immediately after each completed time step (after this%t has advanced by
+    !! this%dt). The default implementation is a no-op.
+    !!
+    !! Override through type-extension to perform lightweight per-step work that
+    !! must stay inside the native time-stepping loop -- e.g. recording receiver
+    !! samples from a device-resident solution -- without driving the integrator
+    !! one step at a time from the host (which would otherwise incur the
+    !! entropy/diagnostic device-to-host copies of ForwardStep).
+    implicit none
+    class(Model),intent(inout) :: this
+
+    if(.false.) this%nvar = this%nvar ! suppress unused-dummy-argument warning
+
+  endsubroutine PostStepHook_Model
 
   pure function entropy_func_Model(this,s) result(e)
     class(Model),intent(in) :: this
@@ -648,6 +666,7 @@ contains
       call this%CalculateTendency()
       call this%UpdateSolution()
       this%t = this%t+this%dt
+      call this%PostStepHook()
 
     enddo
 
@@ -678,6 +697,7 @@ contains
       enddo
 
       this%t = t0+this%dt
+      call this%PostStepHook()
 
     enddo
 
@@ -708,6 +728,7 @@ contains
       enddo
 
       this%t = t0+this%dt
+      call this%PostStepHook()
 
     enddo
 
@@ -738,6 +759,7 @@ contains
       enddo
 
       this%t = t0+this%dt
+      call this%PostStepHook()
 
     enddo
 

--- a/src/SELF_Model.f90
+++ b/src/SELF_Model.f90
@@ -136,7 +136,8 @@ module SELF_Model
     procedure :: LowStorageRK4_timeIntegrator
     procedure(UpdateGRK),deferred :: UpdateGRK4
 
-    procedure :: PreTendency => PreTendency_Model
+    procedure :: PreTendencyHook => PreTendencyHook_Model
+    procedure :: PreStepHook => PreStepHook_Model
     procedure :: PostStepHook => PostStepHook_Model
     procedure :: entropy_func => entropy_func_Model
 
@@ -282,10 +283,10 @@ contains
 
   endsubroutine PrintType_Model
 
-  subroutine PreTendency_Model(this)
-    !! PreTendency is a template routine that is used to house any additional calculations
+  subroutine PreTendencyHook_Model(this)
+    !! PreTendencyHook is a template routine that is used to house any additional calculations
     !! that you want to execute at the beginning of the tendency calculation routine.
-    !! This default PreTendency simply returns back to the caller without executing any instructions
+    !! This default PreTendencyHook simply returns back to the caller without executing any instructions
     !!
     !! The intention is to provide a method that can be overridden through type-extension, to handle
     !! any steps that need to be executed before proceeding with the usual tendency calculation methods.
@@ -295,7 +296,24 @@ contains
 
     if(.false.) this%nvar = this%nvar ! suppress unused-dummy-argument warning
 
-  endsubroutine PreTendency_Model
+  endsubroutine PreTendencyHook_Model
+
+  subroutine PreStepHook_Model(this)
+    !! PreStepHook is a template routine invoked by the time integrators once
+    !! immediately before each time step is taken (before any Runge-Kutta
+    !! stages of that step). The default implementation is a no-op.
+    !!
+    !! This differs from PreTendencyHook, which runs at the start of every
+    !! tendency evaluation (i.e. once per RK stage). PreStepHook fires exactly
+    !! once per step, symmetric with PostStepHook. Override through
+    !! type-extension for lightweight per-step setup that must stay inside the
+    !! native time-stepping loop.
+    implicit none
+    class(Model),intent(inout) :: this
+
+    if(.false.) this%nvar = this%nvar ! suppress unused-dummy-argument warning
+
+  endsubroutine PreStepHook_Model
 
   subroutine PostStepHook_Model(this)
     !! PostStepHook is a template routine invoked by the time integrators once
@@ -661,6 +679,7 @@ contains
     dtLim = this%dt ! Get the max time step size from the dt attribute
     do while(this%t < tn)
 
+      call this%PreStepHook()
       tRemain = tn-this%t
       this%dt = min(dtLim,tRemain)
       call this%CalculateTendency()
@@ -688,6 +707,7 @@ contains
     do while(this%t < tn)
 
       t0 = this%t
+      call this%PreStepHook()
       tRemain = tn-this%t
       this%dt = min(dtLim,tRemain)
       do m = 1,2
@@ -719,6 +739,7 @@ contains
     do while(this%t < tn)
 
       t0 = this%t
+      call this%PreStepHook()
       tRemain = tn-this%t
       this%dt = min(dtLim,tRemain)
       do m = 1,3
@@ -750,6 +771,7 @@ contains
     do while(this%t < tn)
 
       t0 = this%t
+      call this%PreStepHook()
       tRemain = tn-this%t
       this%dt = min(dtLim,tRemain)
       do m = 1,5

--- a/src/SELF_NullDGModel1D_t.f90
+++ b/src/SELF_NullDGModel1D_t.f90
@@ -108,10 +108,10 @@ contains
 
   ! endfunction riemannflux1d_NullDGModel1D_t
 
-  ! subroutine PreTendency_NulDGModel1D_t(this)
-  ! !! PreTendency is a template routine that is used to house any additional calculations
+  ! subroutine PreTendencyHook_NulDGModel1D_t(this)
+  ! !! PreTendencyHook is a template routine that is used to house any additional calculations
   ! !! that you want to execute at the beginning of the tendency calculation routine.
-  ! !! This default PreTendency simply returns back to the caller without executing any instructions
+  ! !! This default PreTendencyHook simply returns back to the caller without executing any instructions
   ! !!
   ! !! The intention is to provide a method that can be overridden through type-extension, to handle
   ! !! any steps that need to be executed before proceeding with the usual tendency calculation methods.
@@ -121,7 +121,7 @@ contains
 
   !   return
 
-  ! endsubroutine PreTendency_NulDGModel1D_t
+  ! endsubroutine PreTendencyHook_NulDGModel1D_t
 
   ! pure function source1d_NullDGModel1D_t(this,s,dsdx) result(source)
   !   class(NullDGModel1D_t),intent(in) :: this

--- a/src/SELF_NullDGModel2D_t.f90
+++ b/src/SELF_NullDGModel2D_t.f90
@@ -133,10 +133,10 @@ contains
 
   ! endfunction riemannflux2d_NullDGModel2D_t
 
-  ! subroutine PreTendency_NulDGModel2D_t(this)
-  ! !! PreTendency is a template routine that is used to house any additional calculations
+  ! subroutine PreTendencyHook_NulDGModel2D_t(this)
+  ! !! PreTendencyHook is a template routine that is used to house any additional calculations
   ! !! that you want to execute at the beginning of the tendency calculation routine.
-  ! !! This default PreTendency simply returns back to the caller without executing any instructions
+  ! !! This default PreTendencyHook simply returns back to the caller without executing any instructions
   ! !!
   ! !! The intention is to provide a method that can be overridden through type-extension, to handle
   ! !! any steps that need to be executed before proceeding with the usual tendency calculation methods.
@@ -146,7 +146,7 @@ contains
 
   !   return
 
-  ! endsubroutine PreTendency_NulDGModel2D_t
+  ! endsubroutine PreTendencyHook_NulDGModel2D_t
 
   ! pure function source2d_NullDGModel2D_t(this,s,dsdx) result(source)
   !   class(NullDGModel2D_t),intent(in) :: this

--- a/src/SELF_NullDGModel3D_t.f90
+++ b/src/SELF_NullDGModel3D_t.f90
@@ -133,10 +133,10 @@ contains
 
   ! endfunction riemannflux3d_NullDGModel3D_t
 
-  ! subroutine PreTendency_NulDGModel3D_t(this)
-  ! !! PreTendency is a template routine that is used to house any additional calculations
+  ! subroutine PreTendencyHook_NulDGModel3D_t(this)
+  ! !! PreTendencyHook is a template routine that is used to house any additional calculations
   ! !! that you want to execute at the beginning of the tendency calculation routine.
-  ! !! This default PreTendency simply returns back to the caller without executing any instructions
+  ! !! This default PreTendencyHook simply returns back to the caller without executing any instructions
   ! !!
   ! !! The intention is to provide a method that can be overridden through type-extension, to handle
   ! !! any steps that need to be executed before proceeding with the usual tendency calculation methods.
@@ -146,7 +146,7 @@ contains
 
   !   return
 
-  ! endsubroutine PreTendency_NulDGModel3D_t
+  ! endsubroutine PreTendencyHook_NulDGModel3D_t
 
   ! pure function source3d_NullDGModel3D_t(this,s,dsdx) result(source)
   !   class(NullDGModel3D_t),intent(in) :: this

--- a/src/gpu/SELF_DGModel1D.f90
+++ b/src/gpu/SELF_DGModel1D.f90
@@ -404,7 +404,7 @@ contains
     call this%solution%BoundaryInterp()
     call this%solution%SideExchange(this%mesh)
 
-    call this%PreTendency() ! User-supplied
+    call this%PreTendencyHook() ! User-supplied
     call this%SetBoundaryCondition() ! User-supplied
 
     if(this%gradient_enabled) then

--- a/src/gpu/SELF_DGModel2D.f90
+++ b/src/gpu/SELF_DGModel2D.f90
@@ -377,7 +377,7 @@ contains
     call this%solution%BoundaryInterp()
     call this%solution%SideExchange(this%mesh)
 
-    call this%PreTendency() ! User-supplied
+    call this%PreTendencyHook() ! User-supplied
     call this%SetBoundaryCondition() ! User-supplied
 
     if(this%gradient_enabled) then

--- a/src/gpu/SELF_DGModel3D.f90
+++ b/src/gpu/SELF_DGModel3D.f90
@@ -378,7 +378,7 @@ contains
     call this%solution%BoundaryInterp()
     call this%solution%SideExchange(this%mesh)
 
-    call this%PreTendency() ! User-supplied
+    call this%PreTendencyHook() ! User-supplied
     call this%SetBoundaryCondition() ! User-supplied
 
     if(this%gradient_enabled) then

--- a/src/gpu/SELF_ECDGModel2D.f90
+++ b/src/gpu/SELF_ECDGModel2D.f90
@@ -58,7 +58,7 @@ contains
     call this%solution%BoundaryInterp()
     call this%solution%SideExchange(this%mesh)
 
-    call this%PreTendency()
+    call this%PreTendencyHook()
     call this%SetBoundaryCondition()
 
     if(this%gradient_enabled) then

--- a/src/gpu/SELF_ECDGModel3D.f90
+++ b/src/gpu/SELF_ECDGModel3D.f90
@@ -52,7 +52,7 @@ contains
     call this%solution%BoundaryInterp()
     call this%solution%SideExchange(this%mesh)
 
-    call this%PreTendency()
+    call this%PreTendencyHook()
     call this%SetBoundaryCondition()
 
     if(this%gradient_enabled) then

--- a/src/gpu/SELF_ESAtmo2D.f90
+++ b/src/gpu/SELF_ESAtmo2D.f90
@@ -375,7 +375,7 @@ contains
     call this%solution%BoundaryInterp()
     call this%solution%SideExchange(this%mesh)
 
-    call this%PreTendency()
+    call this%PreTendencyHook()
     call this%SetBoundaryCondition()
 
     if(this%gradient_enabled) then

--- a/src/gpu/SELF_ESAtmo3D.f90
+++ b/src/gpu/SELF_ESAtmo3D.f90
@@ -389,7 +389,7 @@ contains
     call this%solution%BoundaryInterp()
     call this%solution%SideExchange(this%mesh)
 
-    call this%PreTendency()
+    call this%PreTendencyHook()
     call this%SetBoundaryCondition()
 
     if(this%gradient_enabled) then


### PR DESCRIPTION
## Summary

Adds three overridable, type-bound model hooks to the abstract `Model` type so derived models can run per-step / per-stage work inside the native time-stepping loop without modifying the integrators. All hooks default to no-ops, so existing models are unaffected.

| Hook | Cadence | Default |
|------|---------|---------|
| `PreStepHook` | once per time step, before the RK stages | no-op |
| `PreTendencyHook` | once per tendency evaluation (each RK stage) | no-op |
| `PostStepHook` | once per time step, after `this%t` advances by `this%dt` | no-op |

`PreStepHook` and `PostStepHook` fire in all four integrators (`euler`, low-storage `rk2`, `rk3`, `rk4`). `PreTendencyHook` is the former `PreTendency` hook, renamed for a consistent `Hook` suffix across all three (unchanged in behavior otherwise).

## Motivation

Per-step work — e.g. recording off-grid receiver samples from a device-resident solution — should run inside the native stepping loop. The alternative, driving the integrator one step at a time from the host via `ForwardStep`, forces the entropy/diagnostic and `WriteModel` device-to-host copies every step, which is unnecessary and slow for a GPU-resident model. Overriding `PostStepHook` lets a derived model do that work without touching the integrators or paying the `ForwardStep` diagnostic overhead.

## Changes

- `src/SELF_Model.f90`: add `PreStepHook` / `PostStepHook`, rename `PreTendency` → `PreTendencyHook`, wire all three into the integrators.
- Propagate the `PreTendency` → `PreTendencyHook` rename through the DG / ECDG / ESAtmo model types (1D/2D/3D, CPU and GPU) and the Null models.
- `docs/Models/model-hooks.md`: new page documenting the hooks, their cadence, and the type-extension override pattern; added to the Models nav.
- `mkdocs.yml`: drop the `polyfill.io` script (sold domain that served malware in the 2024 supply-chain incident; MathJax 3 needs no es6 polyfill on supported browsers).

## Compatibility

The rename of `PreTendency` → `PreTendencyHook` changes a public type-bound procedure name. Models that override `PreTendency` must update to the new name; all in-tree models are updated in this PR.
