### PR TITLE
Add single-precision and MI300X variants to docker-publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -30,6 +30,22 @@ jobs:
             context: docker/x86_sm100
             selfish_image: higherordermethods/selfish:latest-x86-cuda130-sm100
             tag_suffix: x86-cuda130-sm100
+            double_precision: "ON"
+          - variant: x86-cuda130-sm100-sp
+            context: docker/x86_sm100
+            selfish_image: higherordermethods/selfish:latest-x86-cuda130-sm100
+            tag_suffix: x86-cuda130-sm100-sp
+            double_precision: "OFF"
+          - variant: x86-rocm643-gfx942
+            context: docker/x86_gfx942
+            selfish_image: higherordermethods/selfish:latest-x86-rocm643-gfx942
+            tag_suffix: x86-rocm643-gfx942
+            double_precision: "ON"
+          - variant: x86-rocm643-gfx942-sp
+            context: docker/x86_gfx942
+            selfish_image: higherordermethods/selfish:latest-x86-rocm643-gfx942
+            tag_suffix: x86-rocm643-gfx942-sp
+            double_precision: "OFF"
 
     steps:
       - name: Checkout repository
@@ -70,5 +86,6 @@ jobs:
           build-args: |
             SELFISH_IMAGE=${{ matrix.selfish_image }}
             SELFISH_SHA=${{ steps.selfish.outputs.sha }}
+            SELF_DOUBLE_PRECISION=${{ matrix.double_precision }}
           cache-from: type=registry,ref=${{ env.REGISTRY_IMAGE }}:buildcache-${{ matrix.tag_suffix }}
           cache-to: type=registry,ref=${{ env.REGISTRY_IMAGE }}:buildcache-${{ matrix.tag_suffix }},mode=max

--- a/docker/x86_gfx942/Dockerfile
+++ b/docker/x86_gfx942/Dockerfile
@@ -1,4 +1,4 @@
-ARG SELFISH_IMAGE=higherordermethods/selfish:latest-x86-cuda130-sm100
+ARG SELFISH_IMAGE=higherordermethods/selfish:latest-x86-rocm643-gfx942
 FROM ${SELFISH_IMAGE}
 
 ARG SELFISH_SHA=""
@@ -18,10 +18,11 @@ RUN source /opt/spack-environment/activate.sh && \
       -DCMAKE_INSTALL_PREFIX=/opt/self/install \
       -DCMAKE_BUILD_TYPE=Release \
       -DSELF_ENABLE_GPU=ON \
-      -DSELF_GPU_BACKEND=CUDA \
+      -DSELF_GPU_BACKEND=HIP \
       -DSELF_ENABLE_TESTING=ON \
       -DSELF_ENABLE_DOUBLE_PRECISION=${SELF_DOUBLE_PRECISION} \
-      -DCMAKE_CUDA_ARCHITECTURES="100" \
+      -DCMAKE_HIP_ARCHITECTURES="gfx942" \
+      -DGPU_TARGETS="gfx942" \
       -DSELF_ENABLE_EXAMPLES=ON \
       /opt/self/src && \
     make -j$(nproc) && \


### PR DESCRIPTION
## Summary

Extends the GitHub Actions `docker-publish` workflow so each published image is offered in **both single and double precision**, and adds **MI300X (gfx942)** as a new published target.

The published-tag matrix becomes:

| variant | precision | tag |
|---|---|---|
| `x86-cuda130-sm100` | double | `latest-x86-cuda130-sm100` *(unchanged)* |
| `x86-cuda130-sm100-sp` | single | `latest-x86-cuda130-sm100-sp` *(new)* |
| `x86-rocm643-gfx942` | double | `latest-x86-rocm643-gfx942` *(new)* |
| `x86-rocm643-gfx942-sp` | single | `latest-x86-rocm643-gfx942-sp` *(new)* |

(Each also gets the corresponding `<sha>-…` tag.)

## Changes

- **`docker/x86_sm100/Dockerfile`**, **`docker/x86_gfx942/Dockerfile`** — add a `SELF_DOUBLE_PRECISION` build-arg (default `ON`) wired to the existing `SELF_ENABLE_DOUBLE_PRECISION` CMake option, so one Dockerfile builds either precision.
- **`docker/x86_gfx942/Dockerfile`** — new file, modeled on the existing `x86_gfx90a` (MI210) Dockerfile, targeting `gfx942` via the `latest-x86-rocm643-gfx942` selfish base image (verified present on Docker Hub).
- **`.github/workflows/docker-publish.yml`** — pass `SELF_DOUBLE_PRECISION` through `build-args` and add the four matrix entries.

## Notes / backward compatibility

- The existing `latest-x86-cuda130-sm100` tag keeps its name and stays double precision — purely additive. Single precision uses the `-sp` suffix.
- Each variant keeps a separate `buildcache-<tag_suffix>` cache tag, so no cache collisions; all four build in parallel (`fail-fast: false`).
- **No on-GPU testing:** like the existing sm100 build, these compile on a GPU-less `ubuntu-22.04` runner. The Buildkite pipeline remains the path that build+tests AMD images on real hardware (MI210). The gfx942 image is built but not exercised on an MI300X here.
- Naming follows the existing `x86-rocm643-gfx90a` convention rather than an `mi300x` alias, for consistency across the GHA and Buildkite pipelines.

## Verification

The workflow only triggers on push to `main` / `workflow_dispatch`, so this PR won't exercise it. After merge, recommend a manual `workflow_dispatch` run to confirm the two new AMD builds pull the gfx942 base and compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)