### PR TITLE
Fix int32 overflow in GPU work-array allocation sizes

### DIFF
--- a/src/gpu/SELF_MappedScalar_2D.f90
+++ b/src/gpu/SELF_MappedScalar_2D.f90
@@ -111,9 +111,9 @@ contains
     call gpuCheck(hipMalloc(this%extBoundary_gpu,sizeof(this%extBoundary)))
     call gpuCheck(hipMalloc(this%avgBoundary_gpu,sizeof(this%avgBoundary)))
     call gpuCheck(hipMalloc(this%boundarynormal_gpu,sizeof(this%boundarynormal)))
-    workSize = (interp%N+1)*(interp%M+1)*nelem*nvar*prec
+    workSize = int(interp%N+1,c_size_t)*(interp%M+1)*nelem*nvar*prec
     call gpuCheck(hipMalloc(this%interpWork,workSize))
-    workSize = (interp%N+1)*(interp%N+1)*nelem*nvar*4*prec
+    workSize = int(interp%N+1,c_size_t)*(interp%N+1)*nelem*nvar*4*prec
     call gpuCheck(hipMalloc(this%jas_gpu,workSize))
 
     call hipblasCheck(hipblasCreate(this%blas_handle))

--- a/src/gpu/SELF_MappedScalar_3D.f90
+++ b/src/gpu/SELF_MappedScalar_3D.f90
@@ -111,11 +111,11 @@ contains
     call gpuCheck(hipMalloc(this%extBoundary_gpu,sizeof(this%extBoundary)))
     call gpuCheck(hipMalloc(this%avgBoundary_gpu,sizeof(this%avgBoundary)))
     call gpuCheck(hipMalloc(this%boundarynormal_gpu,sizeof(this%boundarynormal)))
-    workSize = (interp%N+1)*(interp%N+1)*(interp%M+1)*nelem*nvar*prec
+    workSize = int(interp%N+1,c_size_t)*(interp%N+1)*(interp%M+1)*nelem*nvar*prec
     call gpuCheck(hipMalloc(this%interpWork1,workSize))
-    workSize = (interp%N+1)*(interp%M+1)*(interp%M+1)*nelem*nvar*prec
+    workSize = int(interp%N+1,c_size_t)*(interp%M+1)*(interp%M+1)*nelem*nvar*prec
     call gpuCheck(hipMalloc(this%interpWork2,workSize))
-    workSize = (interp%N+1)*(interp%N+1)*(interp%N+1)*nelem*nvar*9*prec
+    workSize = int(interp%N+1,c_size_t)*(interp%N+1)*(interp%N+1)*nelem*nvar*9*prec
     call gpuCheck(hipMalloc(this%jas_gpu,workSize))
 
     call this%UpdateDevice()

--- a/src/gpu/SELF_Scalar_2D.f90
+++ b/src/gpu/SELF_Scalar_2D.f90
@@ -99,7 +99,7 @@ contains
     call gpuCheck(hipMalloc(this%extBoundary_gpu,sizeof(this%extBoundary)))
     call gpuCheck(hipMalloc(this%avgBoundary_gpu,sizeof(this%avgBoundary)))
     call gpuCheck(hipMalloc(this%boundarynormal_gpu,sizeof(this%boundarynormal)))
-    workSize = (interp%N+1)*(interp%M+1)*nelem*nvar*prec
+    workSize = int(interp%N+1,c_size_t)*(interp%M+1)*nelem*nvar*prec
     call gpuCheck(hipMalloc(this%interpWork,workSize))
 
     call this%UpdateDevice()

--- a/src/gpu/SELF_Scalar_3D.f90
+++ b/src/gpu/SELF_Scalar_3D.f90
@@ -100,9 +100,9 @@ contains
     call gpuCheck(hipMalloc(this%extBoundary_gpu,sizeof(this%extBoundary)))
     call gpuCheck(hipMalloc(this%avgBoundary_gpu,sizeof(this%avgBoundary)))
     call gpuCheck(hipMalloc(this%boundarynormal_gpu,sizeof(this%boundarynormal)))
-    workSize = (interp%N+1)*(interp%N+1)*(interp%M+1)*nelem*nvar*prec
+    workSize = int(interp%N+1,c_size_t)*(interp%N+1)*(interp%M+1)*nelem*nvar*prec
     call gpuCheck(hipMalloc(this%interpWork1,workSize))
-    workSize = (interp%N+1)*(interp%M+1)*(interp%M+1)*nelem*nvar*prec
+    workSize = int(interp%N+1,c_size_t)*(interp%M+1)*(interp%M+1)*nelem*nvar*prec
     call gpuCheck(hipMalloc(this%interpWork2,workSize))
 
     call this%UpdateDevice()

--- a/src/gpu/SELF_Vector_2D.f90
+++ b/src/gpu/SELF_Vector_2D.f90
@@ -116,7 +116,7 @@ contains
     call gpuCheck(hipMalloc(this%extBoundary_gpu,sizeof(this%extBoundary)))
     call gpuCheck(hipMalloc(this%avgBoundary_gpu,sizeof(this%avgBoundary)))
     call gpuCheck(hipMalloc(this%boundaryNormal_gpu,sizeof(this%boundaryNormal)))
-    workSize = (interp%N+1)*(interp%M+1)*nelem*nvar*2*prec
+    workSize = int(interp%N+1,c_size_t)*(interp%M+1)*nelem*nvar*2*prec
     call gpuCheck(hipMalloc(this%interpWork,workSize))
 
     call this%UpdateDevice()

--- a/src/gpu/SELF_Vector_3D.f90
+++ b/src/gpu/SELF_Vector_3D.f90
@@ -120,9 +120,9 @@ contains
     call gpuCheck(hipMalloc(this%extBoundary_gpu,sizeof(this%extBoundary)))
     call gpuCheck(hipMalloc(this%avgBoundary_gpu,sizeof(this%avgBoundary)))
     call gpuCheck(hipMalloc(this%boundaryNormal_gpu,sizeof(this%boundaryNormal)))
-    workSize = (interp%N+1)*(interp%N+1)*(interp%M+1)*nelem*nvar*3*prec
+    workSize = int(interp%N+1,c_size_t)*(interp%N+1)*(interp%M+1)*nelem*nvar*3*prec
     call gpuCheck(hipMalloc(this%interpWork1,workSize))
-    workSize = (interp%N+1)*(interp%M+1)*(interp%M+1)*nelem*nvar*3*prec
+    workSize = int(interp%N+1,c_size_t)*(interp%M+1)*(interp%M+1)*nelem*nvar*3*prec
     call gpuCheck(hipMalloc(this%interpWork2,workSize))
 
     call this%UpdateDevice()


### PR DESCRIPTION
## Summary

The byte-count expressions assigned to the `c_size_t` variable `workSize` in the GPU container `Init` routines were evaluated entirely in default `integer` (int32) arithmetic before being widened on assignment. Once the product `(N+1)*...*nelem*nvar*prec` crossed 2³¹ it wrapped negative and was sign-extended into a garbage `size_t` (~1.8×10¹⁹), causing `hipMalloc`/`cudaMalloc` to fail with `OUT_OF_MEMORY` on requests that comfortably fit the device.

This is reached deterministically with high-`nVar` fields (e.g. `nVar=70`) at moderate element counts, and is required for large-resolution single- and double-precision runs where the work arrays are legitimately multi-GB.

## Fix

Promote the leading factor to `c_size_t` so the entire left-associative multiply chain stays 64-bit, matching the existing idiom in `SELF_Points.f90`. Applied to all scalar/vector/mapped-scalar 2D and 3D containers (11 `workSize` lines across 6 files).

The `sizeof()`-based allocations were already safe — `sizeof` returns `c_size_t`.

## Testing

GPU-only files (`hipMalloc`), exercised by the GPU build pipeline. Letting CI handle build/test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)