### PR TITLE
DGModel3D: wire nstepped into time-integration updates

### DIFF
--- a/src/SELF_DGModel3D_t.f90
+++ b/src/SELF_DGModel3D_t.f90
@@ -100,6 +100,11 @@ contains
     this%geometry => geometry
     call this%SetNumberOfVariables()
 
+    ! Default the number of time-stepped variables to nvar. Models that carry
+    ! auxiliary/diagnostic variables may set this%nstepped < nvar inside
+    ! SetNumberOfVariables to exclude the trailing variables from time integration.
+    if(this%nstepped <= 0 .or. this%nstepped > this%nvar) this%nstepped = this%nvar
+
     call this%solution%Init(geometry%x%interp,this%nvar,this%mesh%nElem)
     call this%workSol%Init(geometry%x%interp,this%nvar,this%mesh%nElem)
     call this%dSdt%Init(geometry%x%interp,this%nvar,this%mesh%nElem)
@@ -247,7 +252,7 @@ contains
     endif
 
     do concurrent(i=1:this%solution%N+1,j=1:this%solution%N+1, &
-                  k=1:this%solution%N+1,iel=1:this%mesh%nElem,ivar=1:this%solution%nVar)
+                  k=1:this%solution%N+1,iel=1:this%mesh%nElem,ivar=1:this%nstepped)
 
       this%solution%interior(i,j,k,iEl,iVar) = &
         this%solution%interior(i,j,k,iEl,iVar)+ &
@@ -265,7 +270,7 @@ contains
     integer :: i,j,k,iVar,iEl
 
     do concurrent(i=1:this%solution%N+1,j=1:this%solution%N+1, &
-                  k=1:this%solution%N+1,iel=1:this%mesh%nElem,ivar=1:this%solution%nVar)
+                  k=1:this%solution%N+1,iel=1:this%mesh%nElem,ivar=1:this%nstepped)
 
       this%workSol%interior(i,j,k,iEl,iVar) = rk2_a(m)* &
                                               this%workSol%interior(i,j,k,iEl,iVar)+ &
@@ -287,7 +292,7 @@ contains
     integer :: i,j,k,iVar,iEl
 
     do concurrent(i=1:this%solution%N+1,j=1:this%solution%N+1, &
-                  k=1:this%solution%N+1,iel=1:this%mesh%nElem,ivar=1:this%solution%nVar)
+                  k=1:this%solution%N+1,iel=1:this%mesh%nElem,ivar=1:this%nstepped)
 
       this%workSol%interior(i,j,k,iEl,iVar) = rk3_a(m)* &
                                               this%workSol%interior(i,j,k,iEl,iVar)+ &
@@ -309,7 +314,7 @@ contains
     integer :: i,j,k,iVar,iEl
 
     do concurrent(i=1:this%solution%N+1,j=1:this%solution%N+1, &
-                  k=1:this%solution%N+1,iel=1:this%mesh%nElem,ivar=1:this%solution%nVar)
+                  k=1:this%solution%N+1,iel=1:this%mesh%nElem,ivar=1:this%nstepped)
 
       this%workSol%interior(i,j,k,iEl,iVar) = rk4_a(m)* &
                                               this%workSol%interior(i,j,k,iEl,iVar)+ &

--- a/src/gpu/SELF_DGModel3D.f90
+++ b/src/gpu/SELF_DGModel3D.f90
@@ -75,7 +75,10 @@ contains
     else
       dtLoc = this%dt
     endif
-    ndof = this%solution%nvar* &
+    ! The stepped variables occupy the leading nstepped entries of the
+    ! variable dimension (the slowest-varying index of the interior array),
+    ! so restricting ndof to nstepped updates exactly variables 1:nstepped.
+    ndof = this%nstepped* &
            this%solution%nelem* &
            (this%solution%interp%N+1)* &
            (this%solution%interp%N+1)* &
@@ -92,7 +95,10 @@ contains
     ! Local
     integer :: ndof
 
-    ndof = this%solution%nvar* &
+    ! The stepped variables occupy the leading nstepped entries of the
+    ! variable dimension (the slowest-varying index of the interior array),
+    ! so restricting ndof to nstepped updates exactly variables 1:nstepped.
+    ndof = this%nstepped* &
            this%solution%nelem* &
            (this%solution%interp%N+1)* &
            (this%solution%interp%N+1)* &
@@ -110,7 +116,10 @@ contains
     ! Local
     integer :: ndof
 
-    ndof = this%solution%nvar* &
+    ! The stepped variables occupy the leading nstepped entries of the
+    ! variable dimension (the slowest-varying index of the interior array),
+    ! so restricting ndof to nstepped updates exactly variables 1:nstepped.
+    ndof = this%nstepped* &
            this%solution%nelem* &
            (this%solution%interp%N+1)* &
            (this%solution%interp%N+1)* &
@@ -128,7 +137,10 @@ contains
     ! Local
     integer :: ndof
 
-    ndof = this%solution%nvar* &
+    ! The stepped variables occupy the leading nstepped entries of the
+    ! variable dimension (the slowest-varying index of the interior array),
+    ! so restricting ndof to nstepped updates exactly variables 1:nstepped.
+    ndof = this%nstepped* &
            this%solution%nelem* &
            (this%solution%interp%N+1)* &
            (this%solution%interp%N+1)* &


### PR DESCRIPTION
## Summary

`DGModel2D` already honors `nstepped` in its time integrators — the RK update loops run over `ivar = 1:nstepped` and the GPU update wrappers size the kernel `ndof` by `nstepped` — but `DGModel3D` looped over all `nvar` variables regardless. This PR mirrors the 2-D treatment in the 3-D model so that trailing static variables (e.g. the sound speed and background density fields in `LinearEuler3D`, which have identically zero flux and source) are skipped during time integration instead of being stepped with zero tendencies.

Changes, matching `SELF_DGModel2D_t.f90` / `src/gpu/SELF_DGModel2D.f90` line for line:

- **`src/SELF_DGModel3D_t.f90`**
  - `Init` clamps `nstepped` to `nvar` when a model leaves it unset (default 0) or sets it out of range, so every existing model that does not declare `nstepped` behaves exactly as before.
  - `UpdateSolution` and `UpdateGRK2/3/4` loop over `ivar = 1:this%nstepped` instead of `1:this%solution%nVar`.
- **`src/gpu/SELF_DGModel3D.f90`**
  - The four update wrappers compute the kernel `ndof` from `nstepped` instead of `nvar`. The variable index is the slowest-varying dimension of the interior arrays, so the first `nstepped` variables form one contiguous block and the truncated `ndof` updates exactly variables `1:nstepped`.

## Numerical impact

None. Models with `nstepped == nvar` (all models except `LinearEuler3D`) execute the identical loops as before. For `LinearEuler3D` (`nstepped = 5`, `nvar = 7`), the skipped variables previously received updates of the form `s = s + coeff*dt*0` since their flux and source are identically zero, so results are unchanged; the work of stepping them is simply removed (2 of 7 variables per RK stage).

## Testing

Built with gfortran/OpenMPI/HDF5 (CPU backend, double precision) and ran:

- `examples/linear_euler3d_spherical_soundwave_radiation` — exercises the `nstepped < nvar` path; pressure/velocity extrema match the pre-change baseline.
- `test/advection_diffusion_3d_rk2`, `_rk3`, `_rk4`, `_euler`, and `ec_advection_3d_rk3` — exercise the default `nstepped = nvar` path across all integrators; all pass.

GPU kernels were not run here (no GPU in the dev environment); the GPU change is limited to the `ndof` sizing of the existing update kernels, mirroring what `DGModel2D` already ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0117Qi4EBQ9XK6CPsxxd5eod

---
_Generated by [Claude Code](https://claude.ai/code/session_0117Qi4EBQ9XK6CPsxxd5eod)_