### PR TITLE
Add nstepped: exclude auxiliary variables from time integration

### DIFF
--- a/src/SELF_DGModel2D_t.f90
+++ b/src/SELF_DGModel2D_t.f90
@@ -100,6 +100,11 @@ contains
     this%geometry => geometry
     call this%SetNumberOfVariables()
 
+    ! Default the number of time-stepped variables to nvar. Models that carry
+    ! auxiliary/diagnostic variables may set this%nstepped < nvar inside
+    ! SetNumberOfVariables to exclude the trailing variables from time integration.
+    if(this%nstepped <= 0 .or. this%nstepped > this%nvar) this%nstepped = this%nvar
+
     call this%solution%Init(geometry%x%interp,this%nvar,this%mesh%nElem)
     call this%workSol%Init(geometry%x%interp,this%nvar,this%mesh%nElem)
     call this%dSdt%Init(geometry%x%interp,this%nvar,this%mesh%nElem)
@@ -247,7 +252,7 @@ contains
     endif
 
     do concurrent(i=1:this%solution%N+1,j=1:this%solution%N+1, &
-                  iel=1:this%mesh%nElem,ivar=1:this%solution%nVar)
+                  iel=1:this%mesh%nElem,ivar=1:this%nstepped)
 
       this%solution%interior(i,j,iEl,iVar) = &
         this%solution%interior(i,j,iEl,iVar)+ &
@@ -265,7 +270,7 @@ contains
     integer :: i,j,iEl,iVar
 
     do concurrent(i=1:this%solution%N+1,j=1:this%solution%N+1, &
-                  iel=1:this%mesh%nElem,ivar=1:this%solution%nVar)
+                  iel=1:this%mesh%nElem,ivar=1:this%nstepped)
 
       this%workSol%interior(i,j,iEl,iVar) = rk2_a(m)* &
                                             this%workSol%interior(i,j,iEl,iVar)+ &
@@ -287,7 +292,7 @@ contains
     integer :: i,j,iEl,iVar
 
     do concurrent(i=1:this%solution%N+1,j=1:this%solution%N+1, &
-                  iel=1:this%mesh%nElem,ivar=1:this%solution%nVar)
+                  iel=1:this%mesh%nElem,ivar=1:this%nstepped)
 
       this%workSol%interior(i,j,iEl,iVar) = rk3_a(m)* &
                                             this%workSol%interior(i,j,iEl,iVar)+ &
@@ -309,7 +314,7 @@ contains
     integer :: i,j,iEl,iVar
 
     do concurrent(i=1:this%solution%N+1,j=1:this%solution%N+1, &
-                  iel=1:this%mesh%nElem,ivar=1:this%solution%nVar)
+                  iel=1:this%mesh%nElem,ivar=1:this%nstepped)
 
       this%workSol%interior(i,j,iEl,iVar) = rk4_a(m)* &
                                             this%workSol%interior(i,j,iEl,iVar)+ &

--- a/src/SELF_LinearEuler2D_t.f90
+++ b/src/SELF_LinearEuler2D_t.f90
@@ -91,6 +91,11 @@ contains
     class(LinearEuler2D_t),intent(inout) :: this
 
     this%nvar = 5
+    ! Only the first four variables (rho, u, v, P) are advanced in time. The
+    ! fifth variable, the sound speed c, is a spatially-varying but
+    ! time-constant background field: its flux and source are identically zero,
+    ! so it is excluded from time integration rather than stepped to a no-op.
+    this%nstepped = 4
 
   endsubroutine SetNumberOfVariables_LinearEuler2D_t
 

--- a/src/SELF_Model.f90
+++ b/src/SELF_Model.f90
@@ -107,6 +107,12 @@ module SELF_Model
     logical :: prescribed_bcs_enabled = .true.
     logical :: tecplot_enabled = .true.
     integer :: nvar
+    ! Number of leading prognostic variables that are advanced in time by the
+    ! time integrator. Variables (nstepped+1:nvar) are auxiliary/diagnostic
+    ! state that is carried in `solution` (e.g. a spatially-varying, time-constant
+    ! sound speed) but never forward-stepped. Defaulted to nvar in the model
+    ! Init, so models that do not set it behave exactly as before.
+    integer :: nstepped = 0
     ! Standard Diagnostics
     real(prec) :: entropy ! Mathematical entropy function for the model
 

--- a/src/gpu/SELF_DGModel2D.f90
+++ b/src/gpu/SELF_DGModel2D.f90
@@ -75,7 +75,7 @@ contains
     else
       dtLoc = this%dt
     endif
-    ndof = this%solution%nvar* &
+    ndof = this%nstepped* &
            this%solution%nelem* &
            (this%solution%interp%N+1)* &
            (this%solution%interp%N+1)
@@ -91,7 +91,7 @@ contains
     ! Local
     integer :: ndof
 
-    ndof = this%solution%nvar* &
+    ndof = this%nstepped* &
            this%solution%nelem* &
            (this%solution%interp%N+1)* &
            (this%solution%interp%N+1)
@@ -108,7 +108,7 @@ contains
     ! Local
     integer :: ndof
 
-    ndof = this%solution%nvar* &
+    ndof = this%nstepped* &
            this%solution%nelem* &
            (this%solution%interp%N+1)* &
            (this%solution%interp%N+1)
@@ -125,7 +125,7 @@ contains
     ! Local
     integer :: ndof
 
-    ndof = this%solution%nvar* &
+    ndof = this%nstepped* &
            this%solution%nelem* &
            (this%solution%interp%N+1)* &
            (this%solution%interp%N+1)


### PR DESCRIPTION
## Summary

Adds `Model % nstepped` — the number of leading prognostic variables advanced by the time integrator. Variables `(nstepped+1 : nvar)` are **auxiliary/diagnostic** state carried in `solution` but never forward-stepped.

This is the mechanism behind *"don't waste compute forward-stepping things like the sound speed."* `LinearEuler2D` carries a spatially-varying sound speed `c` as its 5th solution variable; this PR marks the first 4 (`rho, u, v, P`) as stepped and leaves `c` as fixed background state.

## What changed

- **`SELF_Model.f90`** — new `integer :: nstepped = 0` on the abstract `Model` type, documented.
- **`SELF_DGModel2D_t.f90`** — `Init` clamps/defaults `nstepped` to `nvar` (so every existing model is unchanged); the CPU `UpdateSolution` and `UpdateGRK2/3/4` loops iterate `ivar = 1:nstepped`.
- **`gpu/SELF_DGModel2D.f90`** — the GPU `UpdateSolution`/`UpdateGRK2/3/4` `ndof` is bounded by `nstepped`.
- **`SELF_LinearEuler2D_t.f90`** — sets `nstepped = 4` (keeps `nvar = 5`).

## Why it's numerically safe (bit-identical)

The flux-divergence and `dSdt` computations are intentionally left **full-width**, so all diagnostic arrays (Tecplot output, etc.) remain fully defined.

For `LinearEuler2D`, the sound-speed flux (interior and boundary) is hardwired to `0`. A zero flux field passed through the DG derivative/boundary operators yields an **exact** zero divergence (no round-off), so `dSdt[c] ≡ 0` and `c += dt·0 = c`. The sound speed was therefore *already* held constant bit-for-bit — excluding it from integration produces identical output while skipping the no-op work.

For all other models, `nstepped == nvar`, so the loops are unchanged.

## Scope / follow-ups

- This is the **safe core** (2D + `LinearEuler2D`). The base-type `nstepped` is general; the `Init` default + integrator bounding currently live in the 2D path. 1D/3D follow the identical pattern and can be wired the same way.
- A further optimization — skipping the **flux-divergence kernel** itself for auxiliary variables — is deliberately *not* in this PR. The shared GPU divergence kernels use `nvar` as both the loop count and the storage stride between the x/y flux components, so that change requires either sizing the flux arrays to `nstepped` or decoupling stride from loop-count in shared numerical kernels. Worth a separate, independently-reviewed PR.

## Testing

Relying on CI regression tests. Expectation: bit-for-bit identical results for `LinearEuler2D` (and all other models), per the argument above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)