### PR TITLE
Remove density anomaly from linear Euler solvers (2-D & 3-D)

### DIFF
--- a/docs/Models/linear-euler-2d-model.md
+++ b/docs/Models/linear-euler-2d-model.md
@@ -14,7 +14,6 @@ For the Linear Euler equations in 2-D
 $$
     \vec{s} = 
     \begin{pmatrix}
-    \rho \\ 
     u \\ 
     v \\ 
     p \\
@@ -23,14 +22,13 @@ $$
     \end{pmatrix}
 $$
 
-where $\rho$ is a density anomaly, referenced to the background density $\rho_0$, $u$ and $v$ are the $x$ and $y$ components of the fluid velocity (respectively), $p$ is the pressure, $c$ is the speed of sound, and $\rho_0$ is the background density. Both the sound speed $c$ and the background density $\rho_0$ are carried as per-node solution variables so that they can vary in space (e.g. across material interfaces); their flux and source are identically zero, so $c$ and $\rho_0$ are held fixed in time at each spatial location. This is entropy-stable for piecewise-constant material regions aligned with element boundaries: element interiors have $\nabla \rho_0 = \nabla c = 0$ (so the flux-divergence form is exact) and the impedance-matched Riemann flux handles the jumps at faces.
+where $u$ and $v$ are the $x$ and $y$ components of the fluid velocity (respectively), $p$ is the pressure, $c$ is the speed of sound, and $\rho_0$ is the background density. The density anomaly is *not* carried as a solution variable: for a motionless background state it is slaved to the pressure through the acoustic relation $\rho = p/c^2$ and never feeds back into the velocity or pressure dynamics, so only the velocity components and the pressure are forward-stepped. If the density anomaly is needed as a diagnostic, it can be recovered pointwise as $\rho = p/c^2$. Both the sound speed $c$ and the background density $\rho_0$ are carried as per-node solution variables so that they can vary in space (e.g. across material interfaces); their flux and source are identically zero, so $c$ and $\rho_0$ are held fixed in time at each spatial location. This is entropy-stable for piecewise-constant material regions aligned with element boundaries: element interiors have $\nabla \rho_0 = \nabla c = 0$ (so the flux-divergence form is exact) and the impedance-matched Riemann flux handles the jumps at faces.
 
 When we assume an ideal gas, and a motionless background state, the conservative fluxes are
 
 $$
     \overleftrightarrow{f} = 
     \begin{pmatrix}
-    \rho_0(u \hat{x} + v \hat{y}) \\
     \frac{p}{\rho_0} \hat{x} \\
     \frac{p}{\rho_0} \hat{y} \\
     \rho_0 c^2 (u \hat{x} + v \hat{y}) \\
@@ -52,14 +50,13 @@ $$
 $$
 
 ## Implementation
-The Linear Euler 2D model is implemented as a type extension of the [`DGModel2D` class](../ford/type/dgmodel2d_t.html). The [`LinearEuler2D_t` class](../ford/type/lineareuler2d_t.html) keeps a scalar `rho0` attribute (used as the reference value that fills variable 6 in the built-in initial conditions) and overrides `SetNumberOfVariables` (to declare `nvar = 6` with `nstepped = 4`, so the last two variables are static), `SetMetadata`, `AdditionalInit`, `entropy_func`, `flux2d`, and `riemannflux2d`. The sound speed lives in `solution(:,:,:,5)` and the background density in `solution(:,:,:,6)`; both can be set independently per node when initializing the simulation.
+The Linear Euler 2D model is implemented as a type extension of the [`DGModel2D` class](../ford/type/dgmodel2d_t.html). The [`LinearEuler2D_t` class](../ford/type/lineareuler2d_t.html) keeps a scalar `rho0` attribute (used as the reference value that fills variable 5 in the built-in initial conditions) and overrides `SetNumberOfVariables` (to declare `nvar = 5` with `nstepped = 3`, so the last two variables are static), `SetMetadata`, `AdditionalInit`, `entropy_func`, `flux2d`, and `riemannflux2d`. The sound speed lives in `solution(:,:,:,4)` and the background density in `solution(:,:,:,5)`; both can be set independently per node when initializing the simulation.
 
 ### Riemann Solver
 The `LinearEuler2D` class is defined using the conservative form of the conservation law. The interface flux is the exact upwind (Godunov) solver for the linearized acoustic system obtained by characteristic decomposition. The normal-flux Jacobian has eigenstructure
 
 * $+c$: right-going acoustic mode, $W_+ = \rho_0 c\, u_n + p$
 * $-c$: left-going  acoustic mode, $W_- = -\rho_0 c\, u_n + p$
-* $0$: entropy density mode, $W_0 = \rho - p/c^2$
 * $0$: tangential vorticity mode, $u_t$
 
 Upwinding each mode by its characteristic direction at the face gives the impedance-matched interface state
@@ -74,7 +71,6 @@ with the per-side acoustic impedance $Z = \rho_0 c$, where each side uses its ow
 $$
     \overleftrightarrow{f}^* \cdot \hat{n} =
     \begin{pmatrix}
-    \overline{\rho_0}\,u_n^* \\
     p^*\, n_x / \overline{\rho_0} \\
     p^*\, n_y / \overline{\rho_0} \\
     \overline{\rho_0}\,\overline{c^2}\,u_n^* \\
@@ -85,7 +81,7 @@ $$
     \overline{c^2} = \tfrac{1}{2}(c_L^2 + c_R^2).
 $$
 
-The reconstructed density/momentum/pressure fluxes use the face-averaged $\overline{\rho_0}$ and $\overline{c^2}$ as a pragmatic treatment of the non-conservative products $p/\rho_0$ and $\rho_0 c^2 \nabla \cdot \vec{v}$ at a face where the coefficients jump; the physically important reflection/transmission is carried exactly by the per-side impedances above. The previously used local Lax-Friedrichs solver was found to over-dissipate the tangential and entropy modes and to fail to stably handle impedance mismatch at high polynomial order (aliasing instability at material interfaces), and has been replaced by the characteristic flux above. Details are in [`self_lineareuler2d_t.f90`](../ford/sourcefile/self_lineareuler2d_t.f90.html).
+The reconstructed momentum/pressure fluxes use the face-averaged $\overline{\rho_0}$ and $\overline{c^2}$ as a pragmatic treatment of the non-conservative products $p/\rho_0$ and $\rho_0 c^2 \nabla \cdot \vec{v}$ at a face where the coefficients jump; the physically important reflection/transmission is carried exactly by the per-side impedances above. The previously used local Lax-Friedrichs solver was found to over-dissipate the tangential mode and to fail to stably handle impedance mismatch at high polynomial order (aliasing instability at material interfaces), and has been replaced by the characteristic flux above. Details are in [`self_lineareuler2d_t.f90`](../ford/sourcefile/self_lineareuler2d_t.f90.html).
 
 ### Boundary conditions
 Boundary conditions are managed through the [extensible boundary-condition system](../Learning/BoundaryConditions.md). Each model registers its hyperbolic boundary conditions inside `AdditionalInit` by calling `hyperbolicBCs%RegisterBoundaryCondition(id, name, fn)`. `LinearEuler2D_t` registers both a no-normal-flow and a radiation handler out of the box (CPU); the GPU build overwrites both registrations with equivalent device kernels. Prescribed boundary conditions are registered by user code (or by an example subclass) so that the external state can be set as a function of position and time.
@@ -93,7 +89,7 @@ Boundary conditions are managed through the [extensible boundary-condition syste
 The built-in boundary identifiers used with the mesh generators are
 
 * `SELF_BC_RADIATION` — set the external state on the boundary to zero in the Riemann solver (open/non-reflecting).
-* `SELF_BC_NONORMALFLOW` — reflect the velocity vector about the boundary normal and prolong $\rho$, $p$, $c$, and $\rho_0$. This produces a reflecting (free-slip) wall and works for arbitrarily oriented normals.
+* `SELF_BC_NONORMALFLOW` — reflect the velocity vector about the boundary normal and prolong $p$, $c$, and $\rho_0$. This produces a reflecting (free-slip) wall and works for arbitrarily oriented normals.
 * `SELF_BC_PRESCRIBED` — use a user-registered handler to fill the external state.
 
 As an example, when using the built-in structured mesh generator,
@@ -119,18 +115,18 @@ integer :: bcids(1:4)
     See the [Structured Mesh documentation](../MeshGeneration/StructuredMesh.md) for details on using the `structuredmesh` procedure, and the [Boundary Condition System](../Learning/BoundaryConditions.md) for how to register new BC handlers.
 
 !!! note
-    To set a prescribed state as a function of position and time, create a type-extension of `LinearEuler2D` and register a custom BC method against `SELF_BC_PRESCRIBED` from `AdditionalInit`. Remember that your handler must also fill `solution%extBoundary(:,:,:,5)` (sound speed) and `solution%extBoundary(:,:,:,6)` (background density) with the appropriate values at the boundary — the planewave examples show this pattern.
+    To set a prescribed state as a function of position and time, create a type-extension of `LinearEuler2D` and register a custom BC method against `SELF_BC_PRESCRIBED` from `AdditionalInit`. Remember that your handler must also fill `solution%extBoundary(:,:,:,4)` (sound speed) and `solution%extBoundary(:,:,:,5)` (background density) with the appropriate values at the boundary — the planewave examples show this pattern.
 
 ### Setting the sound speed and background density
 
-Because $c$ and $\rho_0$ are solution variables, you initialize them the same way you initialize $\rho$, $u$, $v$, and $p$:
+Because $c$ and $\rho_0$ are solution variables, you initialize them the same way you initialize $u$, $v$, and $p$:
 
 ```fortran
-this%solution%interior(i,j,iel,5) = c_value_at_this_node
-this%solution%interior(i,j,iel,6) = rho0_value_at_this_node
+this%solution%interior(i,j,iel,4) = c_value_at_this_node
+this%solution%interior(i,j,iel,5) = rho0_value_at_this_node
 ```
 
-For a uniform background, set every node to the same constants. For a piecewise-constant medium (e.g. bone embedded in marrow), assign the local material's $c$ and $\rho_0$. The `SphericalSoundWave` initializer takes the (uniform) sound speed as an explicit argument and fills the background density from the scalar `this%rho0`:
+For a uniform background, set every node to the same constants. For a piecewise-constant medium (e.g. bone embedded in marrow), assign the local material's $c$ and $\rho_0$. The `SphericalSoundWave` initializer takes the (uniform) sound speed as an explicit argument and fills the background density from the scalar `this%rho0`; its `rhoprime` argument sets the pressure-pulse amplitude through the acoustic relation $p = \rho' c^2$:
 
 ```fortran
 call model%SphericalSoundWave(rhoprime=1.0e-2_prec, Lr=0.1_prec, &
@@ -159,7 +155,7 @@ Out-of-the-box, the no-normal-flow and radiation boundary conditions are GPU acc
 
 For examples, see any of the following
 
-* [`examples/lineareuler2d_spherical_soundwave_closeddomain.f90`](https://github.com/FluidNumerics/SELF/blob/main/examples/linear_euler2d_spherical_soundwave_closeddomain.f90) - Simulation with a gaussian pressure and density anomaly as an initial condition in a domain with no-normal-flow boundary conditions on all sides. Demonstrates uniform sound speed via the `SphericalSoundWave` initializer.
-* [`examples/linear_euler2d_planewave_propagation.f90`](https://github.com/FluidNumerics/SELF/blob/main/examples/linear_euler2d_planewave_propagation.f90) - Gaussian plane wave that propagates at a $45^\circ$ angle through a square domain. The initial and boundary conditions are an exact plane-wave solution to the linear Euler equations. The example subclass carries its own `c` attribute and writes it into `solution(...,5)` for both the initial condition and the prescribed boundary state.
+* [`examples/lineareuler2d_spherical_soundwave_closeddomain.f90`](https://github.com/FluidNumerics/SELF/blob/main/examples/linear_euler2d_spherical_soundwave_closeddomain.f90) - Simulation with a gaussian pressure anomaly as an initial condition in a domain with no-normal-flow boundary conditions on all sides. Demonstrates uniform sound speed via the `SphericalSoundWave` initializer.
+* [`examples/linear_euler2d_planewave_propagation.f90`](https://github.com/FluidNumerics/SELF/blob/main/examples/linear_euler2d_planewave_propagation.f90) - Gaussian plane wave that propagates at a $45^\circ$ angle through a square domain. The initial and boundary conditions are an exact plane-wave solution to the linear Euler equations. The example subclass carries its own `c` attribute and writes it into `solution(...,4)` for both the initial condition and the prescribed boundary state.
 * [`examples/linear_euler2d_planewave_reflection.f90`](https://github.com/FluidNumerics/SELF/blob/main/examples/linear_euler2d_planewave_reflection.f90) - Gaussian plane wave reflected off a wall at $x=1$ via the method of images. Combines prescribed boundary conditions with no-normal-flow on the reflecting side.
-* [`examples/linear_euler2d_boneandmarrow.f90`](https://github.com/FluidNumerics/SELF/blob/main/examples/linear_euler2d_boneandmarrow.f90) - Heterogeneous-medium test on a HOHQMesh ISM-MM mesh tagged with three materials (muscle/bone/marrow). Each material is mapped to a representative sound speed and background density, written into `solution(...,5)` and `solution(...,6)`, and a Gaussian acoustic pulse refracts and reflects at the material interfaces. Exercises the impedance-matched Riemann solver across $\rho_0 c$ (impedance) discontinuities.
+* [`examples/linear_euler2d_boneandmarrow.f90`](https://github.com/FluidNumerics/SELF/blob/main/examples/linear_euler2d_boneandmarrow.f90) - Heterogeneous-medium test on a HOHQMesh ISM-MM mesh tagged with three materials (muscle/bone/marrow). Each material is mapped to a representative sound speed and background density, written into `solution(...,4)` and `solution(...,5)`, and a Gaussian acoustic pulse refracts and reflects at the material interfaces. Exercises the impedance-matched Riemann solver across $\rho_0 c$ (impedance) discontinuities.

--- a/docs/Models/linear-euler-2d-pml-model.md
+++ b/docs/Models/linear-euler-2d-pml-model.md
@@ -4,7 +4,7 @@
 
 The [`SELF_LinearEuler2D_PML_t` module](../ford/module/self_lineareuler2d_pml_t.html) defines the [`LinearEuler2D_PML_t` class](../ford/type/lineareuler2d_pml_t.html), a type extension of [`LinearEuler2D_t`](./linear-euler-2d-model.md) that adds a Perfectly Matched Layer (PML) absorbing region for open-domain acoustic simulations.
 
-The interior dynamics are identical to the parent linear Euler 2D model. Inside the PML region the governing equations are augmented with damping coefficients $\sigma_x(x)$, $\sigma_y(y)$ and four auxiliary variables $\phi_\rho, \phi_u, \phi_v, \phi_P$ that together drive outgoing waves to zero with minimal reflection at the interior/PML interface.
+The interior dynamics are identical to the parent linear Euler 2D model. Inside the PML region the governing equations are augmented with damping coefficients $\sigma_x(x)$, $\sigma_y(y)$ and three auxiliary variables $\phi_u, \phi_v, \phi_P$ that together drive outgoing waves to zero with minimal reflection at the interior/PML interface.
 
 ### Formulation
 
@@ -21,25 +21,23 @@ $$
     \frac{\partial \vec{\phi}}{\partial t} = \vec{q}
 $$
 
-where $\vec{q} = (\rho, u, v, p)$ is the acoustic state, $\vec{\phi} = (\phi_\rho, \phi_u, \phi_v, \phi_P)$ is the auxiliary "memory" vector that integrates $\vec{q}$ in time, and $A$, $B$ are the linear-Euler flux Jacobians (see the [Linear Euler 2D reference](./linear-euler-2d-model.md)).
+where $\vec{q} = (u, v, p)$ is the acoustic state, $\vec{\phi} = (\phi_u, \phi_v, \phi_P)$ is the auxiliary "memory" vector that integrates $\vec{q}$ in time, and $A$, $B$ are the linear-Euler flux Jacobians (see the [Linear Euler 2D reference](./linear-euler-2d-model.md)). As in the parent model, the density anomaly is not carried as a solution variable.
 
 In the interior we set $\sigma_x = \sigma_y = 0$ and the system reduces exactly to the standard linear Euler 2D model. The auxiliary $\vec{\phi}$ still integrates $\vec{q}$, but with the coupling coefficient $\sigma_x \sigma_y = 0$ it never feeds back into the dynamics and starts at $\vec{\phi}(t=0) = \vec{0}$.
 
 ### Solution vector
 
-To accommodate the auxiliary $\vec{\phi}$, the PML model carries `nvar = 9`:
+To accommodate the auxiliary $\vec{\phi}$, the PML model carries `nvar = 7`:
 
 | index | name      | meaning                                      |
 |-------|-----------|----------------------------------------------|
-| 1     | `rho`     | density perturbation (acoustic)              |
-| 2     | `u`       | $x$-velocity                                 |
-| 3     | `v`       | $y$-velocity                                 |
-| 4     | `P`       | pressure perturbation                        |
-| 5     | `c`       | sound speed (per-node, static)               |
-| 6     | `phi_rho` | $\int_0^t \rho\,dt$ (PML auxiliary)          |
-| 7     | `phi_u`   | $\int_0^t u\,dt$ (PML auxiliary)             |
-| 8     | `phi_v`   | $\int_0^t v\,dt$ (PML auxiliary)             |
-| 9     | `phi_P`   | $\int_0^t p\,dt$ (PML auxiliary)             |
+| 1     | `u`       | $x$-velocity                                 |
+| 2     | `v`       | $y$-velocity                                 |
+| 3     | `P`       | pressure perturbation                        |
+| 4     | `c`       | sound speed (per-node, static)               |
+| 5     | `phi_u`   | $\int_0^t u\,dt$ (PML auxiliary)             |
+| 6     | `phi_v`   | $\int_0^t v\,dt$ (PML auxiliary)             |
+| 7     | `phi_P`   | $\int_0^t p\,dt$ (PML auxiliary)             |
 
 The auxiliary variables carry **identically zero flux** in both spatial directions. They are evolved exclusively by the source term above. Sound speed $c$ remains static (zero flux, zero source), as in the parent model.
 
@@ -72,33 +70,33 @@ Both paths are covered step-by-step in the [PML tutorial](../Tutorials/LinearEul
 
 `LinearEuler2D_PML_t` is implemented in [`src/SELF_LinearEuler2D_PML_t.f90`](https://github.com/FluidNumerics/SELF/blob/main/src/SELF_LinearEuler2D_PML_t.f90) as a type extension of [`LinearEuler2D_t`](./linear-euler-2d-model.md). It overrides
 
-* `SetNumberOfVariables` — declares `nvar = 9`.
-* `SetMetadata` — registers names and units for the four PML auxiliaries (plus `sigma_x`, `sigma_y`).
+* `SetNumberOfVariables` — declares `nvar = 7`.
+* `SetMetadata` — registers names and units for the three PML auxiliaries (plus `sigma_x`, `sigma_y`).
 * `AdditionalInit` — allocates `sigma_x` and `sigma_y` and registers PML-aware no-normal-flow and radiation boundary handlers.
 * `AdditionalFree` — releases the damping fields.
-* `flux2d`, `riemannflux2d` — use the parent linear-Euler acoustic flux form for variables 1–5 and return zero for variables 6–9 (auxiliaries carry no flux). Note the PML variant uses the **scalar** background density `rho0`: unlike the parent model (which carries `rho0` as a per-node solution variable in slot 6), the PML model repurposes slot 6 for the auxiliary `phi_rho`.
-* `entropy_func` — acoustic energy using the scalar `rho0` and the per-node sound speed `s(5)`. This override is required because the parent's `entropy_func` reads `rho0` from `s(6)`, which the PML model uses for `phi_rho`.
+* `flux2d`, `riemannflux2d` — use the parent linear-Euler acoustic flux form for variables 1–4 and return zero for variables 5–7 (auxiliaries carry no flux). Note the PML variant uses the **scalar** background density `rho0`: unlike the parent model (which carries `rho0` as a per-node solution variable in slot 5), the PML model repurposes slot 5 for the auxiliary `phi_u`.
+* `entropy_func` — acoustic energy using the scalar `rho0` and the per-node sound speed `s(4)`. This override is required because the parent's `entropy_func` reads `rho0` from `s(5)`, which the PML model uses for `phi_u`.
 * `sourcemethod` — implements the ADE source term node-by-node. We override `sourcemethod` rather than `source2d` because the pure `source2d(s, dsdx)` signature has no access to the per-node $\sigma_x(i,j,iel)$, $\sigma_y(i,j,iel)$ lookups.
 
 A new procedure `SetPMLProfile(x_interior_min, x_interior_max, y_interior_min, y_interior_max, pml_width, sigma_max, ramp_exponent)` populates `sigma_x` and `sigma_y` from the per-element material tags and the geometric ramp.
 
 ### Boundary conditions
 
-`LinearEuler2D_PML_t` re-registers both the **no-normal-flow** and **radiation** boundary handlers so that the auxiliary variables 6–9 are also handled at the boundary. Variables 1–5 are treated exactly as in the parent model:
+`LinearEuler2D_PML_t` re-registers both the **no-normal-flow** and **radiation** boundary handlers so that the auxiliary variables 5–7 are also handled at the boundary. Variables 1–4 are treated exactly as in the parent model:
 
-* `SELF_BC_NONORMALFLOW` — reflect $\vec{v}$ about the boundary normal; copy $\rho$, $p$, $c$; zero $\vec{\phi}$ in `extBoundary`.
-* `SELF_BC_RADIATION` — set $\rho = u = v = p = 0$ in the exterior state; copy $c$ from the interior side so the Riemann solver sees a consistent sound speed; zero $\vec{\phi}$.
+* `SELF_BC_NONORMALFLOW` — reflect $\vec{v}$ about the boundary normal; copy $p$, $c$; zero $\vec{\phi}$ in `extBoundary`.
+* `SELF_BC_RADIATION` — set $u = v = p = 0$ in the exterior state; copy $c$ from the interior side so the Riemann solver sees a consistent sound speed; zero $\vec{\phi}$.
 
 Because the auxiliary variables carry zero Riemann flux, their `extBoundary` value is mathematically irrelevant — we zero it purely for diagnostic cleanliness.
 
-`SELF_BC_PRESCRIBED` is *not* automatically registered. If you need it (e.g. driving a planewave in from one side while absorbing on the other), follow the same pattern as the prescribed-BC examples for the parent model and remember to fill `extBoundary(:,:,:,6:9)` (zero is the natural choice).
+`SELF_BC_PRESCRIBED` is *not* automatically registered. If you need it (e.g. driving a planewave in from one side while absorbing on the other), follow the same pattern as the prescribed-BC examples for the parent model and remember to fill `extBoundary(:,:,:,5:7)` (zero is the natural choice).
 
 ## GPU acceleration
 
 When SELF is built with GPU support, the GPU-backed `LinearEuler2D_PML` type (in [`src/gpu/SELF_LinearEuler2D_PML.f90`](https://github.com/FluidNumerics/SELF/blob/main/src/gpu/SELF_LinearEuler2D_PML.f90) and [`src/gpu/SELF_LinearEuler2D_PML.cpp`](https://github.com/FluidNumerics/SELF/blob/main/src/gpu/SELF_LinearEuler2D_PML.cpp)) overrides
 
-* `BoundaryFlux` — launches a 9-variable PML-aware Riemann kernel.
-* `FluxMethod` — launches a 9-variable PML-aware interior-flux kernel.
+* `BoundaryFlux` — launches a 7-variable PML-aware Riemann kernel.
+* `FluxMethod` — launches a 7-variable PML-aware interior-flux kernel.
 * `SourceMethod` — launches the PML source kernel that reads `sigma_x_gpu`, `sigma_y_gpu`, and `solution_gpu`.
 
 The GPU no-normal-flow and radiation BC handlers are re-registered to point to device-resident kernels (`hbc2d_*_lineareuler2d_pml_gpu`). `sigma_x` and `sigma_y` live on the device after `SetPMLProfile` calls `UpdateDevice`, so no host/device traffic is needed during time stepping unless prescribed BCs are enabled.

--- a/docs/Models/linear-euler-3d-model.md
+++ b/docs/Models/linear-euler-3d-model.md
@@ -16,7 +16,6 @@ For the Linear Euler equations in 3-D
 $$
     \vec{s} = 
     \begin{pmatrix}
-    \rho \\ 
     u \\ 
     v \\ 
     w \\
@@ -26,12 +25,11 @@ $$
     \end{pmatrix}
 $$
 
-where $\rho$ is a density anomaly, referenced to the background density $\rho_0$, $u$, $v$, and $w$ are the $x$, $y$, and $z$ components of the fluid velocity (respectively), and $p$ is the pressure. Both the sound speed $c$ and the background density $\rho_0$ are carried as solution variables so that heterogeneous (spatially varying) media are supported; they have zero flux and zero source, so they are static in time and set by the initial condition (mirroring the 2-D model). This is entropy-stable for piecewise-constant material regions aligned with element boundaries. When we assume an ideal gas, and a motionless background state, the conservative fluxes are
+where $u$, $v$, and $w$ are the $x$, $y$, and $z$ components of the fluid velocity (respectively), and $p$ is the pressure. The density anomaly is *not* carried as a solution variable: for a motionless background state it is slaved to the pressure through the acoustic relation $\rho = p/c^2$ and never feeds back into the velocity or pressure dynamics, so only the velocity components and the pressure are forward-stepped. If the density anomaly is needed as a diagnostic, it can be recovered pointwise as $\rho = p/c^2$. Both the sound speed $c$ and the background density $\rho_0$ are carried as solution variables so that heterogeneous (spatially varying) media are supported; they have zero flux and zero source, so they are static in time and set by the initial condition (mirroring the 2-D model). This is entropy-stable for piecewise-constant material regions aligned with element boundaries. When we assume an ideal gas, and a motionless background state, the conservative fluxes are
 
 $$
     \overleftrightarrow{f} = 
     \begin{pmatrix}
-    \rho_0(u \hat{x} + v \hat{y} + w \hat{z}) \\
     \frac{p}{\rho_0} \hat{x} \\
     \frac{p}{\rho_0} \hat{y} \\
     \frac{p}{\rho_0} \hat{z} \\
@@ -54,7 +52,7 @@ $$
 $$
 
 ## Implementation
-The Linear Euler 3D model is implemented as a type extension of the [`DGModel3D` class](../ford/type/dgmodel3d_t.html). The [`LinearEuler3D_t` class](../ford/type/lineareuler3d_t.html) keeps scalar `rho0` and `c` attributes (used as the reference values that fill variables 7 and 6 in the built-in initial conditions) and overrides `SetNumberOfVariables` (to declare `nvar = 7` with `nstepped = 5`, so the last two variables are static), `SetMetadata`, `AdditionalInit`, `entropy_func`, `flux3d`, and `riemannflux3d`. The sound speed lives in `solution(:,:,:,:,6)` and the background density in `solution(:,:,:,:,7)`; both can be set independently per node when initializing the simulation.
+The Linear Euler 3D model is implemented as a type extension of the [`DGModel3D` class](../ford/type/dgmodel3d_t.html). The [`LinearEuler3D_t` class](../ford/type/lineareuler3d_t.html) keeps scalar `rho0` and `c` attributes (used as the reference values that fill variables 6 and 5 in the built-in initial conditions) and overrides `SetNumberOfVariables` (to declare `nvar = 6` with `nstepped = 4`, so the last two variables are static), `SetMetadata`, `AdditionalInit`, `entropy_func`, `flux3d`, and `riemannflux3d`. The sound speed lives in `solution(:,:,:,:,5)` and the background density in `solution(:,:,:,:,6)`; both can be set independently per node when initializing the simulation.
 
 ### Riemann Solver
 The `LinearEuler3D` class is defined using the conservative form of the conservation law. The Riemann solver for the hyperbolic part of the Euler equation is the impedance-matched (characteristic/Godunov) upwind flux, identical in form to the 2-D model's. With the per-side acoustic impedances $Z_L = \rho_{0,L} c_L$ and $Z_R = \rho_{0,R} c_R$ evaluated from the per-node background density and sound speed on either side of the face, the interface normal velocity and pressure are
@@ -69,7 +67,6 @@ and the normal flux is
 $$
     \overleftrightarrow{f}_h^* \cdot \hat{n} = 
     \begin{pmatrix}
-    \overline{\rho_0} u_n^* \\
     p^* n_x / \overline{\rho_0} \\
     p^* n_y / \overline{\rho_0} \\
     p^* n_z / \overline{\rho_0} \\
@@ -81,13 +78,13 @@ $$
     \overline{c^2} = \frac{1}{2}(c_L^2 + c_R^2)
 $$
 
-Because the interface states are resolved with the per-side impedances, material interfaces in a heterogeneous field (density and/or sound-speed jumps) produce the physically correct transmission and reflection. The face-averaged $\overline{\rho_0}$ and $\overline{c^2}$ are used to reconstruct the density/momentum/pressure fluxes. The details for this implementation can be found in [`self_lineareuler3d_t.f90`](../ford/sourcefile/self_lineareuler3d_t.f90.html)
+Because the interface states are resolved with the per-side impedances, material interfaces in a heterogeneous field (density and/or sound-speed jumps) produce the physically correct transmission and reflection. The face-averaged $\overline{\rho_0}$ and $\overline{c^2}$ are used to reconstruct the momentum/pressure fluxes. The details for this implementation can be found in [`self_lineareuler3d_t.f90`](../ford/sourcefile/self_lineareuler3d_t.f90.html)
 
 ### Boundary conditions
 When initializing the mesh for your Euler 3D equation solver, you can change the boundary conditions to 
 
 * `SELF_BC_Radiation` to set the external state on model boundaries to 0 in the Riemann solver
-* `SELF_BC_NoNormalFlow` to set the external normal velocity to the negative of the interior normal velocity and prolong the density, pressure, tangential velocity, sound speed, and background density (free slip). This effectively creates a reflecting boundary condition.
+* `SELF_BC_NoNormalFlow` to set the external normal velocity to the negative of the interior normal velocity and prolong the pressure, tangential velocity, sound speed, and background density (free slip). This effectively creates a reflecting boundary condition.
 * `SELF_BC_Prescribed` to set a prescribed external state.
 
 
@@ -148,4 +145,4 @@ Out-of-the-box, the no-normal-flow and radiation boundary conditions are GPU acc
 
 For examples, see any of the following
 
-* [`examples/linear_euler3d_spherical_soundwave_radiation.f90`](https://github.com/FluidNumerics/SELF/blob/main/examples/linear_euler3d_spherical_soundwave_radiation.f90) - Implements a simulation with a gaussian pressure and density anomaly as an initial condition in a domain with radiation boundary conditions on all sides. Uses the `SphericalSoundWave` initializer, which fills the uniform sound speed and background density fields.
+* [`examples/linear_euler3d_spherical_soundwave_radiation.f90`](https://github.com/FluidNumerics/SELF/blob/main/examples/linear_euler3d_spherical_soundwave_radiation.f90) - Implements a simulation with a gaussian pressure anomaly as an initial condition in a domain with radiation boundary conditions on all sides. Uses the `SphericalSoundWave` initializer, which fills the uniform sound speed and background density fields.

--- a/docs/Tutorials/LinearEuler2D/PerfectlyMatchedLayer.md
+++ b/docs/Tutorials/LinearEuler2D/PerfectlyMatchedLayer.md
@@ -11,7 +11,7 @@ The numerics and PML formulation are summarised in the [PML model reference](../
 
 `LinearEuler2D_PML` is a type extension of `LinearEuler2D`. Compared to the parent model it
 
-* extends `nvar` from 5 to 9 (the original acoustic state plus four PML auxiliary variables `phi_rho`, `phi_u`, `phi_v`, `phi_P`);
+* extends `nvar` from 4 to 7 (the original acoustic state plus three PML auxiliary variables `phi_u`, `phi_v`, `phi_P`);
 * carries two per-node fields `sigma_x` and `sigma_y` that hold the PML damping coefficients;
 * registers PML-aware no-normal-flow and radiation boundary handlers automatically.
 
@@ -58,10 +58,10 @@ call modelobj%SetPMLProfile(x_interior_min = 0.0_prec, &
 After this point the PML is fully active. Initial-condition setup, time integration, and IO follow the same patterns as the [parent `LinearEuler2D`](../../Models/linear-euler-2d-model.md).
 
 !!! note
-    Always set the four PML auxiliary variables to zero in your initial condition:
+    Always set the three PML auxiliary variables to zero in your initial condition:
 
     ```fortran
-    this%solution%interior(i,j,iel,6:9) = 0.0_prec
+    this%solution%interior(i,j,iel,5:7) = 0.0_prec
     ```
 
     Their initial value is the integral $\int_0^t \vec{q}\,dt$, so starting them at zero corresponds to "the simulation has just begun".

--- a/docs/Tutorials/LinearEuler2D/PlaneWavePropagation.md
+++ b/docs/Tutorials/LinearEuler2D/PlaneWavePropagation.md
@@ -16,7 +16,6 @@ where
 $$
     \vec{s} = 
     \begin{pmatrix}
-    \rho \\ 
     u \\ 
     v \\ 
     p
@@ -28,7 +27,6 @@ and
 $$
     \overleftrightarrow{f} = 
     \begin{pmatrix}
-    \rho_0(u \hat{x} + v \hat{y}) \\
     p \hat{x} \\
     p \hat{y} \\
     \rho_0c^2(u \hat{x} + v \hat{y})
@@ -43,10 +41,11 @@ $$
 
 The variables are defined as follows
 
-* $\rho$ is a density anomaly referenced to the density $\rho_0$
 * $u$ and $v$ are the $x$ and $y$ components of the fluid velocity (respectively)
 * $p$ is the pressure
 * $c$ is the (constant) speed of sound. 
+
+The density anomaly is not carried as a solution variable; when needed as a diagnostic it can be recovered pointwise as $\rho = p/c^2$.
 
 ### Model Domain
 The physical domain is defined by $\vec{x} \in [0, 1]\times[0,1]$. We use the `StructuredMesh` routine to create a domain with 20 × 20 elements that are dimensioned 0.05 × 0.05 . Model boundaries are all tagged with the `SELF_BC_PRESCRIBED` flag to implement prescribed boundary conditions.
@@ -59,13 +58,11 @@ The initial and boundary conditions are set using an exact solution,
 
 $$
     \begin{pmatrix}
-    ρ \\ 
     u \\ 
     v \\ 
     P
     \end{pmatrix} = 
     \begin{pmatrix}
-    \frac{1}{c^2} \\
     \frac{k_x}{c} \\ 
     \frac{k_y}{c} \\ 
     1

--- a/docs/Tutorials/LinearEuler2D/PlaneWaveReflection.md
+++ b/docs/Tutorials/LinearEuler2D/PlaneWaveReflection.md
@@ -16,7 +16,6 @@ where
 $$
     \vec{s} = 
     \begin{pmatrix}
-    \rho \\ 
     u \\ 
     v \\ 
     p
@@ -28,7 +27,6 @@ and
 $$
     \overleftrightarrow{f} = 
     \begin{pmatrix}
-    \rho_0(u \hat{x} + v \hat{y}) \\
     p \hat{x} \\
     p \hat{y} \\
     \rho_0c^2(u \hat{x} + v \hat{y})
@@ -43,10 +41,11 @@ $$
 
 The variables are defined as follows
 
-* $\rho$ is a density anomaly referenced to the density $\rho_0$
 * $u$ and $v$ are the $x$ and $y$ components of the fluid velocity (respectively)
 * $p$ is the pressure
 * $c$ is the (constant) speed of sound. 
+
+The density anomaly is not carried as a solution variable; when needed as a diagnostic it can be recovered pointwise as $\rho = p/c^2$.
 
 ### Model Domain
 The physical domain is defined by $\vec{x} \in [0, 1]\times[0,1]$. We use the `StructuredMesh` routine to create a domain with 20 × 20 elements that are dimensioned 0.05 × 0.05 . Model boundaries on the south, north, and west edges of the domain are all tagged with the `SELF_BC_PRESCRIBED` flag to implement prescribed boundary conditions; the east boundary is tagged with `SELF_BC_NONORMALFLOW` to implement no-normal-flow boundary conditions.
@@ -66,7 +65,6 @@ where
 $$
     \vec{s}_i = 
     \begin{pmatrix}
-    \frac{1}{c^2} \\
     \frac{k_x}{c} \\ 
     \frac{k_y}{c} \\ 
     1
@@ -78,7 +76,6 @@ is the incident wave, and
 $$
     \vec{s}_r = 
     \begin{pmatrix}
-    \frac{1}{c^2} \\
     -\frac{k_x}{c} \\ 
     \frac{k_y}{c} \\ 
     1

--- a/docs/Tutorials/LinearEuler2D/SphericalSoundWave.md
+++ b/docs/Tutorials/LinearEuler2D/SphericalSoundWave.md
@@ -16,7 +16,6 @@ where
 $$
     \vec{s} = 
     \begin{pmatrix}
-    \rho \\ 
     u \\ 
     v \\ 
     p
@@ -28,7 +27,6 @@ and
 $$
     \overleftrightarrow{f} = 
     \begin{pmatrix}
-    \rho_0(u \hat{x} + v \hat{y}) \\
     p \hat{x} \\
     p \hat{y} \\
     \rho_0c^2(u \hat{x} + v \hat{y})
@@ -43,10 +41,11 @@ $$
 
 The variables are defined as follows
 
-* $\rho$ is a density anomaly referenced to the density $\rho_0$
 * $u$ and $v$ are the $x$ and $y$ components of the fluid velocity (respectively)
 * $p$ is the pressure
 * $c$ is the (constant) speed of sound. 
+
+The density anomaly is not carried as a solution variable; when needed as a diagnostic it can be recovered pointwise as $\rho = p/c^2$.
 
 ### Model Domain
 The physical domain is defined by $\vec{x} \in [0, 1]\times[0,1]$. We use the `StructuredMesh` routine to create a domain with 20 × 20 elements that are dimensioned 0.05 × 0.05 . All model boundaries are all tagged with the `SELF_BC_NONORMALFLOW` flag to implement no-normal-flow boundary conditions.
@@ -60,13 +59,11 @@ The initial condition is set using
 
 $$
     \begin{pmatrix}
-    ρ \\ 
     u \\ 
     v \\ 
     P
     \end{pmatrix} = 
     \begin{pmatrix}
-    \frac{1}{c^2} \\
     0 \\ 
     0 \\ 
     1

--- a/docs/Tutorials/LinearEuler3D/PlaneWavePropagation.md
+++ b/docs/Tutorials/LinearEuler3D/PlaneWavePropagation.md
@@ -16,7 +16,6 @@ where
 $$
     \vec{s} = 
     \begin{pmatrix}
-    \rho \\ 
     u \\ 
     v \\ 
     p
@@ -28,7 +27,6 @@ and
 $$
     \overleftrightarrow{f} = 
     \begin{pmatrix}
-    \rho_0(u \hat{x} + v \hat{y}) \\
     p \hat{x} \\
     p \hat{y} \\
     \rho_0c^2(u \hat{x} + v \hat{y})
@@ -43,10 +41,11 @@ $$
 
 The variables are defined as follows
 
-* $\rho$ is a density anomaly referenced to the density $\rho_0$
 * $u$ and $v$ are the $x$ and $y$ components of the fluid velocity (respectively)
 * $p$ is the pressure
 * $c$ is the (constant) speed of sound. 
+
+The density anomaly is not carried as a solution variable; when needed as a diagnostic it can be recovered pointwise as $\rho = p/c^2$.
 
 ### Model Domain
 The physical domain is defined by $\vec{x} \in [0, 1]\times[0,1]$. We use the `StructuredMesh` routine to create a domain with 20 × 20 elements that are dimensioned 0.05 × 0.05 . Model boundaries are all tagged with the `SELF_BC_PRESCRIBED` flag to implement prescribed boundary conditions.
@@ -59,13 +58,11 @@ The initial and boundary conditions are set using an exact solution,
 
 $$
     \begin{pmatrix}
-    ρ \\ 
     u \\ 
     v \\ 
     P
     \end{pmatrix} = 
     \begin{pmatrix}
-    \frac{1}{c^2} \\
     \frac{k_x}{c} \\ 
     \frac{k_y}{c} \\ 
     1

--- a/docs/Tutorials/LinearEuler3D/SphericalSoundWave.md
+++ b/docs/Tutorials/LinearEuler3D/SphericalSoundWave.md
@@ -16,7 +16,6 @@ where
 $$
     \vec{s} = 
     \begin{pmatrix}
-    \rho \\ 
     u \\ 
     v \\ 
     p
@@ -28,7 +27,6 @@ and
 $$
     \overleftrightarrow{f} = 
     \begin{pmatrix}
-    \rho_0(u \hat{x} + v \hat{y}) \\
     p \hat{x} \\
     p \hat{y} \\
     \rho_0c^2(u \hat{x} + v \hat{y})
@@ -43,10 +41,11 @@ $$
 
 The variables are defined as follows
 
-* $\rho$ is a density anomaly referenced to the density $\rho_0$
 * $u$ and $v$ are the $x$ and $y$ components of the fluid velocity (respectively)
 * $p$ is the pressure
 * $c$ is the (constant) speed of sound. 
+
+The density anomaly is not carried as a solution variable; when needed as a diagnostic it can be recovered pointwise as $\rho = p/c^2$.
 
 ### Model Domain
 The physical domain is defined by $\vec{x} \in [0, 1]\times[0,1]$. We use the `StructuredMesh` routine to create a domain with 20 × 20 elements that are dimensioned 0.05 × 0.05 . All model boundaries are all tagged with the `SELF_BC_NONORMALFLOW` flag to implement no-normal-flow boundary conditions.
@@ -60,13 +59,11 @@ The initial condition is set using
 
 $$
     \begin{pmatrix}
-    ρ \\ 
     u \\ 
     v \\ 
     P
     \end{pmatrix} = 
     \begin{pmatrix}
-    \frac{1}{c^2} \\
     0 \\ 
     0 \\ 
     1

--- a/examples/linear_euler2d_boneandmarrow.f90
+++ b/examples/linear_euler2d_boneandmarrow.f90
@@ -26,7 +26,7 @@ module lineareuler2d_boneandmarrow_model
 !! "Marrow" (smaller disk of radius 1.5 about (-1.5, 0.5))
 !! nested inside the bone region. We map each material to a
 !! representative sound speed and background density and write those
-!! into solution(...,5) (c) and solution(...,6) (rho0), which are
+!! into solution(...,4) (c) and solution(...,5) (rho0), which are
 !! held fixed in time by the LinearEuler2D model.
 !!
 !! This exercises a genuinely heterogeneous background: both the
@@ -37,7 +37,7 @@ module lineareuler2d_boneandmarrow_model
 !! piecewise-constant per element (aligned with mesh boundaries), so
 !! the flux-divergence interior is exactly entropy-conservative.
 !!
-!! Initial condition: a small Gaussian pressure / density bump is
+!! Initial condition: a small Gaussian pressure bump is
 !! placed in the Muscle region, well outside the bone region. The
 !! transient acoustic pulse propagates outward, refracts/reflects
 !! at the material interfaces (because c and rho0 are discontinuous
@@ -61,13 +61,13 @@ module lineareuler2d_boneandmarrow_model
     real(prec) :: bump_x0 = 10.0_prec ! Pulse center, well into the muscle annulus
     real(prec) :: bump_y0 = 0.0_prec
     real(prec) :: bump_L = 0.6_prec ! Halfwidth (e-folding length) of the bump
-    real(prec) :: bump_amp = 1.0e-3_prec ! Density-perturbation amplitude
+    real(prec) :: bump_amp = 1.0e-3_prec ! Pressure-pulse amplitude (in units of rho'*c^2)
 
   contains
 
     ! AdditionalInit is inherited from `lineareuler2d`, which registers both
     ! the no-normal-flow and radiation BCs using the correct CPU/GPU wrappers
-    ! for the current build. The radiation wrapper zeros (rho', u, v, p) and
+    ! for the current build. The radiation wrapper zeros (u, v, p) and
     ! preserves c on the same host/device buffer the rest of the pipeline
     ! reads from, which is what this disk-shaped scatterer test requires.
     procedure :: setInitialCondition
@@ -78,7 +78,7 @@ contains
 
   subroutine setInitialCondition(this)
     !! Material-aware initial condition: stamp `c` and `rho0` from the
-    !! per-element material id, then add a Gaussian rho/p bump only in
+    !! per-element material id, then add a Gaussian pressure bump only in
     !! Muscle elements (so the pulse starts cleanly in a uniform
     !! medium and the bone/marrow inclusions are seen as scatterers).
     implicit none
@@ -109,12 +109,11 @@ contains
             shape = 0.0_prec
           endif
 
-          this%solution%interior(i,j,iel,1) = shape ! density perturbation
-          this%solution%interior(i,j,iel,2) = 0.0_prec ! u
-          this%solution%interior(i,j,iel,3) = 0.0_prec ! v
-          this%solution%interior(i,j,iel,4) = shape*c_mat*c_mat ! p = rho * c^2 (acoustic)
-          this%solution%interior(i,j,iel,5) = c_mat ! sound speed for this material
-          this%solution%interior(i,j,iel,6) = rho0_mat ! background density for this material
+          this%solution%interior(i,j,iel,1) = 0.0_prec ! u
+          this%solution%interior(i,j,iel,2) = 0.0_prec ! v
+          this%solution%interior(i,j,iel,3) = shape*c_mat*c_mat ! p = rho' * c^2 (acoustic)
+          this%solution%interior(i,j,iel,4) = c_mat ! sound speed for this material
+          this%solution%interior(i,j,iel,5) = rho0_mat ! background density for this material
         enddo
       enddo
     enddo

--- a/examples/linear_euler2d_planewave_propagation.f90
+++ b/examples/linear_euler2d_planewave_propagation.f90
@@ -79,10 +79,9 @@ contains
     class(lineareuler2d_planewave),intent(inout) :: this
     ! Local
     integer :: i,j,iel
-    real(prec) :: p,rho,u,v,x,y,phase,shape
+    real(prec) :: p,u,v,x,y,phase,shape
 
     p = this%p
-    rho = this%p/this%c/this%c
     u = this%p*this%wx/this%c
     v = this%p*this%wy/this%c
 
@@ -94,12 +93,11 @@ contains
       phase = this%wx*(x-this%x0)+this%wy*(y-this%y0)-this%c*this%t
       shape = exp(-phase*phase/(this%L*this%L))
 
-      this%solution%interior(i,j,iel,1) = rho*shape ! density
-      this%solution%interior(i,j,iel,2) = u*shape ! u
-      this%solution%interior(i,j,iel,3) = v*shape ! v
-      this%solution%interior(i,j,iel,4) = p*shape ! pressure
-      this%solution%interior(i,j,iel,5) = this%c ! sound speed (uniform background)
-      this%solution%interior(i,j,iel,6) = this%rho0 ! background density (uniform)
+      this%solution%interior(i,j,iel,1) = u*shape ! u
+      this%solution%interior(i,j,iel,2) = v*shape ! v
+      this%solution%interior(i,j,iel,3) = p*shape ! pressure
+      this%solution%interior(i,j,iel,4) = this%c ! sound speed (uniform background)
+      this%solution%interior(i,j,iel,5) = this%rho0 ! background density (uniform)
 
     enddo
 
@@ -113,12 +111,11 @@ contains
     ! Local
     integer :: n,i,iEl,j
     real(prec) :: x(1:2)
-    real(prec) :: p,rho,u,v,phase,shape
+    real(prec) :: p,u,v,phase,shape
 
     select type(m => mymodel)
     class is(lineareuler2d_planewave)
       p = m%p
-      rho = m%p/m%c/m%c
       u = m%p*m%wx/m%c
       v = m%p*m%wy/m%c
 
@@ -131,12 +128,11 @@ contains
           phase = m%wx*(x(1)-m%x0)+m%wy*(x(2)-m%y0)-m%c*m%t
           shape = exp(-phase*phase/(m%L*m%L))
 
-          m%solution%extBoundary(i,j,iEl,1) = rho*shape ! density
-          m%solution%extBoundary(i,j,iEl,2) = u*shape ! u
-          m%solution%extBoundary(i,j,iEl,3) = v*shape ! v
-          m%solution%extBoundary(i,j,iEl,4) = p*shape ! pressure
-          m%solution%extBoundary(i,j,iEl,5) = m%c ! sound speed
-          m%solution%extBoundary(i,j,iEl,6) = m%rho0 ! background density
+          m%solution%extBoundary(i,j,iEl,1) = u*shape ! u
+          m%solution%extBoundary(i,j,iEl,2) = v*shape ! v
+          m%solution%extBoundary(i,j,iEl,3) = p*shape ! pressure
+          m%solution%extBoundary(i,j,iEl,4) = m%c ! sound speed
+          m%solution%extBoundary(i,j,iEl,5) = m%rho0 ! background density
         enddo
       enddo
     endselect

--- a/examples/linear_euler2d_planewave_reflection.f90
+++ b/examples/linear_euler2d_planewave_reflection.f90
@@ -82,11 +82,10 @@ contains
     class(lineareuler2d_planewave),intent(inout) :: this
     ! Local
     integer :: i,j,iel
-    real(prec) :: p,rho,u,v,x,y
+    real(prec) :: p,u,v,x,y
     real(prec) :: phi,phr,shi,shr
 
     p = this%p
-    rho = this%p/this%c/this%c
     u = this%p*this%wx/this%c
     v = this%p*this%wy/this%c
 
@@ -104,12 +103,11 @@ contains
       phr = -this%wx*(x-(2.0_prec-this%x0))+this%wy*(y-this%y0)-this%c*this%t
       shr = exp(-phr*phr/(this%L*this%L))
 
-      this%solution%interior(i,j,iel,1) = rho*(shi+shr) ! density
-      this%solution%interior(i,j,iel,2) = u*(shi-shr) ! u
-      this%solution%interior(i,j,iel,3) = v*(shi+shr) ! v
-      this%solution%interior(i,j,iel,4) = p*(shi+shr) ! pressure
-      this%solution%interior(i,j,iel,5) = this%c ! sound speed (uniform background)
-      this%solution%interior(i,j,iel,6) = this%rho0 ! background density (uniform)
+      this%solution%interior(i,j,iel,1) = u*(shi-shr) ! u
+      this%solution%interior(i,j,iel,2) = v*(shi+shr) ! v
+      this%solution%interior(i,j,iel,3) = p*(shi+shr) ! pressure
+      this%solution%interior(i,j,iel,4) = this%c ! sound speed (uniform background)
+      this%solution%interior(i,j,iel,5) = this%rho0 ! background density (uniform)
 
     enddo
 
@@ -123,12 +121,11 @@ contains
     ! Local
     integer :: n,i,iEl,j
     real(prec) :: x(1:2)
-    real(prec) :: p,rho,u,v,phase,shi,shr
+    real(prec) :: p,u,v,phase,shi,shr
 
     select type(m => mymodel)
     class is(lineareuler2d_planewave)
       p = m%p
-      rho = m%p/m%c/m%c
       u = m%p*m%wx/m%c
       v = m%p*m%wy/m%c
 
@@ -146,12 +143,11 @@ contains
           phase = -m%wx*(x(1)+m%x0-2.0_prec)+m%wy*(x(2)-m%y0)-m%c*m%t
           shr = exp(-phase*phase/(m%L*m%L))
 
-          m%solution%extBoundary(i,j,iEl,1) = rho*(shi+shr) ! density
-          m%solution%extBoundary(i,j,iEl,2) = u*(shi-shr) ! u
-          m%solution%extBoundary(i,j,iEl,3) = v*(shi+shr) ! v
-          m%solution%extBoundary(i,j,iEl,4) = p*(shi+shr) ! pressure
-          m%solution%extBoundary(i,j,iEl,5) = m%c ! sound speed
-          m%solution%extBoundary(i,j,iEl,6) = m%rho0 ! background density
+          m%solution%extBoundary(i,j,iEl,1) = u*(shi-shr) ! u
+          m%solution%extBoundary(i,j,iEl,2) = v*(shi+shr) ! v
+          m%solution%extBoundary(i,j,iEl,3) = p*(shi+shr) ! pressure
+          m%solution%extBoundary(i,j,iEl,4) = m%c ! sound speed
+          m%solution%extBoundary(i,j,iEl,5) = m%rho0 ! background density
         enddo
       enddo
     endselect

--- a/examples/linear_euler2d_pml_planewave.f90
+++ b/examples/linear_euler2d_pml_planewave.f90
@@ -41,7 +41,6 @@ contains
   subroutine setInitialCondition(this)
     !! Right-going acoustic wave packet:
     !!   p(x,y,0) = amp * exp(-((x-x0)^2 + (y-y0)^2)/L^2)
-    !!   rho      = p/c^2
     !!   u        = p/(rho0*c)
     !!   v        = 0
     !! consistent with a planewave travelling in +x at sound speed c.
@@ -49,7 +48,7 @@ contains
     class(lineareuler2d_pml_planewave),intent(inout) :: this
     ! Local
     integer :: i,j,iel
-    real(prec) :: x,y,r2,p_loc,rho_loc,u_loc
+    real(prec) :: x,y,r2,p_loc,u_loc
 
     do concurrent(i=1:this%solution%N+1,j=1:this%solution%N+1, &
                   iel=1:this%mesh%nElem)
@@ -57,16 +56,14 @@ contains
       y = this%geometry%x%interior(i,j,iel,1,2)
       r2 = (x-this%x0)**2+(y-this%y0)**2
       p_loc = this%amp*exp(-r2/(this%L*this%L))
-      rho_loc = p_loc/(this%c*this%c)
       u_loc = p_loc/(this%rho0*this%c)
 
-      this%solution%interior(i,j,iel,1) = rho_loc
-      this%solution%interior(i,j,iel,2) = u_loc
-      this%solution%interior(i,j,iel,3) = 0.0_prec
-      this%solution%interior(i,j,iel,4) = p_loc
-      this%solution%interior(i,j,iel,5) = this%c
+      this%solution%interior(i,j,iel,1) = u_loc
+      this%solution%interior(i,j,iel,2) = 0.0_prec
+      this%solution%interior(i,j,iel,3) = p_loc
+      this%solution%interior(i,j,iel,4) = this%c
       ! PML auxiliaries start at zero
-      this%solution%interior(i,j,iel,6:9) = 0.0_prec
+      this%solution%interior(i,j,iel,5:7) = 0.0_prec
     enddo
 
     call this%solution%UpdateDevice()

--- a/examples/linear_euler2d_spherical_soundwave_closeddomain.f90
+++ b/examples/linear_euler2d_spherical_soundwave_closeddomain.f90
@@ -74,8 +74,9 @@ program LinearEuler_Example
   modelobj%tecplot_enabled = .false. ! Disables tecplot output
   modelobj%rho0 = rho0 ! optional, set the reference density
 
-  ! Set the initial condition. The sound speed `c` is now carried as a
-  ! solution variable, so it is passed in here and written into solution(...,5).
+  ! Set the initial condition. The sound speed `c` is carried as a
+  ! solution variable, so it is passed in here and written into solution(...,4).
+  ! `rhoprime` sets the pressure-pulse amplitude through p = rhoprime*c^2.
   call modelobj%SphericalSoundWave(rhoprime,Lr,x0,y0,c)
 
   call modelobj%WriteModel()

--- a/src/SELF_LinearEuler2D_PML_t.f90
+++ b/src/SELF_LinearEuler2D_PML_t.f90
@@ -32,27 +32,26 @@ module self_LinearEuler2D_PML_t
 !! ADE (Auxiliary Differential Equation) form for the no-mean-flow case.
 !!
 !! In the PML region the dynamics for the acoustic state
-!! q = (rho', u, v, p) become
+!! q = (u, v, p) become
 !!
 !!   dq/dt + A dq/dx + B dq/dy + (sigma_x + sigma_y) q + sigma_x*sigma_y phi = 0
 !!   dphi/dt = q
 !!
-!! where phi = (phi_rho, phi_u, phi_v, phi_P) is a 4-component auxiliary
+!! where phi = (phi_u, phi_v, phi_P) is a 3-component auxiliary
 !! that accumulates the time integral of q. The sigma_x(x), sigma_y(y)
 !! damping coefficients vanish in the interior and rise toward the outer
 !! boundary, leaving the original linear Euler 2D dynamics unaltered where
-!! sigma = 0.
+!! sigma = 0. As in the parent model, the density anomaly is not carried as
+!! a solution variable (it is slaved to the pressure through rho = p/c^2).
 !!
-!! Solution layout (nvar = 9):
-!!   s(1) = rho     (density perturbation)
-!!   s(2) = u       (x-velocity)
-!!   s(3) = v       (y-velocity)
-!!   s(4) = P       (pressure perturbation)
-!!   s(5) = c       (sound speed, static; per-node)
-!!   s(6) = phi_rho (auxiliary; time-integral of rho)
-!!   s(7) = phi_u   (auxiliary; time-integral of u)
-!!   s(8) = phi_v   (auxiliary; time-integral of v)
-!!   s(9) = phi_P   (auxiliary; time-integral of P)
+!! Solution layout (nvar = 7):
+!!   s(1) = u       (x-velocity)
+!!   s(2) = v       (y-velocity)
+!!   s(3) = P       (pressure perturbation)
+!!   s(4) = c       (sound speed, static; per-node)
+!!   s(5) = phi_u   (auxiliary; time-integral of u)
+!!   s(6) = phi_v   (auxiliary; time-integral of v)
+!!   s(7) = phi_P   (auxiliary; time-integral of P)
 !!
 !! The auxiliary variables phi_* have identically zero flux; they evolve
 !! only via the source term. Sound speed c is also static (zero flux,
@@ -107,7 +106,7 @@ contains
     implicit none
     class(LinearEuler2D_PML_t),intent(inout) :: this
 
-    this%nvar = 9
+    this%nvar = 7
 
   endsubroutine SetNumberOfVariables_LinearEuler2D_PML_t
 
@@ -115,20 +114,19 @@ contains
     implicit none
     class(LinearEuler2D_PML_t),intent(inout) :: this
 
-    ! Reuse parent metadata for the first five variables.
+    ! Reuse parent metadata for the first four variables (u, v, P, c). The
+    ! parent also names variable 5 ("rho0"), which is overwritten below since
+    ! the PML model repurposes that slot for phi_u.
     call SetMetadata_LinearEuler2D_t(this)
 
-    call this%solution%SetName(6,"phi_rho")
-    call this%solution%SetUnits(6,"kg⋅m⁻³⋅s")
+    call this%solution%SetName(5,"phi_u")
+    call this%solution%SetUnits(5,"m")
 
-    call this%solution%SetName(7,"phi_u")
-    call this%solution%SetUnits(7,"m")
+    call this%solution%SetName(6,"phi_v")
+    call this%solution%SetUnits(6,"m")
 
-    call this%solution%SetName(8,"phi_v")
-    call this%solution%SetUnits(8,"m")
-
-    call this%solution%SetName(9,"phi_P")
-    call this%solution%SetUnits(9,"kg⋅m⁻¹⋅s⁻¹")
+    call this%solution%SetName(7,"phi_P")
+    call this%solution%SetUnits(7,"kg⋅m⁻¹⋅s⁻¹")
 
     call this%sigma_x%SetName(1,"sigma_x")
     call this%sigma_x%SetUnits(1,"s⁻¹")
@@ -140,15 +138,15 @@ contains
   pure function entropy_func_LinearEuler2D_PML_t(this,s) result(e)
     !! Acoustic energy for the PML model. The background density is the scalar
     !! this%rho0 (the PML variant does not carry a per-node background density;
-    !! its variable 6 is the auxiliary phi_rho, not rho0), and the sound speed
-    !! is taken from s(5). This overrides the parent entropy_func, which reads
-    !! rho0 from s(6).
+    !! its variable 5 is the auxiliary phi_u, not rho0), and the sound speed
+    !! is taken from s(4). This overrides the parent entropy_func, which reads
+    !! rho0 from s(5).
     class(LinearEuler2D_PML_t),intent(in) :: this
     real(prec),intent(in) :: s(1:this%nvar)
     real(prec) :: e
 
-    e = 0.5_prec*this%rho0*(s(2)*s(2)+s(3)*s(3))+ &
-        0.5_prec*(s(4)*s(4)/(this%rho0*s(5)*s(5)))
+    e = 0.5_prec*this%rho0*(s(1)*s(1)+s(2)*s(2))+ &
+        0.5_prec*(s(3)*s(3)/(this%rho0*s(4)*s(4)))
 
   endfunction entropy_func_LinearEuler2D_PML_t
 
@@ -163,8 +161,8 @@ contains
     call this%sigma_y%Init(this%geometry%x%interp,1,this%mesh%nElem)
 
     ! Register PML-aware BC methods. The PML-aware versions reuse the
-    ! parent acoustic-side behaviour for variables 1-5 and zero the
-    ! auxiliary variables 6-9 in extBoundary so that interior-side
+    ! parent acoustic-side behaviour for variables 1-4 and zero the
+    ! auxiliary variables 5-7 in extBoundary so that interior-side
     ! and exterior-side states are consistent with the zero-flux
     ! treatment of phi_*.
     bcfunc => hbc2d_NoNormalFlow_LinearEuler2D_PML
@@ -255,33 +253,31 @@ contains
   endsubroutine SetPMLProfile_LinearEuler2D_PML_t
 
   pure function flux2d_LinearEuler2D_PML_t(this,s,dsdx) result(flux)
-    !! Interior flux. Variables 1-5 use the parent linear Euler 2D
-    !! flux; auxiliary variables 6-9 carry zero flux in both directions
+    !! Interior flux. Variables 1-4 use the parent linear Euler 2D
+    !! flux; auxiliary variables 5-7 carry zero flux in both directions
     !! and are evolved purely by the PML source term.
     class(LinearEuler2D_PML_t),intent(in) :: this
     real(prec),intent(in) :: s(1:this%nvar)
     real(prec),intent(in) :: dsdx(1:this%nvar,1:2)
     real(prec) :: flux(1:this%nvar,1:2)
 
-    flux(1,1) = this%rho0*s(2) ! density, x flux ; rho0*u
-    flux(1,2) = this%rho0*s(3) ! density, y flux ; rho0*v
-    flux(2,1) = s(4)/this%rho0 ! x-velocity, x flux; p/rho0
-    flux(2,2) = 0.0_prec ! x-velocity, y flux; 0
-    flux(3,1) = 0.0_prec ! y-velocity, x flux; 0
-    flux(3,2) = s(4)/this%rho0 ! y-velocity, y flux; p/rho0
-    flux(4,1) = s(5)*s(5)*this%rho0*s(2) ! pressure, x flux : rho0*c^2*u
-    flux(4,2) = s(5)*s(5)*this%rho0*s(3) ! pressure, y flux : rho0*c^2*v
-    flux(5,1) = 0.0_prec ! sound speed, x flux; 0 (c held fixed in time)
-    flux(5,2) = 0.0_prec ! sound speed, y flux; 0
-    flux(6:9,1) = 0.0_prec ! PML auxiliaries evolve only via source term
-    flux(6:9,2) = 0.0_prec
+    flux(1,1) = s(3)/this%rho0 ! x-velocity, x flux; p/rho0
+    flux(1,2) = 0.0_prec ! x-velocity, y flux; 0
+    flux(2,1) = 0.0_prec ! y-velocity, x flux; 0
+    flux(2,2) = s(3)/this%rho0 ! y-velocity, y flux; p/rho0
+    flux(3,1) = s(4)*s(4)*this%rho0*s(1) ! pressure, x flux : rho0*c^2*u
+    flux(3,2) = s(4)*s(4)*this%rho0*s(2) ! pressure, y flux : rho0*c^2*v
+    flux(4,1) = 0.0_prec ! sound speed, x flux; 0 (c held fixed in time)
+    flux(4,2) = 0.0_prec ! sound speed, y flux; 0
+    flux(5:7,1) = 0.0_prec ! PML auxiliaries evolve only via source term
+    flux(5:7,2) = 0.0_prec
     if(.false.) flux(1,1) = flux(1,1)+dsdx(1,1) ! suppress unused-dummy-argument warning
 
   endfunction flux2d_LinearEuler2D_PML_t
 
   pure function riemannflux2d_LinearEuler2D_PML_t(this,sL,sR,dsdx,nhat) result(flux)
-    !! Impedance-matched Riemann flux for acoustic variables 1-5, with
-    !! zero flux returned for the auxiliary variables 6-9. The acoustic
+    !! Impedance-matched Riemann flux for acoustic variables 1-4, with
+    !! zero flux returned for the auxiliary variables 5-7. The acoustic
     !! formula is identical to the parent LinearEuler2D model; see
     !! riemannflux2d_LinearEuler2D_t for the derivation.
     class(LinearEuler2D_PML_t),intent(in) :: this
@@ -294,26 +290,25 @@ contains
     real(prec) :: rho0,cL,cR,ZL,ZR,unL,unR,pL,pR,un_star,p_star,c2_avg
 
     rho0 = this%rho0
-    cL = sL(5)
-    cR = sR(5)
+    cL = sL(4)
+    cR = sR(4)
     ZL = rho0*cL
     ZR = rho0*cR
 
-    unL = sL(2)*nhat(1)+sL(3)*nhat(2)
-    unR = sR(2)*nhat(1)+sR(3)*nhat(2)
-    pL = sL(4)
-    pR = sR(4)
+    unL = sL(1)*nhat(1)+sL(2)*nhat(2)
+    unR = sR(1)*nhat(1)+sR(2)*nhat(2)
+    pL = sL(3)
+    pR = sR(3)
 
     un_star = (ZL*unL+ZR*unR+(pL-pR))/(ZL+ZR)
     p_star = (ZR*pL+ZL*pR+ZL*ZR*(unL-unR))/(ZL+ZR)
     c2_avg = 0.5_prec*(cL*cL+cR*cR)
 
-    flux(1) = rho0*un_star
-    flux(2) = p_star*nhat(1)/rho0
-    flux(3) = p_star*nhat(2)/rho0
-    flux(4) = rho0*c2_avg*un_star
-    flux(5) = 0.0_prec
-    flux(6:9) = 0.0_prec
+    flux(1) = p_star*nhat(1)/rho0
+    flux(2) = p_star*nhat(2)/rho0
+    flux(3) = rho0*c2_avg*un_star
+    flux(4) = 0.0_prec
+    flux(5:7) = 0.0_prec
     if(.false.) flux(1) = flux(1)+dsdx(1,1) ! suppress unused-dummy-argument warning
 
   endfunction riemannflux2d_LinearEuler2D_PML_t
@@ -344,15 +339,13 @@ contains
       sy = this%sigma_y%interior(i,j,iel,1)
       s = this%solution%interior(i,j,iel,1:this%nvar)
 
-      this%source%interior(i,j,iel,1) = -(sx+sy)*s(1)-sx*sy*s(6)
-      this%source%interior(i,j,iel,2) = -(sx+sy)*s(2)-sx*sy*s(7)
-      this%source%interior(i,j,iel,3) = -(sx+sy)*s(3)-sx*sy*s(8)
-      this%source%interior(i,j,iel,4) = -(sx+sy)*s(4)-sx*sy*s(9)
-      this%source%interior(i,j,iel,5) = 0.0_prec
-      this%source%interior(i,j,iel,6) = s(1)
-      this%source%interior(i,j,iel,7) = s(2)
-      this%source%interior(i,j,iel,8) = s(3)
-      this%source%interior(i,j,iel,9) = s(4)
+      this%source%interior(i,j,iel,1) = -(sx+sy)*s(1)-sx*sy*s(5)
+      this%source%interior(i,j,iel,2) = -(sx+sy)*s(2)-sx*sy*s(6)
+      this%source%interior(i,j,iel,3) = -(sx+sy)*s(3)-sx*sy*s(7)
+      this%source%interior(i,j,iel,4) = 0.0_prec
+      this%source%interior(i,j,iel,5) = s(1)
+      this%source%interior(i,j,iel,6) = s(2)
+      this%source%interior(i,j,iel,7) = s(3)
 
     enddo
 
@@ -360,8 +353,8 @@ contains
 
   subroutine hbc2d_NoNormalFlow_LinearEuler2D_PML(bc,mymodel)
     !! No-normal-flow BC for the PML-augmented linear Euler model.
-    !! Variables 1-5 are treated identically to the parent
-    !! LinearEuler2D no-normal-flow BC. Auxiliary variables 6-9 are
+    !! Variables 1-4 are treated identically to the parent
+    !! LinearEuler2D no-normal-flow BC. Auxiliary variables 5-7 are
     !! given a zero exterior state; since they carry zero Riemann flux
     !! the exterior value is mathematically irrelevant, but zeroing it
     !! keeps the boundary state clean for diagnostics.
@@ -369,7 +362,7 @@ contains
     class(Model),intent(inout) :: mymodel
     ! Local
     integer :: n,i,iEl,j
-    real(prec) :: nhat(1:2),s(1:5)
+    real(prec) :: nhat(1:2),s(1:4)
 
     select type(m => mymodel)
     class is(LinearEuler2D_PML_t)
@@ -378,15 +371,14 @@ contains
         j = bc%sides(n)
         do i = 1,m%solution%interp%N+1
           nhat = m%geometry%nhat%boundary(i,j,iEl,1,1:2)
-          s = m%solution%boundary(i,j,iEl,1:5)
-          m%solution%extBoundary(i,j,iEl,1) = s(1) ! density
+          s = m%solution%boundary(i,j,iEl,1:4)
+          m%solution%extBoundary(i,j,iEl,1) = &
+            (nhat(2)**2-nhat(1)**2)*s(1)-2.0_prec*nhat(1)*nhat(2)*s(2) ! u
           m%solution%extBoundary(i,j,iEl,2) = &
-            (nhat(2)**2-nhat(1)**2)*s(2)-2.0_prec*nhat(1)*nhat(2)*s(3) ! u
-          m%solution%extBoundary(i,j,iEl,3) = &
-            (nhat(1)**2-nhat(2)**2)*s(3)-2.0_prec*nhat(1)*nhat(2)*s(2) ! v
-          m%solution%extBoundary(i,j,iEl,4) = s(4) ! p
-          m%solution%extBoundary(i,j,iEl,5) = s(5) ! c
-          m%solution%extBoundary(i,j,iEl,6:9) = 0.0_prec ! PML auxiliaries
+            (nhat(1)**2-nhat(2)**2)*s(2)-2.0_prec*nhat(1)*nhat(2)*s(1) ! v
+          m%solution%extBoundary(i,j,iEl,3) = s(3) ! p
+          m%solution%extBoundary(i,j,iEl,4) = s(4) ! c
+          m%solution%extBoundary(i,j,iEl,5:7) = 0.0_prec ! PML auxiliaries
         enddo
       enddo
     endselect
@@ -412,9 +404,8 @@ contains
           m%solution%extBoundary(i,j,iEl,1) = 0.0_prec
           m%solution%extBoundary(i,j,iEl,2) = 0.0_prec
           m%solution%extBoundary(i,j,iEl,3) = 0.0_prec
-          m%solution%extBoundary(i,j,iEl,4) = 0.0_prec
-          m%solution%extBoundary(i,j,iEl,5) = m%solution%boundary(i,j,iEl,5) ! c preserved
-          m%solution%extBoundary(i,j,iEl,6:9) = 0.0_prec
+          m%solution%extBoundary(i,j,iEl,4) = m%solution%boundary(i,j,iEl,4) ! c preserved
+          m%solution%extBoundary(i,j,iEl,5:7) = 0.0_prec
         enddo
       enddo
     endselect

--- a/src/SELF_LinearEuler2D_t.f90
+++ b/src/SELF_LinearEuler2D_t.f90
@@ -29,11 +29,17 @@ module self_LinearEuler2D_t
 !! equations in 2-D. The Linear Euler Equations, here, are the Euler equations
 !! linearized about a motionless background state.
 !!
+!! The density anomaly is not carried as a solution variable: for a motionless
+!! background state it is slaved to the pressure through \(\rho = p/c^2\) and
+!! never feeds back into the velocity or pressure dynamics, so only the
+!! velocity components and the pressure are forward-stepped. If the density
+!! anomaly is needed as a diagnostic, it can be recovered pointwise as
+!! \(\rho = p/c^2\).
+!!
 !! The solution variables are
 !!
 !! \begin{equation}
 !! \vec{s} = \begin{pmatrix}
-!!     \rho \\
 !!      u \\
 !!      v \\
 !!      p \\
@@ -54,7 +60,6 @@ module self_LinearEuler2D_t
 !!
 !! \begin{equation}
 !! \overleftrightarrow{f} = \begin{pmatrix}
-!!     \rho_0 u \hat{x} + \rho_0 v \hat{y} \\
 !!      \frac{p}{\rho_0} \hat{x} \\
 !!      \frac{p}{\rho_0} \hat{y} \\
 !!      c^2 \rho_0 ( u \hat{x} + v \hat{y} ) \\
@@ -75,7 +80,7 @@ module self_LinearEuler2D_t
 
   type,extends(dgmodel2d) :: LinearEuler2D_t
     ! Add any additional attributes here that are specific to your model
-    real(prec) :: rho0 = 1.0_prec ! Reference density (used to fill variable 6 in initial conditions)
+    real(prec) :: rho0 = 1.0_prec ! Reference density (used to fill variable 5 in initial conditions)
     real(prec) :: g = 0.0_prec ! gravitational acceleration (y-direction only)
 
   contains
@@ -96,13 +101,13 @@ contains
     implicit none
     class(LinearEuler2D_t),intent(inout) :: this
 
-    this%nvar = 6
-    ! Only the first four variables (rho, u, v, P) are advanced in time. The
-    ! fifth and sixth variables, the sound speed c and background density rho0,
+    this%nvar = 5
+    ! Only the first three variables (u, v, P) are advanced in time. The
+    ! fourth and fifth variables, the sound speed c and background density rho0,
     ! are spatially-varying but time-constant background fields: their flux and
     ! source are identically zero, so they are excluded from time integration
     ! rather than stepped to a no-op.
-    this%nstepped = 4
+    this%nstepped = 3
 
   endsubroutine SetNumberOfVariables_LinearEuler2D_t
 
@@ -110,23 +115,20 @@ contains
     implicit none
     class(LinearEuler2D_t),intent(inout) :: this
 
-    call this%solution%SetName(1,"rho") ! Density
-    call this%solution%SetUnits(1,"kg⋅m⁻³")
+    call this%solution%SetName(1,"u") ! x-velocity component
+    call this%solution%SetUnits(1,"m⋅s⁻¹")
 
-    call this%solution%SetName(2,"u") ! x-velocity component
+    call this%solution%SetName(2,"v") ! y-velocity component
     call this%solution%SetUnits(2,"m⋅s⁻¹")
 
-    call this%solution%SetName(3,"v") ! y-velocity component
-    call this%solution%SetUnits(3,"m⋅s⁻¹")
+    call this%solution%SetName(3,"P") ! Pressure
+    call this%solution%SetUnits(3,"kg⋅m⁻¹⋅s⁻²")
 
-    call this%solution%SetName(4,"P") ! Pressure
-    call this%solution%SetUnits(4,"kg⋅m⁻¹⋅s⁻²")
+    call this%solution%SetName(4,"c") ! Sound speed
+    call this%solution%SetUnits(4,"m⋅s⁻¹")
 
-    call this%solution%SetName(5,"c") ! Sound speed
-    call this%solution%SetUnits(5,"m⋅s⁻¹")
-
-    call this%solution%SetName(6,"rho0") ! Background density (static; possibly heterogeneous)
-    call this%solution%SetUnits(6,"kg⋅m⁻³")
+    call this%solution%SetName(5,"rho0") ! Background density (static; possibly heterogeneous)
+    call this%solution%SetUnits(5,"kg⋅m⁻³")
 
   endsubroutine SetMetadata_LinearEuler2D_t
 
@@ -137,14 +139,14 @@ contains
     !! \begin{equation}
     !!   e = \frac{1}{2} \left( \rho_0*( u^2 + v^2 ) + \frac{P^2}{\rho_0 c^2} \right)
     !!
-    !! where the sound speed c is taken from s(5) and the background density
-    !! rho0 from s(6).
+    !! where the sound speed c is taken from s(4) and the background density
+    !! rho0 from s(5).
     class(LinearEuler2D_t),intent(in) :: this
     real(prec),intent(in) :: s(1:this%nvar)
     real(prec) :: e
 
-    e = 0.5_prec*s(6)*(s(2)*s(2)+s(3)*s(3))+ &
-        0.5_prec*(s(4)*s(4)/(s(6)*s(5)*s(5)))
+    e = 0.5_prec*s(5)*(s(1)*s(1)+s(2)*s(2))+ &
+        0.5_prec*(s(3)*s(3)/(s(5)*s(4)*s(4)))
 
   endfunction entropy_func_LinearEuler2D_t
 
@@ -169,7 +171,7 @@ contains
 
   subroutine hbc2d_Radiation_LinearEuler2D(bc,mymodel)
     !! Radiation BC: zero acoustic perturbation in the exterior state; the
-    !! sound speed (variable 5) and background density (variable 6) are copied
+    !! sound speed (variable 4) and background density (variable 5) are copied
     !! from the interior side so the Riemann solver sees a consistent c and
     !! rho0 (impedance-matched, non-reflecting outflow).
     class(BoundaryCondition),intent(in) :: bc
@@ -183,9 +185,9 @@ contains
         iEl = bc%elements(n)
         j = bc%sides(n)
         do i = 1,m%solution%interp%N+1
-          m%solution%extBoundary(i,j,iEl,1:4) = 0.0_prec
-          m%solution%extBoundary(i,j,iEl,5) = m%solution%boundary(i,j,iEl,5) ! c preserved
-          m%solution%extBoundary(i,j,iEl,6) = m%solution%boundary(i,j,iEl,6) ! rho0 preserved
+          m%solution%extBoundary(i,j,iEl,1:3) = 0.0_prec
+          m%solution%extBoundary(i,j,iEl,4) = m%solution%boundary(i,j,iEl,4) ! c preserved
+          m%solution%extBoundary(i,j,iEl,5) = m%solution%boundary(i,j,iEl,5) ! rho0 preserved
         enddo
       enddo
     endselect
@@ -195,12 +197,12 @@ contains
   subroutine hbc2d_NoNormalFlow_LinearEuler2D(bc,mymodel)
     !! No-normal-flow boundary condition for 2D linear Euler equations.
     !! Reflects the velocity vector about the boundary normal while
-    !! preserving density, pressure, sound speed, and background density.
+    !! preserving pressure, sound speed, and background density.
     class(BoundaryCondition),intent(in) :: bc
     class(Model),intent(inout) :: mymodel
     ! Local
     integer :: n,i,iEl,j
-    real(prec) :: nhat(1:2),s(1:6)
+    real(prec) :: nhat(1:2),s(1:5)
 
     select type(m => mymodel)
     class is(LinearEuler2D_t)
@@ -209,15 +211,14 @@ contains
         j = bc%sides(n)
         do i = 1,m%solution%interp%N+1
           nhat = m%geometry%nhat%boundary(i,j,iEl,1,1:2)
-          s = m%solution%boundary(i,j,iEl,1:6)
-          m%solution%extBoundary(i,j,iEl,1) = s(1) ! density
+          s = m%solution%boundary(i,j,iEl,1:5)
+          m%solution%extBoundary(i,j,iEl,1) = &
+            (nhat(2)**2-nhat(1)**2)*s(1)-2.0_prec*nhat(1)*nhat(2)*s(2) ! u
           m%solution%extBoundary(i,j,iEl,2) = &
-            (nhat(2)**2-nhat(1)**2)*s(2)-2.0_prec*nhat(1)*nhat(2)*s(3) ! u
-          m%solution%extBoundary(i,j,iEl,3) = &
-            (nhat(1)**2-nhat(2)**2)*s(3)-2.0_prec*nhat(1)*nhat(2)*s(2) ! v
-          m%solution%extBoundary(i,j,iEl,4) = s(4) ! p
-          m%solution%extBoundary(i,j,iEl,5) = s(5) ! c
-          m%solution%extBoundary(i,j,iEl,6) = s(6) ! rho0
+            (nhat(1)**2-nhat(2)**2)*s(2)-2.0_prec*nhat(1)*nhat(2)*s(1) ! v
+          m%solution%extBoundary(i,j,iEl,3) = s(3) ! p
+          m%solution%extBoundary(i,j,iEl,4) = s(4) ! c
+          m%solution%extBoundary(i,j,iEl,5) = s(5) ! rho0
         enddo
       enddo
     endselect
@@ -230,18 +231,16 @@ contains
     real(prec),intent(in) :: dsdx(1:this%nvar,1:2)
     real(prec) :: flux(1:this%nvar,1:2)
 
-    flux(1,1) = s(6)*s(2) ! density, x flux ; rho0*u
-    flux(1,2) = s(6)*s(3) ! density, y flux ; rho0*v
-    flux(2,1) = s(4)/s(6) ! x-velocity, x flux; p/rho0
-    flux(2,2) = 0.0_prec ! x-velocity, y flux; 0
-    flux(3,1) = 0.0_prec ! y-velocity, x flux; 0
-    flux(3,2) = s(4)/s(6) ! y-velocity, y flux; p/rho0
-    flux(4,1) = s(5)*s(5)*s(6)*s(2) ! pressure, x flux : rho0*c^2*u
-    flux(4,2) = s(5)*s(5)*s(6)*s(3) ! pressure, y flux : rho0*c^2*v
-    flux(5,1) = 0.0_prec ! sound speed, x flux; 0 (c is held fixed in time)
-    flux(5,2) = 0.0_prec ! sound speed, y flux; 0 (c is held fixed in time)
-    flux(6,1) = 0.0_prec ! background density, x flux; 0 (rho0 is held fixed in time)
-    flux(6,2) = 0.0_prec ! background density, y flux; 0 (rho0 is held fixed in time)
+    flux(1,1) = s(3)/s(5) ! x-velocity, x flux; p/rho0
+    flux(1,2) = 0.0_prec ! x-velocity, y flux; 0
+    flux(2,1) = 0.0_prec ! y-velocity, x flux; 0
+    flux(2,2) = s(3)/s(5) ! y-velocity, y flux; p/rho0
+    flux(3,1) = s(4)*s(4)*s(5)*s(1) ! pressure, x flux : rho0*c^2*u
+    flux(3,2) = s(4)*s(4)*s(5)*s(2) ! pressure, y flux : rho0*c^2*v
+    flux(4,1) = 0.0_prec ! sound speed, x flux; 0 (c is held fixed in time)
+    flux(4,2) = 0.0_prec ! sound speed, y flux; 0 (c is held fixed in time)
+    flux(5,1) = 0.0_prec ! background density, x flux; 0 (rho0 is held fixed in time)
+    flux(5,2) = 0.0_prec ! background density, y flux; 0 (rho0 is held fixed in time)
     if(.false.) flux(1,1) = flux(1,1)+dsdx(1,1) ! suppress unused-dummy-argument warning
 
   endfunction flux2d_LinearEuler2D_t
@@ -253,7 +252,6 @@ contains
     !! The normal-flux Jacobian has eigenstructure
     !!   +c : right-going acoustic mode, W_+ = rho0*c*u_n + p
     !!   -c : left-going  acoustic mode, W_- = -rho0*c*u_n + p
-    !!    0 : entropy density mode      , W_0 = rho' - p/c^2
     !!    0 : tangential vorticity mode , u_t
     !! Upwinding each mode by its characteristic direction at the face,
     !!   W_+|* = W_+|_L   (transmitted from left,  at speed +c_L)
@@ -266,11 +264,11 @@ contains
     !! Godunov for the linearised acoustic system and reduces correctly to
     !! Fresnel reflection / transmission across an impedance jump (Z_L .ne. Z_R,
     !! whether from a density jump, a sound-speed jump, or both). LLF with
-    !! cmax = max(c_L, c_R) over-dissipates tangential and entropy modes
+    !! cmax = max(c_L, c_R) over-dissipates the tangential mode
     !! and at high polynomial order fails to stably handle the
     !! impedance mismatch (aliasing instability at material interfaces).
     !!
-    !! The reconstructed density/momentum/pressure fluxes need a single rho0
+    !! The reconstructed momentum/pressure fluxes need a single rho0
     !! (and c^2) at the face, but rho0 and c are two-valued across a material
     !! interface. We use the arithmetic averages rho0_avg and c2_avg; this is a
     !! pragmatic treatment of the non-conservative products p/rho0 and
@@ -288,29 +286,28 @@ contains
     ! Local
     real(prec) :: rho0L,rho0R,rho0_avg,cL,cR,ZL,ZR,unL,unR,pL,pR,un_star,p_star,c2_avg
 
-    rho0L = sL(6)
-    rho0R = sR(6)
+    rho0L = sL(5)
+    rho0R = sR(5)
     rho0_avg = 0.5_prec*(rho0L+rho0R)
-    cL = sL(5)
-    cR = sR(5)
+    cL = sL(4)
+    cR = sR(4)
     ZL = rho0L*cL
     ZR = rho0R*cR
 
-    unL = sL(2)*nhat(1)+sL(3)*nhat(2)
-    unR = sR(2)*nhat(1)+sR(3)*nhat(2)
-    pL = sL(4)
-    pR = sR(4)
+    unL = sL(1)*nhat(1)+sL(2)*nhat(2)
+    unR = sR(1)*nhat(1)+sR(2)*nhat(2)
+    pL = sL(3)
+    pR = sR(3)
 
     un_star = (ZL*unL+ZR*unR+(pL-pR))/(ZL+ZR)
     p_star = (ZR*pL+ZL*pR+ZL*ZR*(unL-unR))/(ZL+ZR)
     c2_avg = 0.5_prec*(cL*cL+cR*cR)
 
-    flux(1) = rho0_avg*un_star
-    flux(2) = p_star*nhat(1)/rho0_avg
-    flux(3) = p_star*nhat(2)/rho0_avg
-    flux(4) = rho0_avg*c2_avg*un_star
+    flux(1) = p_star*nhat(1)/rho0_avg
+    flux(2) = p_star*nhat(2)/rho0_avg
+    flux(3) = rho0_avg*c2_avg*un_star
+    flux(4) = 0.0_prec
     flux(5) = 0.0_prec
-    flux(6) = 0.0_prec
     if(.false.) flux(1) = flux(1)+dsdx(1,1) ! suppress unused-dummy-argument warning
 
   endfunction riemannflux2d_LinearEuler2D_t
@@ -321,14 +318,16 @@ contains
     !!
     !! \begin{equation}
     !! \begin{aligned}
-    !! \rho &= \rho_0 + \rho' \exp\left( -\ln(2) \frac{(x-x_0)^2 + (y-y_0)^2}{L_r^2} \right)
     !! u &= 0 \\
     !! v &= 0 \\
-    !! E &= \frac{P_0}{\gamma - 1} + E \exp\left( -\ln(2) \frac{(x-x_0)^2 + (y-y_0)^2}{L_e^2} \right)
+    !! p &= \rho' c^2 \exp\left( -\ln(2) \frac{(x-x_0)^2 + (y-y_0)^2}{L_r^2} \right)
     !! \end{aligned}
     !! \end{equation}
     !!
-    !! The sound speed `c` (passed as an argument since it is no longer a
+    !! `rhoprime` is the amplitude of the (diagnostic) density anomaly that the
+    !! pressure pulse corresponds to through the acoustic relation p = rho*c^2;
+    !! the density anomaly itself is not a solution variable.
+    !! The sound speed `c` (passed as an argument since it is not a
     !! scalar model attribute) and the background density `this%rho0` are set
     !! uniformly across the domain.
     implicit none
@@ -353,12 +352,11 @@ contains
 
       rho = (rhoprime)*exp(-log(2.0_prec)*r**2/Lr**2)
 
-      this%solution%interior(i,j,iEl,1) = rho
+      this%solution%interior(i,j,iEl,1) = 0.0_prec
       this%solution%interior(i,j,iEl,2) = 0.0_prec
-      this%solution%interior(i,j,iEl,3) = 0.0_prec
-      this%solution%interior(i,j,iEl,4) = rho*c*c
-      this%solution%interior(i,j,iEl,5) = c
-      this%solution%interior(i,j,iEl,6) = this%rho0 ! uniform background density
+      this%solution%interior(i,j,iEl,3) = rho*c*c
+      this%solution%interior(i,j,iEl,4) = c
+      this%solution%interior(i,j,iEl,5) = this%rho0 ! uniform background density
 
     enddo
 

--- a/src/SELF_LinearEuler3D_t.f90
+++ b/src/SELF_LinearEuler3D_t.f90
@@ -32,11 +32,17 @@ module self_LinearEuler3D_t
 !! possibly spatially varying) so that heterogeneous media are supported,
 !! mirroring the 2-D model.
 !!
+!! The density anomaly is not carried as a solution variable: for a motionless
+!! background state it is slaved to the pressure through \(\rho = p/c^2\) and
+!! never feeds back into the velocity or pressure dynamics, so only the
+!! velocity components and the pressure are forward-stepped. If the density
+!! anomaly is needed as a diagnostic, it can be recovered pointwise as
+!! \(\rho = p/c^2\).
+!!
 !! The solution variables are
 !!
 !! \begin{equation}
 !! \vec{s} = \begin{pmatrix}
-!!     \rho \\
 !!      u \\
 !!      v \\
 !!      w \\
@@ -50,7 +56,6 @@ module self_LinearEuler3D_t
 !!
 !! \begin{equation}
 !! \overleftrightarrow{f} = \begin{pmatrix}
-!!     \rho_0 u \hat{x} + \rho_0 v \hat{y} + \rho_0 w \hat{z} \\
 !!      \frac{p}{\rho_0} \hat{x} \\
 !!      \frac{p}{\rho_0} \hat{y} \\
 !!      \frac{p}{\rho_0} \hat{z} \\
@@ -77,8 +82,8 @@ module self_LinearEuler3D_t
 
   type,extends(dgmodel3D) :: LinearEuler3D_t
     ! Add any additional attributes here that are specific to your model
-    real(prec) :: rho0 = 1.0_prec ! Reference density (used to fill variable 7 in initial conditions)
-    real(prec) :: c = 1.0_prec ! Reference sound speed (used to fill variable 6 in initial conditions)
+    real(prec) :: rho0 = 1.0_prec ! Reference density (used to fill variable 6 in initial conditions)
+    real(prec) :: c = 1.0_prec ! Reference sound speed (used to fill variable 5 in initial conditions)
     real(prec) :: g = 0.0_prec ! gravitational acceleration (y-direction only)
 
   contains
@@ -99,13 +104,13 @@ contains
     implicit none
     class(LinearEuler3D_t),intent(inout) :: this
 
-    this%nvar = 7
-    ! Only the first five variables (rho, u, v, w, P) are advanced in time. The
-    ! sixth and seventh variables, the sound speed c and background density
+    this%nvar = 6
+    ! Only the first four variables (u, v, w, P) are advanced in time. The
+    ! fifth and sixth variables, the sound speed c and background density
     ! rho0, are spatially-varying but time-constant background fields: their
     ! flux and source are identically zero, so they are excluded from time
     ! integration rather than stepped to a no-op.
-    this%nstepped = 5
+    this%nstepped = 4
 
   endsubroutine SetNumberOfVariables_LinearEuler3D_t
 
@@ -113,26 +118,23 @@ contains
     implicit none
     class(LinearEuler3D_t),intent(inout) :: this
 
-    call this%solution%SetName(1,"rho") ! Density
-    call this%solution%SetUnits(1,"kg⋅m⁻³")
+    call this%solution%SetName(1,"u") ! x-velocity component
+    call this%solution%SetUnits(1,"m⋅s⁻¹")
 
-    call this%solution%SetName(2,"u") ! x-velocity component
+    call this%solution%SetName(2,"v") ! y-velocity component
     call this%solution%SetUnits(2,"m⋅s⁻¹")
 
-    call this%solution%SetName(3,"v") ! y-velocity component
+    call this%solution%SetName(3,"w") ! z-velocity component
     call this%solution%SetUnits(3,"m⋅s⁻¹")
 
-    call this%solution%SetName(4,"w") ! z-velocity component
-    call this%solution%SetUnits(4,"m⋅s⁻¹")
+    call this%solution%SetName(4,"P") ! Pressure
+    call this%solution%SetUnits(4,"kg⋅m⁻¹⋅s⁻²")
 
-    call this%solution%SetName(5,"P") ! Pressure
-    call this%solution%SetUnits(5,"kg⋅m⁻¹⋅s⁻²")
+    call this%solution%SetName(5,"c") ! Sound speed (static; possibly heterogeneous)
+    call this%solution%SetUnits(5,"m⋅s⁻¹")
 
-    call this%solution%SetName(6,"c") ! Sound speed (static; possibly heterogeneous)
-    call this%solution%SetUnits(6,"m⋅s⁻¹")
-
-    call this%solution%SetName(7,"rho0") ! Background density (static; possibly heterogeneous)
-    call this%solution%SetUnits(7,"kg⋅m⁻³")
+    call this%solution%SetName(6,"rho0") ! Background density (static; possibly heterogeneous)
+    call this%solution%SetUnits(6,"kg⋅m⁻³")
 
   endsubroutine SetMetadata_LinearEuler3D_t
 
@@ -152,7 +154,7 @@ contains
 
   subroutine hbc3d_Radiation_LinearEuler3D(bc,mymodel)
     !! Radiation BC: zero acoustic perturbation in the exterior state; the
-    !! sound speed (variable 6) and background density (variable 7) are copied
+    !! sound speed (variable 5) and background density (variable 6) are copied
     !! from the interior side so the Riemann solver sees a consistent c and
     !! rho0.
     class(BoundaryCondition),intent(in) :: bc
@@ -167,9 +169,9 @@ contains
         s = bc%sides(n)
         do j = 1,m%solution%interp%N+1
           do i = 1,m%solution%interp%N+1
-            m%solution%extBoundary(i,j,s,iEl,1:5) = 0.0_prec
-            m%solution%extBoundary(i,j,s,iEl,6) = m%solution%boundary(i,j,s,iEl,6) ! c preserved
-            m%solution%extBoundary(i,j,s,iEl,7) = m%solution%boundary(i,j,s,iEl,7) ! rho0 preserved
+            m%solution%extBoundary(i,j,s,iEl,1:4) = 0.0_prec
+            m%solution%extBoundary(i,j,s,iEl,5) = m%solution%boundary(i,j,s,iEl,5) ! c preserved
+            m%solution%extBoundary(i,j,s,iEl,6) = m%solution%boundary(i,j,s,iEl,6) ! rho0 preserved
           enddo
         enddo
       enddo
@@ -184,14 +186,14 @@ contains
     !! \begin{equation}
     !!   e = \frac{1}{2} \left( \rho_0*( u^2 + v^2 + w^2 ) + \frac{P^2}{\rho_0 c^2} \right)
     !!
-    !! where the sound speed c is taken from s(6) and the background density
-    !! rho0 from s(7).
+    !! where the sound speed c is taken from s(5) and the background density
+    !! rho0 from s(6).
     class(LinearEuler3D_t),intent(in) :: this
     real(prec),intent(in) :: s(1:this%nvar)
     real(prec) :: e
 
-    e = 0.5_prec*s(7)*(s(2)*s(2)+s(3)*s(3)+s(4)*s(4))+ &
-        0.5_prec*(s(5)*s(5)/(s(7)*s(6)*s(6)))
+    e = 0.5_prec*s(6)*(s(1)*s(1)+s(2)*s(2)+s(3)*s(3))+ &
+        0.5_prec*(s(4)*s(4)/(s(6)*s(5)*s(5)))
 
   endfunction entropy_func_LinearEuler3D_t
 
@@ -209,33 +211,29 @@ contains
     real(prec),intent(in) :: dsdx(1:this%nvar,1:3)
     real(prec) :: flux(1:this%nvar,1:3)
 
-    flux(1,1) = s(7)*s(2) ! density, x flux ; rho0*u
-    flux(1,2) = s(7)*s(3) ! density, y flux ; rho0*v
-    flux(1,3) = s(7)*s(4) ! density, y flux ; rho0*w
+    flux(1,1) = s(4)/s(6) ! x-velocity, x flux; p/rho0
+    flux(1,2) = 0.0_prec ! x-velocity, y flux; 0
+    flux(1,3) = 0.0_prec ! x-velocity, z flux; 0
 
-    flux(2,1) = s(5)/s(7) ! x-velocity, x flux; p/rho0
-    flux(2,2) = 0.0_prec ! x-velocity, y flux; 0
-    flux(2,3) = 0.0_prec ! x-velocity, z flux; 0
+    flux(2,1) = 0.0_prec ! y-velocity, x flux; 0
+    flux(2,2) = s(4)/s(6) ! y-velocity, y flux; p/rho0
+    flux(2,3) = 0.0_prec ! y-velocity, z flux; 0
 
-    flux(3,1) = 0.0_prec ! y-velocity, x flux; 0
-    flux(3,2) = s(5)/s(7) ! y-velocity, y flux; p/rho0
-    flux(3,3) = 0.0_prec ! y-velocity, z flux; 0
+    flux(3,1) = 0.0_prec ! z-velocity, x flux; 0
+    flux(3,2) = 0.0_prec ! z-velocity, y flux; 0
+    flux(3,3) = s(4)/s(6) ! z-velocity, z flux; p/rho0
 
-    flux(4,1) = 0.0_prec ! z-velocity, x flux; 0
-    flux(4,2) = 0.0_prec ! z-velocity, y flux; 0
-    flux(4,3) = s(5)/s(7) ! z-velocity, z flux; p/rho0
+    flux(4,1) = s(5)*s(5)*s(6)*s(1) ! pressure, x flux : rho0*c^2*u
+    flux(4,2) = s(5)*s(5)*s(6)*s(2) ! pressure, y flux : rho0*c^2*v
+    flux(4,3) = s(5)*s(5)*s(6)*s(3) ! pressure, z flux : rho0*c^2*w
 
-    flux(5,1) = s(6)*s(6)*s(7)*s(2) ! pressure, x flux : rho0*c^2*u
-    flux(5,2) = s(6)*s(6)*s(7)*s(3) ! pressure, y flux : rho0*c^2*v
-    flux(5,3) = s(6)*s(6)*s(7)*s(4) ! pressure, z flux : rho0*c^2*w
+    flux(5,1) = 0.0_prec ! sound speed, x flux; 0 (c held fixed in time)
+    flux(5,2) = 0.0_prec ! sound speed, y flux; 0
+    flux(5,3) = 0.0_prec ! sound speed, z flux; 0
 
-    flux(6,1) = 0.0_prec ! sound speed, x flux; 0 (c held fixed in time)
-    flux(6,2) = 0.0_prec ! sound speed, y flux; 0
-    flux(6,3) = 0.0_prec ! sound speed, z flux; 0
-
-    flux(7,1) = 0.0_prec ! background density, x flux; 0 (rho0 held fixed in time)
-    flux(7,2) = 0.0_prec ! background density, y flux; 0
-    flux(7,3) = 0.0_prec ! background density, z flux; 0
+    flux(6,1) = 0.0_prec ! background density, x flux; 0 (rho0 held fixed in time)
+    flux(6,2) = 0.0_prec ! background density, y flux; 0
+    flux(6,3) = 0.0_prec ! background density, z flux; 0
     if(.false.) flux(1,1) = flux(1,1)+dsdx(1,1) ! suppress unused-dummy-argument warning
 
   endfunction flux3D_LinearEuler3D_t
@@ -251,7 +249,7 @@ contains
     !!   un* = (ZL*unL + ZR*unR + (pL - pR)) / (ZL + ZR)
     !!   p*  = (ZR*pL + ZL*pR + ZL*ZR*(unL - unR)) / (ZL + ZR)
     !!
-    !! The reconstructed density/momentum/pressure fluxes use the arithmetic
+    !! The reconstructed momentum/pressure fluxes use the arithmetic
     !! averages rho0_avg and c2_avg at the face (see the 2-D model for the
     !! rationale). The sound speed and background density variables carry zero
     !! flux.
@@ -264,30 +262,29 @@ contains
     ! Local
     real(prec) :: rho0L,rho0R,rho0_avg,cL,cR,ZL,ZR,unL,unR,pL,pR,un_star,p_star,c2_avg
 
-    rho0L = sL(7)
-    rho0R = sR(7)
+    rho0L = sL(6)
+    rho0R = sR(6)
     rho0_avg = 0.5_prec*(rho0L+rho0R)
-    cL = sL(6)
-    cR = sR(6)
+    cL = sL(5)
+    cR = sR(5)
     ZL = rho0L*cL
     ZR = rho0R*cR
 
-    unL = sL(2)*nhat(1)+sL(3)*nhat(2)+sL(4)*nhat(3)
-    unR = sR(2)*nhat(1)+sR(3)*nhat(2)+sR(4)*nhat(3)
-    pL = sL(5)
-    pR = sR(5)
+    unL = sL(1)*nhat(1)+sL(2)*nhat(2)+sL(3)*nhat(3)
+    unR = sR(1)*nhat(1)+sR(2)*nhat(2)+sR(3)*nhat(3)
+    pL = sL(4)
+    pR = sR(4)
 
     un_star = (ZL*unL+ZR*unR+(pL-pR))/(ZL+ZR)
     p_star = (ZR*pL+ZL*pR+ZL*ZR*(unL-unR))/(ZL+ZR)
     c2_avg = 0.5_prec*(cL*cL+cR*cR)
 
-    flux(1) = rho0_avg*un_star
-    flux(2) = p_star*nhat(1)/rho0_avg
-    flux(3) = p_star*nhat(2)/rho0_avg
-    flux(4) = p_star*nhat(3)/rho0_avg
-    flux(5) = rho0_avg*c2_avg*un_star
+    flux(1) = p_star*nhat(1)/rho0_avg
+    flux(2) = p_star*nhat(2)/rho0_avg
+    flux(3) = p_star*nhat(3)/rho0_avg
+    flux(4) = rho0_avg*c2_avg*un_star
+    flux(5) = 0.0_prec
     flux(6) = 0.0_prec
-    flux(7) = 0.0_prec
     if(.false.) flux(1) = flux(1)+dsdx(1,1) ! suppress unused-dummy-argument warning
 
   endfunction riemannflux3D_LinearEuler3D_t
@@ -298,12 +295,16 @@ contains
     !!
     !! \begin{equation}
     !! \begin{aligned}
-    !! \rho &= \rho_0 + \rho' \exp\left( -\ln(2) \frac{(x-x_0)^2 + (y-y_0)^2}{L_r^2} \right)
     !! u &= 0 \\
     !! v &= 0 \\
-    !! E &= \frac{P_0}{\gamma - 1} + E \exp\left( -\ln(2) \frac{(x-x_0)^2 + (y-y_0)^2}{L_e^2} \right)
+    !! w &= 0 \\
+    !! p &= \rho' c^2 \exp\left( -\ln(2) \frac{(x-x_0)^2 + (y-y_0)^2 + (z-z_0)^2}{L_r^2} \right)
     !! \end{aligned}
     !! \end{equation}
+    !!
+    !! `rhoprime` is the amplitude of the (diagnostic) density anomaly that the
+    !! pressure pulse corresponds to through the acoustic relation p = rho*c^2;
+    !! the density anomaly itself is not a solution variable.
     !!
     implicit none
     class(LinearEuler3D_t),intent(inout) :: this
@@ -328,13 +329,12 @@ contains
 
       rho = (rhoprime)*exp(-log(2.0_prec)*r**2/Lr**2)
 
-      this%solution%interior(i,j,k,iEl,1) = rho
+      this%solution%interior(i,j,k,iEl,1) = 0.0_prec
       this%solution%interior(i,j,k,iEl,2) = 0.0_prec
       this%solution%interior(i,j,k,iEl,3) = 0.0_prec
-      this%solution%interior(i,j,k,iEl,4) = 0.0_prec
-      this%solution%interior(i,j,k,iEl,5) = rho*this%c*this%c
-      this%solution%interior(i,j,k,iEl,6) = this%c ! uniform background sound speed
-      this%solution%interior(i,j,k,iEl,7) = this%rho0 ! uniform background density
+      this%solution%interior(i,j,k,iEl,4) = rho*this%c*this%c
+      this%solution%interior(i,j,k,iEl,5) = this%c ! uniform background sound speed
+      this%solution%interior(i,j,k,iEl,6) = this%rho0 ! uniform background density
 
     enddo
 

--- a/src/gpu/SELF_LinearEuler2D.cpp
+++ b/src/gpu/SELF_LinearEuler2D.cpp
@@ -34,10 +34,11 @@ __global__ void boundaryflux_LinearEuler2D_kernel(real *fb, real *extfb, real *n
   // linear acoustics with possibly discontinuous sound speed and background
   // density. See the CPU-side Fortran subroutine riemannflux2d_LinearEuler2D_t
   // for the derivation. This replaces LLF, which over-dissipates the tangential
-  // and entropy modes and fails to stably handle the impedance mismatch
+  // mode and fails to stably handle the impedance mismatch
   // at high polynomial order (aliasing instability). The per-side background
-  // density rho0 is read from variable 6 (index 5); the impedances use each
+  // density rho0 is read from variable 5 (index 4); the impedances use each
   // side's own rho0, and the reconstructed fluxes use the face average.
+  // Variable layout (0-based): 0=u, 1=v, 2=p, 3=c, 4=rho0.
   uint32_t idof = threadIdx.x + blockIdx.x*blockDim.x;
 
   if( idof < ndof ){
@@ -45,29 +46,28 @@ __global__ void boundaryflux_LinearEuler2D_kernel(real *fb, real *extfb, real *n
     real ny  = nhat[idof+ndof];
     real nm  = nmag[idof];
 
-    real cL     = fb[idof + 4*ndof];
-    real cR     = extfb[idof + 4*ndof];
-    real rho0L  = fb[idof + 5*ndof];
-    real rho0R  = extfb[idof + 5*ndof];
+    real cL     = fb[idof + 3*ndof];
+    real cR     = extfb[idof + 3*ndof];
+    real rho0L  = fb[idof + 4*ndof];
+    real rho0R  = extfb[idof + 4*ndof];
     real rho0_avg = 0.5*(rho0L + rho0R);
     real ZL  = rho0L*cL;
     real ZR  = rho0R*cR;
 
-    real unL = fb[idof +     ndof]*nx + fb[idof + 2*ndof]*ny;
-    real unR = extfb[idof +  ndof]*nx + extfb[idof + 2*ndof]*ny;
-    real pL  = fb[idof + 3*ndof];
-    real pR  = extfb[idof + 3*ndof];
+    real unL = fb[idof]*nx + fb[idof + ndof]*ny;
+    real unR = extfb[idof]*nx + extfb[idof + ndof]*ny;
+    real pL  = fb[idof + 2*ndof];
+    real pR  = extfb[idof + 2*ndof];
 
     real un_star = (ZL*unL + ZR*unR + (pL - pR)) / (ZL + ZR);
     real p_star  = (ZR*pL  + ZL*pR  + ZL*ZR*(unL - unR)) / (ZL + ZR);
     real c2_avg  = 0.5*(cL*cL + cR*cR);
 
-    flux[idof]          = (rho0_avg*un_star) * nm;          // density
-    flux[idof + ndof]   = (p_star*nx/rho0_avg) * nm;        // u
-    flux[idof + 2*ndof] = (p_star*ny/rho0_avg) * nm;        // v
-    flux[idof + 3*ndof] = (rho0_avg*c2_avg*un_star) * nm;   // pressure
-    flux[idof + 4*ndof] = 0.0;                              // sound speed
-    flux[idof + 5*ndof] = 0.0;                              // background density
+    flux[idof]          = (p_star*nx/rho0_avg) * nm;        // u
+    flux[idof + ndof]   = (p_star*ny/rho0_avg) * nm;        // v
+    flux[idof + 2*ndof] = (rho0_avg*c2_avg*un_star) * nm;   // pressure
+    flux[idof + 3*ndof] = 0.0;                              // sound speed
+    flux[idof + 4*ndof] = 0.0;                              // background density
   }
 }
 
@@ -89,29 +89,26 @@ extern "C"
   uint32_t idof = threadIdx.x + blockIdx.x*blockDim.x;
 
   if( idof < ndof ){
-    real u = solution[idof + ndof];
-    real v = solution[idof + 2*ndof];
-    real p = solution[idof + 3*ndof];
-    real c = solution[idof + 4*ndof];
-    real rho0 = solution[idof + 5*ndof];
+    real u = solution[idof];
+    real v = solution[idof + ndof];
+    real p = solution[idof + 2*ndof];
+    real c = solution[idof + 3*ndof];
+    real rho0 = solution[idof + 4*ndof];
 
-    flux[idof + ndof*(0 + nvar*0)] = rho0*u; // density, x flux ; rho0*u
-    flux[idof + ndof*(0 + nvar*1)] = rho0*v; // density, y flux ; rho0*v
+    flux[idof + ndof*(0 + nvar*0)] = p/rho0; // x-velocity, x flux; p/rho0
+    flux[idof + ndof*(0 + nvar*1)] = 0.0; // x-velocity, y flux; 0
 
-    flux[idof + ndof*(1 + nvar*0)] = p/rho0; // x-velocity, x flux; p/rho0
-    flux[idof + ndof*(1 + nvar*1)] = 0.0; // x-velocity, y flux; 0
+    flux[idof + ndof*(1 + nvar*0)] = 0.0; // y-velocity, x flux; 0
+    flux[idof + ndof*(1 + nvar*1)] = p/rho0; // y-velocity, y flux; p/rho0
 
-    flux[idof + ndof*(2 + nvar*0)] = 0.0; // y-velocity, x flux; 0
-    flux[idof + ndof*(2 + nvar*1)] = p/rho0; // y-velocity, y flux; p/rho0
+    flux[idof + ndof*(2 + nvar*0)] = c*c*rho0*u; // pressure, x flux : rho0*c^2*u
+    flux[idof + ndof*(2 + nvar*1)] = c*c*rho0*v; // pressure, y flux : rho0*c^2*v
 
-    flux[idof + ndof*(3 + nvar*0)] = c*c*rho0*u; // pressure, x flux : rho0*c^2*u
-    flux[idof + ndof*(3 + nvar*1)] = c*c*rho0*v; // pressure, y flux : rho0*c^2*v
+    flux[idof + ndof*(3 + nvar*0)] = 0.0; // sound speed, x flux; 0 (c held fixed in time)
+    flux[idof + ndof*(3 + nvar*1)] = 0.0; // sound speed, y flux; 0 (c held fixed in time)
 
-    flux[idof + ndof*(4 + nvar*0)] = 0.0; // sound speed, x flux; 0 (c held fixed in time)
-    flux[idof + ndof*(4 + nvar*1)] = 0.0; // sound speed, y flux; 0 (c held fixed in time)
-
-    flux[idof + ndof*(5 + nvar*0)] = 0.0; // background density, x flux; 0 (rho0 held fixed in time)
-    flux[idof + ndof*(5 + nvar*1)] = 0.0; // background density, y flux; 0 (rho0 held fixed in time)
+    flux[idof + ndof*(4 + nvar*0)] = 0.0; // background density, x flux; 0 (rho0 held fixed in time)
+    flux[idof + ndof*(4 + nvar*1)] = 0.0; // background density, y flux; 0 (rho0 held fixed in time)
   }
 
 }
@@ -143,17 +140,16 @@ __global__ void hbc2d_nonormalflow_lineareuler2d_kernel(
     uint32_t e1 = elements[n] - 1; // Fortran 1-based to C 0-based
     uint32_t s1 = sides[n] - 1;
 
-    real u  = boundary[SCB_2D_INDEX(i,s1,e1,1,N,nel)];
-    real v  = boundary[SCB_2D_INDEX(i,s1,e1,2,N,nel)];
+    real u  = boundary[SCB_2D_INDEX(i,s1,e1,0,N,nel)];
+    real v  = boundary[SCB_2D_INDEX(i,s1,e1,1,N,nel)];
     real nx = nhat[VEB_2D_INDEX(i,s1,e1,0,0,N,nel,1)];
     real ny = nhat[VEB_2D_INDEX(i,s1,e1,0,1,N,nel,1)];
 
-    extBoundary[SCB_2D_INDEX(i,s1,e1,0,N,nel)] = boundary[SCB_2D_INDEX(i,s1,e1,0,N,nel)]; // density
-    extBoundary[SCB_2D_INDEX(i,s1,e1,1,N,nel)] = (ny*ny-nx*nx)*u - 2.0*nx*ny*v; // u
-    extBoundary[SCB_2D_INDEX(i,s1,e1,2,N,nel)] = (nx*nx-ny*ny)*v - 2.0*nx*ny*u; // v
-    extBoundary[SCB_2D_INDEX(i,s1,e1,3,N,nel)] = boundary[SCB_2D_INDEX(i,s1,e1,3,N,nel)]; // pressure
-    extBoundary[SCB_2D_INDEX(i,s1,e1,4,N,nel)] = boundary[SCB_2D_INDEX(i,s1,e1,4,N,nel)]; // c
-    extBoundary[SCB_2D_INDEX(i,s1,e1,5,N,nel)] = boundary[SCB_2D_INDEX(i,s1,e1,5,N,nel)]; // rho0
+    extBoundary[SCB_2D_INDEX(i,s1,e1,0,N,nel)] = (ny*ny-nx*nx)*u - 2.0*nx*ny*v; // u
+    extBoundary[SCB_2D_INDEX(i,s1,e1,1,N,nel)] = (nx*nx-ny*ny)*v - 2.0*nx*ny*u; // v
+    extBoundary[SCB_2D_INDEX(i,s1,e1,2,N,nel)] = boundary[SCB_2D_INDEX(i,s1,e1,2,N,nel)]; // pressure
+    extBoundary[SCB_2D_INDEX(i,s1,e1,3,N,nel)] = boundary[SCB_2D_INDEX(i,s1,e1,3,N,nel)]; // c
+    extBoundary[SCB_2D_INDEX(i,s1,e1,4,N,nel)] = boundary[SCB_2D_INDEX(i,s1,e1,4,N,nel)]; // rho0
   }
 }
 
@@ -175,8 +171,8 @@ extern "C"
 
 // ============================================================
 // Radiation BC kernel for 2D Linear Euler
-// Sets density/u/v/p extBoundary = 0 on pre-filtered boundary
-// faces. The sound speed (index 4) and background density (index 5)
+// Sets u/v/p extBoundary = 0 on pre-filtered boundary
+// faces. The sound speed (index 3) and background density (index 4)
 // are copied from the interior side so that face Riemann fluxes see
 // a consistent c and rho0.
 // ============================================================
@@ -197,9 +193,8 @@ __global__ void hbc2d_radiation_lineareuler2d_kernel(
     extBoundary[SCB_2D_INDEX(i,s1,e1,0,N,nel)] = 0.0;
     extBoundary[SCB_2D_INDEX(i,s1,e1,1,N,nel)] = 0.0;
     extBoundary[SCB_2D_INDEX(i,s1,e1,2,N,nel)] = 0.0;
-    extBoundary[SCB_2D_INDEX(i,s1,e1,3,N,nel)] = 0.0;
-    extBoundary[SCB_2D_INDEX(i,s1,e1,4,N,nel)] = boundary[SCB_2D_INDEX(i,s1,e1,4,N,nel)]; // c preserved
-    extBoundary[SCB_2D_INDEX(i,s1,e1,5,N,nel)] = boundary[SCB_2D_INDEX(i,s1,e1,5,N,nel)]; // rho0 preserved
+    extBoundary[SCB_2D_INDEX(i,s1,e1,3,N,nel)] = boundary[SCB_2D_INDEX(i,s1,e1,3,N,nel)]; // c preserved
+    extBoundary[SCB_2D_INDEX(i,s1,e1,4,N,nel)] = boundary[SCB_2D_INDEX(i,s1,e1,4,N,nel)]; // rho0 preserved
   }
 }
 

--- a/src/gpu/SELF_LinearEuler2D_PML.cpp
+++ b/src/gpu/SELF_LinearEuler2D_PML.cpp
@@ -31,10 +31,12 @@
 
 // ============================================================
 // Riemann boundary-flux kernel (PML variant).
-// Acoustic variables 0..4 use the impedance-matched solver from
-// the parent LinearEuler2D kernel; auxiliary variables 5..8
+// Acoustic variables 0..3 use the impedance-matched solver from
+// the parent LinearEuler2D kernel; auxiliary variables 4..6
 // (the PML phi fields) carry zero flux and are evolved purely by
 // the source term.
+// Variable layout (0-based): 0=u, 1=v, 2=p, 3=c, 4=phi_u,
+// 5=phi_v, 6=phi_p.
 // ============================================================
 __global__ void boundaryflux_LinearEuler2D_PML_kernel(real *fb, real *extfb, real *nhat, real *nmag, real *flux, real rho0, int ndof){
   uint32_t idof = threadIdx.x + blockIdx.x*blockDim.x;
@@ -44,29 +46,27 @@ __global__ void boundaryflux_LinearEuler2D_PML_kernel(real *fb, real *extfb, rea
     real ny  = nhat[idof+ndof];
     real nm  = nmag[idof];
 
-    real cL  = fb[idof + 4*ndof];
-    real cR  = extfb[idof + 4*ndof];
+    real cL  = fb[idof + 3*ndof];
+    real cR  = extfb[idof + 3*ndof];
     real ZL  = rho0*cL;
     real ZR  = rho0*cR;
 
-    real unL = fb[idof +     ndof]*nx + fb[idof + 2*ndof]*ny;
-    real unR = extfb[idof +  ndof]*nx + extfb[idof + 2*ndof]*ny;
-    real pL  = fb[idof + 3*ndof];
-    real pR  = extfb[idof + 3*ndof];
+    real unL = fb[idof]*nx + fb[idof + ndof]*ny;
+    real unR = extfb[idof]*nx + extfb[idof + ndof]*ny;
+    real pL  = fb[idof + 2*ndof];
+    real pR  = extfb[idof + 2*ndof];
 
     real un_star = (ZL*unL + ZR*unR + (pL - pR)) / (ZL + ZR);
     real p_star  = (ZR*pL  + ZL*pR  + ZL*ZR*(unL - unR)) / (ZL + ZR);
     real c2_avg  = 0.5*(cL*cL + cR*cR);
 
-    flux[idof]          = (rho0*un_star) * nm;          // density
-    flux[idof + ndof]   = (p_star*nx/rho0) * nm;        // u
-    flux[idof + 2*ndof] = (p_star*ny/rho0) * nm;        // v
-    flux[idof + 3*ndof] = (rho0*c2_avg*un_star) * nm;   // pressure
-    flux[idof + 4*ndof] = 0.0;                          // sound speed
-    flux[idof + 5*ndof] = 0.0;                          // phi_rho
-    flux[idof + 6*ndof] = 0.0;                          // phi_u
-    flux[idof + 7*ndof] = 0.0;                          // phi_v
-    flux[idof + 8*ndof] = 0.0;                          // phi_p
+    flux[idof]          = (p_star*nx/rho0) * nm;        // u
+    flux[idof + ndof]   = (p_star*ny/rho0) * nm;        // v
+    flux[idof + 2*ndof] = (rho0*c2_avg*un_star) * nm;   // pressure
+    flux[idof + 3*ndof] = 0.0;                          // sound speed
+    flux[idof + 4*ndof] = 0.0;                          // phi_u
+    flux[idof + 5*ndof] = 0.0;                          // phi_v
+    flux[idof + 6*ndof] = 0.0;                          // phi_p
   }
 }
 
@@ -85,37 +85,34 @@ extern "C"
 }
 
 // ============================================================
-// Interior-flux kernel (PML variant). Acoustic variables 0..4
-// match the parent LinearEuler2D kernel; auxiliary variables 5..8
+// Interior-flux kernel (PML variant). Acoustic variables 0..3
+// match the parent LinearEuler2D kernel; auxiliary variables 4..6
 // have zero flux in both directions.
 // ============================================================
 __global__ void fluxmethod_LinearEuler2D_PML_kernel(real *solution, real *flux, real rho0, int ndof, int nvar){
   uint32_t idof = threadIdx.x + blockIdx.x*blockDim.x;
 
   if( idof < ndof ){
-    real u = solution[idof +     ndof];
-    real v = solution[idof + 2*ndof];
-    real p = solution[idof + 3*ndof];
-    real c = solution[idof + 4*ndof];
+    real u = solution[idof];
+    real v = solution[idof +     ndof];
+    real p = solution[idof + 2*ndof];
+    real c = solution[idof + 3*ndof];
 
-    flux[idof + ndof*(0 + nvar*0)] = rho0*u;   // rho, x-flux
-    flux[idof + ndof*(0 + nvar*1)] = rho0*v;   // rho, y-flux
+    flux[idof + ndof*(0 + nvar*0)] = p/rho0;   // u, x-flux
+    flux[idof + ndof*(0 + nvar*1)] = 0.0;      // u, y-flux
 
-    flux[idof + ndof*(1 + nvar*0)] = p/rho0;   // u, x-flux
-    flux[idof + ndof*(1 + nvar*1)] = 0.0;      // u, y-flux
+    flux[idof + ndof*(1 + nvar*0)] = 0.0;      // v, x-flux
+    flux[idof + ndof*(1 + nvar*1)] = p/rho0;   // v, y-flux
 
-    flux[idof + ndof*(2 + nvar*0)] = 0.0;      // v, x-flux
-    flux[idof + ndof*(2 + nvar*1)] = p/rho0;   // v, y-flux
+    flux[idof + ndof*(2 + nvar*0)] = c*c*rho0*u; // p, x-flux
+    flux[idof + ndof*(2 + nvar*1)] = c*c*rho0*v; // p, y-flux
 
-    flux[idof + ndof*(3 + nvar*0)] = c*c*rho0*u; // p, x-flux
-    flux[idof + ndof*(3 + nvar*1)] = c*c*rho0*v; // p, y-flux
+    flux[idof + ndof*(3 + nvar*0)] = 0.0;      // c, x-flux
+    flux[idof + ndof*(3 + nvar*1)] = 0.0;      // c, y-flux
 
-    flux[idof + ndof*(4 + nvar*0)] = 0.0;      // c, x-flux
-    flux[idof + ndof*(4 + nvar*1)] = 0.0;      // c, y-flux
-
-    // PML auxiliary variables 5..8 (phi_rho, phi_u, phi_v, phi_p)
+    // PML auxiliary variables 4..6 (phi_u, phi_v, phi_p)
     // carry zero flux; they are evolved exclusively by the source.
-    for(int ivar = 5; ivar < 9; ivar++){
+    for(int ivar = 4; ivar < 7; ivar++){
       flux[idof + ndof*(ivar + nvar*0)] = 0.0;
       flux[idof + ndof*(ivar + nvar*1)] = 0.0;
     }
@@ -135,10 +132,10 @@ extern "C"
 // ============================================================
 // Source-term kernel (Hu 2001 unsplit PML, ADE form).
 //
-// For acoustic variables (0..3) the PML adds:
+// For acoustic variables (0..2) the PML adds:
 //   source = -(sigma_x + sigma_y) q - sigma_x sigma_y phi
-// For sound speed (4): source = 0 (held fixed in time).
-// For auxiliaries (5..8): source = q (so dphi/dt = q).
+// For sound speed (3): source = 0 (held fixed in time).
+// For auxiliaries (4..6): source = q (so dphi/dt = q).
 //
 // sigma_x and sigma_y are single-variable MappedScalar2D fields,
 // so their device storage is exactly ndof reals each (one value
@@ -150,28 +147,24 @@ __global__ void sourcemethod_LinearEuler2D_PML_kernel(real *source, real *soluti
   if( idof < ndof ){
     real sx = sigma_x[idof];
     real sy = sigma_y[idof];
-    real rho     = solution[idof +     0*ndof];
-    real u       = solution[idof +     1*ndof];
-    real v       = solution[idof +     2*ndof];
-    real p       = solution[idof +     3*ndof];
-    // solution[idof + 4*ndof] is c (sound speed); not used here.
-    real phi_rho = solution[idof +     5*ndof];
-    real phi_u   = solution[idof +     6*ndof];
-    real phi_v   = solution[idof +     7*ndof];
-    real phi_p   = solution[idof +     8*ndof];
+    real u       = solution[idof +     0*ndof];
+    real v       = solution[idof +     1*ndof];
+    real p       = solution[idof +     2*ndof];
+    // solution[idof + 3*ndof] is c (sound speed); not used here.
+    real phi_u   = solution[idof +     4*ndof];
+    real phi_v   = solution[idof +     5*ndof];
+    real phi_p   = solution[idof +     6*ndof];
 
     real sxy = sx + sy;
     real sxsy = sx * sy;
 
-    source[idof + 0*ndof] = -sxy*rho - sxsy*phi_rho;
-    source[idof + 1*ndof] = -sxy*u   - sxsy*phi_u;
-    source[idof + 2*ndof] = -sxy*v   - sxsy*phi_v;
-    source[idof + 3*ndof] = -sxy*p   - sxsy*phi_p;
-    source[idof + 4*ndof] = 0.0;
-    source[idof + 5*ndof] = rho;
-    source[idof + 6*ndof] = u;
-    source[idof + 7*ndof] = v;
-    source[idof + 8*ndof] = p;
+    source[idof + 0*ndof] = -sxy*u   - sxsy*phi_u;
+    source[idof + 1*ndof] = -sxy*v   - sxsy*phi_v;
+    source[idof + 2*ndof] = -sxy*p   - sxsy*phi_p;
+    source[idof + 3*ndof] = 0.0;
+    source[idof + 4*ndof] = u;
+    source[idof + 5*ndof] = v;
+    source[idof + 6*ndof] = p;
   }
 }
 
@@ -187,8 +180,8 @@ extern "C"
 
 // ============================================================
 // No-normal-flow BC (PML variant).
-// Variables 0..4 follow the parent LinearEuler2D no-normal-flow
-// behaviour; variables 5..8 (PML auxiliaries) are zeroed in
+// Variables 0..3 follow the parent LinearEuler2D no-normal-flow
+// behaviour; variables 4..6 (PML auxiliaries) are zeroed in
 // extBoundary for cleanliness (they have zero Riemann flux, so
 // their exterior state is mathematically irrelevant).
 // ============================================================
@@ -206,20 +199,18 @@ __global__ void hbc2d_nonormalflow_lineareuler2d_pml_kernel(
     uint32_t e1 = elements[n] - 1;
     uint32_t s1 = sides[n] - 1;
 
-    real u  = boundary[SCB_2D_INDEX(i,s1,e1,1,N,nel)];
-    real v  = boundary[SCB_2D_INDEX(i,s1,e1,2,N,nel)];
+    real u  = boundary[SCB_2D_INDEX(i,s1,e1,0,N,nel)];
+    real v  = boundary[SCB_2D_INDEX(i,s1,e1,1,N,nel)];
     real nx = nhat[VEB_2D_INDEX(i,s1,e1,0,0,N,nel,1)];
     real ny = nhat[VEB_2D_INDEX(i,s1,e1,0,1,N,nel,1)];
 
-    extBoundary[SCB_2D_INDEX(i,s1,e1,0,N,nel)] = boundary[SCB_2D_INDEX(i,s1,e1,0,N,nel)]; // density
-    extBoundary[SCB_2D_INDEX(i,s1,e1,1,N,nel)] = (ny*ny-nx*nx)*u - 2.0*nx*ny*v;            // u
-    extBoundary[SCB_2D_INDEX(i,s1,e1,2,N,nel)] = (nx*nx-ny*ny)*v - 2.0*nx*ny*u;            // v
-    extBoundary[SCB_2D_INDEX(i,s1,e1,3,N,nel)] = boundary[SCB_2D_INDEX(i,s1,e1,3,N,nel)]; // pressure
-    extBoundary[SCB_2D_INDEX(i,s1,e1,4,N,nel)] = boundary[SCB_2D_INDEX(i,s1,e1,4,N,nel)]; // c
-    extBoundary[SCB_2D_INDEX(i,s1,e1,5,N,nel)] = 0.0;                                     // phi_rho
-    extBoundary[SCB_2D_INDEX(i,s1,e1,6,N,nel)] = 0.0;                                     // phi_u
-    extBoundary[SCB_2D_INDEX(i,s1,e1,7,N,nel)] = 0.0;                                     // phi_v
-    extBoundary[SCB_2D_INDEX(i,s1,e1,8,N,nel)] = 0.0;                                     // phi_p
+    extBoundary[SCB_2D_INDEX(i,s1,e1,0,N,nel)] = (ny*ny-nx*nx)*u - 2.0*nx*ny*v;            // u
+    extBoundary[SCB_2D_INDEX(i,s1,e1,1,N,nel)] = (nx*nx-ny*ny)*v - 2.0*nx*ny*u;            // v
+    extBoundary[SCB_2D_INDEX(i,s1,e1,2,N,nel)] = boundary[SCB_2D_INDEX(i,s1,e1,2,N,nel)]; // pressure
+    extBoundary[SCB_2D_INDEX(i,s1,e1,3,N,nel)] = boundary[SCB_2D_INDEX(i,s1,e1,3,N,nel)]; // c
+    extBoundary[SCB_2D_INDEX(i,s1,e1,4,N,nel)] = 0.0;                                     // phi_u
+    extBoundary[SCB_2D_INDEX(i,s1,e1,5,N,nel)] = 0.0;                                     // phi_v
+    extBoundary[SCB_2D_INDEX(i,s1,e1,6,N,nel)] = 0.0;                                     // phi_p
   }
 }
 
@@ -262,12 +253,10 @@ __global__ void hbc2d_radiation_lineareuler2d_pml_kernel(
     extBoundary[SCB_2D_INDEX(i,s1,e1,0,N,nel)] = 0.0;
     extBoundary[SCB_2D_INDEX(i,s1,e1,1,N,nel)] = 0.0;
     extBoundary[SCB_2D_INDEX(i,s1,e1,2,N,nel)] = 0.0;
-    extBoundary[SCB_2D_INDEX(i,s1,e1,3,N,nel)] = 0.0;
-    extBoundary[SCB_2D_INDEX(i,s1,e1,4,N,nel)] = boundary[SCB_2D_INDEX(i,s1,e1,4,N,nel)]; // c preserved
+    extBoundary[SCB_2D_INDEX(i,s1,e1,3,N,nel)] = boundary[SCB_2D_INDEX(i,s1,e1,3,N,nel)]; // c preserved
+    extBoundary[SCB_2D_INDEX(i,s1,e1,4,N,nel)] = 0.0;
     extBoundary[SCB_2D_INDEX(i,s1,e1,5,N,nel)] = 0.0;
     extBoundary[SCB_2D_INDEX(i,s1,e1,6,N,nel)] = 0.0;
-    extBoundary[SCB_2D_INDEX(i,s1,e1,7,N,nel)] = 0.0;
-    extBoundary[SCB_2D_INDEX(i,s1,e1,8,N,nel)] = 0.0;
   }
 }
 

--- a/src/gpu/SELF_LinearEuler3D.cpp
+++ b/src/gpu/SELF_LinearEuler3D.cpp
@@ -30,13 +30,13 @@
 
 
 // Impedance-matched (characteristic/Godunov) Riemann flux with a per-node
-// sound speed carried as solution variable 6 (0-based index 5) and background
-// density as variable 7 (0-based index 6), mirroring the 2-D model. The
+// sound speed carried as solution variable 5 (0-based index 4) and background
+// density as variable 6 (0-based index 5), mirroring the 2-D model. The
 // interface states are resolved with the per-side acoustic impedances
 // Z = rho0*c (each side using its own rho0 and c):
 //   un* = (ZL*unL + ZR*unR + (pL - pR)) / (ZL + ZR)
 //   p*  = (ZR*pL + ZL*pR + ZL*ZR*(unL - unR)) / (ZL + ZR)
-// Variable layout (0-based): 0=rho, 1=u, 2=v, 3=w, 4=p, 5=c, 6=rho0. The
+// Variable layout (0-based): 0=u, 1=v, 2=w, 3=p, 4=c, 5=rho0. The
 // reconstructed fluxes use the face-average rho0. The sound-speed and
 // background-density variables carry zero flux.
 __global__ void boundaryflux_LinearEuler3D_kernel(real *fb, real *extfb, real *nhat, real *nmag, real *flux, int ndof){
@@ -49,30 +49,29 @@ __global__ void boundaryflux_LinearEuler3D_kernel(real *fb, real *extfb, real *n
     real nz = nhat[idof+2*ndof];
     real nm = nmag[idof];
 
-    real cL = fb[idof + 5*ndof];
-    real cR = extfb[idof + 5*ndof];
-    real rho0L = fb[idof + 6*ndof];
-    real rho0R = extfb[idof + 6*ndof];
+    real cL = fb[idof + 4*ndof];
+    real cR = extfb[idof + 4*ndof];
+    real rho0L = fb[idof + 5*ndof];
+    real rho0R = extfb[idof + 5*ndof];
     real rho0_avg = 0.5*(rho0L + rho0R);
     real ZL = rho0L*cL;
     real ZR = rho0R*cR;
 
-    real unL = fb[idof + ndof]*nx + fb[idof + 2*ndof]*ny + fb[idof + 3*ndof]*nz;
-    real unR = extfb[idof + ndof]*nx + extfb[idof + 2*ndof]*ny + extfb[idof + 3*ndof]*nz;
-    real pL = fb[idof + 4*ndof];
-    real pR = extfb[idof + 4*ndof];
+    real unL = fb[idof]*nx + fb[idof + ndof]*ny + fb[idof + 2*ndof]*nz;
+    real unR = extfb[idof]*nx + extfb[idof + ndof]*ny + extfb[idof + 2*ndof]*nz;
+    real pL = fb[idof + 3*ndof];
+    real pR = extfb[idof + 3*ndof];
 
     real un_star = (ZL*unL + ZR*unR + (pL - pR))/(ZL + ZR);
     real p_star = (ZR*pL + ZL*pR + ZL*ZR*(unL - unR))/(ZL + ZR);
     real c2_avg = 0.5*(cL*cL + cR*cR);
 
-    flux[idof] = (rho0_avg*un_star)*nm;              // density
-    flux[idof+ndof] = (p_star*nx/rho0_avg)*nm;       // u
-    flux[idof+2*ndof] = (p_star*ny/rho0_avg)*nm;     // v
-    flux[idof+3*ndof] = (p_star*nz/rho0_avg)*nm;     // w
-    flux[idof+4*ndof] = (rho0_avg*c2_avg*un_star)*nm; // pressure
-    flux[idof+5*ndof] = 0.0;                     // sound speed (static)
-    flux[idof+6*ndof] = 0.0;                     // background density (static)
+    flux[idof] = (p_star*nx/rho0_avg)*nm;            // u
+    flux[idof+ndof] = (p_star*ny/rho0_avg)*nm;       // v
+    flux[idof+2*ndof] = (p_star*nz/rho0_avg)*nm;     // w
+    flux[idof+3*ndof] = (rho0_avg*c2_avg*un_star)*nm; // pressure
+    flux[idof+4*ndof] = 0.0;                     // sound speed (static)
+    flux[idof+5*ndof] = 0.0;                     // background density (static)
   }
 }
 
@@ -94,40 +93,36 @@ extern "C"
   uint32_t idof = threadIdx.x + blockIdx.x*blockDim.x;
 
   if( idof < ndof ){
-    real u = solution[idof + ndof];
-    real v = solution[idof + 2*ndof];
-    real w = solution[idof + 3*ndof];
-    real p = solution[idof + 4*ndof];
-    real c = solution[idof + 5*ndof];
-    real rho0 = solution[idof + 6*ndof];
+    real u = solution[idof];
+    real v = solution[idof + ndof];
+    real w = solution[idof + 2*ndof];
+    real p = solution[idof + 3*ndof];
+    real c = solution[idof + 4*ndof];
+    real rho0 = solution[idof + 5*ndof];
 
-    flux[idof + ndof*(0 + nvar*0)] = rho0*u; // density, x flux ; rho0*u
-    flux[idof + ndof*(0 + nvar*1)] = rho0*v; // density, y flux ; rho0*v
-    flux[idof + ndof*(0 + nvar*2)] = rho0*w; // density, z flux ; rho0*w
+    flux[idof + ndof*(0 + nvar*0)] = p/rho0; // x-velocity, x flux; p/rho0
+    flux[idof + ndof*(0 + nvar*1)] = 0.0; // x-velocity, y flux; 0
+    flux[idof + ndof*(0 + nvar*2)] = 0.0; // x-velocity, z flux; 0
 
-    flux[idof + ndof*(1 + nvar*0)] = p/rho0; // x-velocity, x flux; p/rho0
-    flux[idof + ndof*(1 + nvar*1)] = 0.0; // x-velocity, y flux; 0
-    flux[idof + ndof*(1 + nvar*2)] = 0.0; // x-velocity, z flux; 0
+    flux[idof + ndof*(1 + nvar*0)] = 0.0; // y-velocity, x flux; 0
+    flux[idof + ndof*(1 + nvar*1)] = p/rho0; // y-velocity, y flux; p/rho0
+    flux[idof + ndof*(1 + nvar*2)] = 0.0; // y-velocity, z flux; 0
 
-    flux[idof + ndof*(2 + nvar*0)] = 0.0; // y-velocity, x flux; 0
-    flux[idof + ndof*(2 + nvar*1)] = p/rho0; // y-velocity, y flux; p/rho0
-    flux[idof + ndof*(2 + nvar*2)] = 0.0; // y-velocity, z flux; 0
+    flux[idof + ndof*(2 + nvar*0)] = 0.0; // z-velocity, x flux; 0
+    flux[idof + ndof*(2 + nvar*1)] = 0.0; // z-velocity, y flux; 0
+    flux[idof + ndof*(2 + nvar*2)] = p/rho0; // z-velocity, z flux; p/rho0
 
-    flux[idof + ndof*(3 + nvar*0)] = 0.0; // z-velocity, x flux; 0
-    flux[idof + ndof*(3 + nvar*1)] = 0.0; // z-velocity, y flux; 0
-    flux[idof + ndof*(3 + nvar*2)] = p/rho0; // z-velocity, z flux; p/rho0
+    flux[idof + ndof*(3 + nvar*0)] = c*c*rho0*u; // pressure, x flux : rho0*c^2*u
+    flux[idof + ndof*(3 + nvar*1)] = c*c*rho0*v; // pressure, y flux : rho0*c^2*v
+    flux[idof + ndof*(3 + nvar*2)] = c*c*rho0*w; // pressure, z flux : rho0*c^2*w
 
-    flux[idof + ndof*(4 + nvar*0)] = c*c*rho0*u; // pressure, x flux : rho0*c^2*u
-    flux[idof + ndof*(4 + nvar*1)] = c*c*rho0*v; // pressure, y flux : rho0*c^2*v
-    flux[idof + ndof*(4 + nvar*2)] = c*c*rho0*w; // pressure, z flux : rho0*c^2*w
+    flux[idof + ndof*(4 + nvar*0)] = 0.0; // sound speed, x flux; 0 (c held fixed in time)
+    flux[idof + ndof*(4 + nvar*1)] = 0.0; // sound speed, y flux; 0
+    flux[idof + ndof*(4 + nvar*2)] = 0.0; // sound speed, z flux; 0
 
-    flux[idof + ndof*(5 + nvar*0)] = 0.0; // sound speed, x flux; 0 (c held fixed in time)
-    flux[idof + ndof*(5 + nvar*1)] = 0.0; // sound speed, y flux; 0
-    flux[idof + ndof*(5 + nvar*2)] = 0.0; // sound speed, z flux; 0
-
-    flux[idof + ndof*(6 + nvar*0)] = 0.0; // background density, x flux; 0 (rho0 held fixed in time)
-    flux[idof + ndof*(6 + nvar*1)] = 0.0; // background density, y flux; 0
-    flux[idof + ndof*(6 + nvar*2)] = 0.0; // background density, z flux; 0
+    flux[idof + ndof*(5 + nvar*0)] = 0.0; // background density, x flux; 0 (rho0 held fixed in time)
+    flux[idof + ndof*(5 + nvar*1)] = 0.0; // background density, y flux; 0
+    flux[idof + ndof*(5 + nvar*2)] = 0.0; // background density, z flux; 0
 
   }
 
@@ -143,9 +138,9 @@ extern "C"
 
 }
 // Radiation BC kernel for 3D Linear Euler
-// Zeroes the acoustic perturbation (rho,u,v,w,p) in extBoundary on
-// pre-filtered boundary faces; the sound speed (index 5) and background
-// density (index 6) are copied from the interior side so face Riemann fluxes
+// Zeroes the acoustic perturbation (u,v,w,p) in extBoundary on
+// pre-filtered boundary faces; the sound speed (index 4) and background
+// density (index 5) are copied from the interior side so face Riemann fluxes
 // see a consistent c and rho0.
 __global__ void hbc3d_radiation_lineareuler3d_kernel(
     real *extBoundary, real *boundary,
@@ -167,9 +162,8 @@ __global__ void hbc3d_radiation_lineareuler3d_kernel(
     extBoundary[SCB_3D_INDEX(i,j,s1,e1,1,N,nel)] = 0.0;
     extBoundary[SCB_3D_INDEX(i,j,s1,e1,2,N,nel)] = 0.0;
     extBoundary[SCB_3D_INDEX(i,j,s1,e1,3,N,nel)] = 0.0;
-    extBoundary[SCB_3D_INDEX(i,j,s1,e1,4,N,nel)] = 0.0;
-    extBoundary[SCB_3D_INDEX(i,j,s1,e1,5,N,nel)] = boundary[SCB_3D_INDEX(i,j,s1,e1,5,N,nel)]; // c preserved
-    extBoundary[SCB_3D_INDEX(i,j,s1,e1,6,N,nel)] = boundary[SCB_3D_INDEX(i,j,s1,e1,6,N,nel)]; // rho0 preserved
+    extBoundary[SCB_3D_INDEX(i,j,s1,e1,4,N,nel)] = boundary[SCB_3D_INDEX(i,j,s1,e1,4,N,nel)]; // c preserved
+    extBoundary[SCB_3D_INDEX(i,j,s1,e1,5,N,nel)] = boundary[SCB_3D_INDEX(i,j,s1,e1,5,N,nel)]; // rho0 preserved
   }
 }
 

--- a/test/lineareuler2d_pml_absorption.f90
+++ b/test/lineareuler2d_pml_absorption.f90
@@ -119,7 +119,7 @@ program LinearEuler2D_PML_Absorption
 
   ! Initial planar (uniform in y) right-going acoustic pulse:
   !   p(x) = amp * exp(-((x-pulse_x0)/pulse_width)^2)
-  !   rho  = p/c^2,  u = p/(rho0*c),  v = 0
+  !   u = p/(rho0*c),  v = 0
   ! which is the right eigenvector of A for the linear Euler system.
   do iel = 1,mesh%nElem
     do j = 1,modelobj%solution%N+1
@@ -127,18 +127,17 @@ program LinearEuler2D_PML_Absorption
         x = modelobj%geometry%x%interior(i,j,iel,1,1)
         r2 = (x-pulse_x0)**2
         p_loc = amp*exp(-r2/(pulse_width*pulse_width))
-        modelobj%solution%interior(i,j,iel,1) = p_loc/(c0*c0) ! rho
-        modelobj%solution%interior(i,j,iel,2) = p_loc/(modelobj%rho0*c0) ! u
-        modelobj%solution%interior(i,j,iel,3) = 0.0_prec ! v
-        modelobj%solution%interior(i,j,iel,4) = p_loc ! p
-        modelobj%solution%interior(i,j,iel,5) = c0 ! c
-        modelobj%solution%interior(i,j,iel,6:9) = 0.0_prec ! phi_*
+        modelobj%solution%interior(i,j,iel,1) = p_loc/(modelobj%rho0*c0) ! u
+        modelobj%solution%interior(i,j,iel,2) = 0.0_prec ! v
+        modelobj%solution%interior(i,j,iel,3) = p_loc ! p
+        modelobj%solution%interior(i,j,iel,4) = c0 ! c
+        modelobj%solution%interior(i,j,iel,5:7) = 0.0_prec ! phi_*
       enddo
     enddo
   enddo
   call modelobj%solution%UpdateDevice()
 
-  p_max_initial = maxval(modelobj%solution%interior(:,:,:,4))
+  p_max_initial = maxval(modelobj%solution%interior(:,:,:,3))
   print*,"Initial max |p|: ",p_max_initial
   call modelobj%CalculateEntropy()
   e0 = modelobj%entropy
@@ -156,7 +155,7 @@ program LinearEuler2D_PML_Absorption
     if(xmid > x_interior_max) cycle
     do j = 1,modelobj%solution%N+1
       do i = 1,modelobj%solution%N+1
-        p_max_interior = max(p_max_interior,abs(modelobj%solution%interior(i,j,iel,4)))
+        p_max_interior = max(p_max_interior,abs(modelobj%solution%interior(i,j,iel,3)))
       enddo
     enddo
   enddo


### PR DESCRIPTION
For a motionless background state the density anomaly is slaved to the
pressure through rho = p/c^2 and never feeds back into the velocity or
pressure dynamics, so it does not need to be forward-stepped. The linear
Euler models now carry only the velocity components and pressure as
prognostic variables, plus the static background fields:

- LinearEuler2D: nvar 6 -> 5 (u, v, P, c, rho0), nstepped 4 -> 3
- LinearEuler3D: nvar 7 -> 6 (u, v, w, P, c, rho0), nstepped 5 -> 4
- LinearEuler2D_PML: nvar 9 -> 7 (u, v, P, c, phi_u, phi_v, phi_P);
  the phi_rho auxiliary is dropped along with the density anomaly

CPU flux/Riemann/BC routines and the corresponding GPU kernels are
updated for the shifted variable layout; the impedance-matched Riemann
solver is unchanged for the surviving velocity/pressure components. The
SphericalSoundWave initializers keep their signatures: rhoprime now sets
the pressure-pulse amplitude through p = rhoprime*c^2. Tests, examples,
model docs, and tutorials are updated to the new layout, with a note
that the density anomaly can be recovered diagnostically as rho = p/c^2.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0117Qi4EBQ9XK6CPsxxd5eod