### PR TITLE
Aggregate GPU MPI halo exchange per neighbor rank (all 2-D/3-D side-exchange classes) (#84)

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -74,4 +74,5 @@ add_fortran_tests (
   "esatmo3d_thermal_bubble.f90"
   "esatmo3d_abc_flow.f90"
   "esatmo2d_thermal_bubble.f90"
+  "bench_lineareuler3d_scaling.f90"
     )

--- a/examples/bench_lineareuler3d_scaling.f90
+++ b/examples/bench_lineareuler3d_scaling.f90
@@ -1,0 +1,216 @@
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+!
+! Maintainers : support@fluidnumerics.com
+! Official Repository : https://github.com/FluidNumerics/self/
+!
+! Copyright © 2024 Fluid Numerics LLC
+!
+! Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+!
+! 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+!    the documentation and/or other materials provided with the distribution.
+!
+! 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+!    this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+! HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+! LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+! THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+! THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+!
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+
+program bench_lineareuler3d_scaling
+!! Multi-process / multi-GPU scaling benchmark for the 3-D linear Euler solver.
+!!
+!! Solves the linear Euler equations (spherical sound wave initial condition,
+!! radiation boundary conditions) on a uniform structured mesh of
+!! nex x ney x nez elements with degree `cdegree` polynomials, using the
+!! low-storage RK3 integrator. No file IO is performed; the program reports
+!! wall-time per time step and degrees-of-freedom throughput so that runs at
+!! 1, 2, 4, and 8 MPI ranks measure parallel scaling.
+!!
+!! The mesh is tiled so that each MPI rank owns exactly one cuboid tile
+!! (SELF's linear element decomposition maps tiles to contiguous element
+!! ranges). The number of tiles (ntx*nty*ntz) must equal the number of ranks,
+!! and each global element count must be divisible by its tile count.
+!!
+!! Usage:
+!!   bench_lineareuler3d_scaling [nex ney nez ntx nty ntz nsteps cdegree]
+!!
+!! Defaults (no arguments) run a small single-rank problem: 8^3 elements,
+!! 1x1x1 tiles, 5 steps, degree 7.
+!!
+!! The time step is set from a CFL-like rule dt = cfl*dx/(c*(N+1)^2) with
+!! cfl = 0.5, c = 1, so the run is stable for any resolution; a NaN check on
+!! the final entropy guards against silent blowup.
+
+  use iso_fortran_env,only:real64
+  use self_data
+  use self_LinearEuler3D
+  use mpi
+
+  implicit none
+
+  real(prec),parameter :: rho0 = 1.225_prec ! Background density
+  real(prec),parameter :: rhoprime = 0.01_prec ! Sound wave density anomaly
+  real(prec),parameter :: c = 1.0_prec ! Speed of sound
+  real(prec),parameter :: cfl = 0.5_prec ! CFL-like number for time step selection
+
+  type(LinearEuler3D) :: modelobj
+  type(Lagrange),target :: interp
+  type(Mesh3D),target :: mesh
+  type(SEMHex),target :: geometry
+  integer :: bcids(1:6)
+  integer :: nex,ney,nez ! Global element counts in each direction
+  integer :: ntx,nty,ntz ! Number of tiles (= ranks) in each direction
+  integer :: nsteps ! Number of benchmark time steps
+  integer :: nwarmup ! Number of untimed warm-up time steps
+  integer :: cdegree ! Control polynomial degree
+  integer :: istep
+  integer :: rankid,nranks,ierror
+  logical :: mpiInitialized
+  real(prec) :: dx,dt
+  real(real64) :: t1,t2,tstep
+  real(real64) :: ndof
+  character(len=32) :: arg
+
+  nex = 8
+  ney = 8
+  nez = 8
+  ntx = 1
+  nty = 1
+  ntz = 1
+  nsteps = 5
+  nwarmup = 2
+  cdegree = 7
+
+  if(command_argument_count() >= 6) then
+    call get_command_argument(1,arg); read(arg,*) nex
+    call get_command_argument(2,arg); read(arg,*) ney
+    call get_command_argument(3,arg); read(arg,*) nez
+    call get_command_argument(4,arg); read(arg,*) ntx
+    call get_command_argument(5,arg); read(arg,*) nty
+    call get_command_argument(6,arg); read(arg,*) ntz
+  endif
+  if(command_argument_count() >= 7) then
+    call get_command_argument(7,arg); read(arg,*) nsteps
+  endif
+  if(command_argument_count() >= 8) then
+    call get_command_argument(8,arg); read(arg,*) cdegree
+  endif
+
+  if(mod(nex,ntx) /= 0 .or. mod(ney,nty) /= 0 .or. mod(nez,ntz) /= 0) then
+    print*,'bench_lineareuler3d_scaling: element counts must be divisible by tile counts'
+    stop 1
+  endif
+
+  ! Radiation boundary conditions on all sides
+  bcids(1:6) = [SELF_BC_RADIATION,SELF_BC_RADIATION,SELF_BC_RADIATION, &
+                SELF_BC_RADIATION,SELF_BC_RADIATION,SELF_BC_RADIATION]
+
+  ! Uniform element width for a unit cube domain in x; dy,dz chosen equal to dx
+  ! so that elements are isotropic.
+  dx = 1.0_prec/real(nex,prec)
+
+  ! Create a structured mesh with one tile per rank. Mesh generation
+  ! initializes the domain decomposition (and MPI).
+  call mesh%StructuredMesh(nex/ntx,ney/nty,nez/ntz, &
+                           ntx,nty,ntz,dx,dx,dx,bcids)
+
+  rankid = mesh%decomp%rankId
+  nranks = mesh%decomp%nRanks
+
+  if(nranks /= ntx*nty*ntz) then
+    if(rankid == 0) then
+      print*,'bench_lineareuler3d_scaling: number of tiles must equal number of ranks: ', &
+        ntx*nty*ntz,nranks
+    endif
+    stop 1
+  endif
+
+  call interp%Init(N=cdegree, &
+                   controlNodeType=GAUSS, &
+                   M=cdegree, &
+                   targetNodeType=UNIFORM)
+
+  call geometry%Init(interp,mesh%nElem)
+  call geometry%GenerateFromMesh(mesh)
+
+  call modelobj%Init(mesh,geometry)
+  modelobj%prescribed_bcs_enabled = .false.
+  modelobj%tecplot_enabled = .false.
+  modelobj%rho0 = rho0
+  modelobj%c = c
+
+  ! Spherical sound wave centered in the unit cube; length scale set relative
+  ! to the domain so the initial condition is resolution independent.
+  call modelobj%SphericalSoundWave(rhoprime,0.06_prec,0.5_prec,0.5_prec,0.5_prec)
+
+  call modelobj%SetTimeIntegrator('rk3')
+
+  ! Stable explicit time step for degree N spectral elements
+  dt = cfl*dx/(c*real((cdegree+1)*(cdegree+1),prec))
+  modelobj%dt = dt
+
+  if(rankid == 0) then
+    print*,'bench_lineareuler3d_scaling : global elements :',nex,ney,nez
+    print*,'bench_lineareuler3d_scaling : tiles           :',ntx,nty,ntz
+    print*,'bench_lineareuler3d_scaling : ranks           :',nranks
+    print*,'bench_lineareuler3d_scaling : degree          :',cdegree
+    print*,'bench_lineareuler3d_scaling : local elements  :',mesh%nElem
+    print*,'bench_lineareuler3d_scaling : dt              :',dt
+    print*,'bench_lineareuler3d_scaling : nsteps          :',nsteps
+  endif
+
+  ! Untimed warm-up steps (kernel compilation, MPI wire-up, allocator warmup)
+  do istep = 1,nwarmup
+    call modelobj%timeIntegrator(modelobj%t+dt)
+  enddo
+
+  ! Synchronize all ranks; CalculateEntropy performs a device synchronization
+  ! (device-to-host copy) and an MPI reduction, so all warm-up work is complete
+  ! before the timers start.
+  call modelobj%CalculateEntropy()
+  call MPI_Barrier(mesh%decomp%mpiComm,ierror)
+
+  t1 = MPI_Wtime()
+  do istep = 1,nsteps
+    call modelobj%timeIntegrator(modelobj%t+dt)
+  enddo
+  ! CalculateEntropy forces completion of all device work and includes the
+  ! final MPI reduction; its cost is amortized over nsteps.
+  call modelobj%CalculateEntropy()
+  t2 = MPI_Wtime()
+  call MPI_Barrier(mesh%decomp%mpiComm,ierror)
+
+  tstep = (t2-t1)/real(nsteps,real64)
+  ndof = real(nex,real64)*real(ney,real64)*real(nez,real64)* &
+         real((cdegree+1)**3,real64)
+
+  if(rankid == 0) then
+    print*,'bench_lineareuler3d_scaling : total time (s)          :',t2-t1
+    print*,'bench_lineareuler3d_scaling : time per step (s)       :',tstep
+    print*,'bench_lineareuler3d_scaling : DOF                     :',ndof
+    print*,'bench_lineareuler3d_scaling : DOF/s (per prognostic)  :',ndof/tstep
+  endif
+
+  if(modelobj%entropy /= modelobj%entropy) then
+    print*,'Error: Final entropy is inf or nan',modelobj%entropy
+    stop 1
+  endif
+
+  if(rankid == 0) then
+    print*,'bench_lineareuler3d_scaling : final entropy           :',modelobj%entropy
+  endif
+
+  call modelobj%free()
+  call mesh%free()
+  call geometry%free()
+  call interp%free()
+
+endprogram bench_lineareuler3d_scaling

--- a/src/SELF_DGModel3D_t.f90
+++ b/src/SELF_DGModel3D_t.f90
@@ -100,6 +100,11 @@ contains
     this%geometry => geometry
     call this%SetNumberOfVariables()
 
+    ! Default the number of time-stepped variables to nvar. Models that carry
+    ! auxiliary/diagnostic variables may set this%nstepped < nvar inside
+    ! SetNumberOfVariables to exclude the trailing variables from time integration.
+    if(this%nstepped <= 0 .or. this%nstepped > this%nvar) this%nstepped = this%nvar
+
     call this%solution%Init(geometry%x%interp,this%nvar,this%mesh%nElem)
     call this%workSol%Init(geometry%x%interp,this%nvar,this%mesh%nElem)
     call this%dSdt%Init(geometry%x%interp,this%nvar,this%mesh%nElem)

--- a/src/gpu/SELF_DGModel2D.f90
+++ b/src/gpu/SELF_DGModel2D.f90
@@ -375,20 +375,42 @@ contains
     integer :: ndof
 
     call this%solution%BoundaryInterp()
-    call this%solution%SideExchange(this%mesh)
 
+    ! Post the halo exchange for the prognostic variables; static variables
+    ! (nstepped+1:nvar) are carried in full by the first exchange only, and
+    ! their boundary traces do not change thereafter. The MPI messages are
+    ! in flight while the hooks, boundary conditions, source, and interior
+    ! flux evaluations below execute.
+    call this%solution%SideExchangeStart(this%mesh,this%nstepped)
+
+    ! The hooks and methods between SideExchangeStart and SideExchangeFinish
+    ! must not read extBoundary on interior (rank-shared) faces.
+    ! SetBoundaryCondition writes extBoundary only on physical-boundary
+    ! faces, which are disjoint from the faces the exchange fills.
     call this%PreTendencyHook() ! User-supplied
     call this%SetBoundaryCondition() ! User-supplied
 
     if(this%gradient_enabled) then
+      ! The BR gradient consumes extBoundary (through the side averages), so
+      ! the exchange must complete before the gradient is computed.
+      call this%solution%SideExchangeFinish(this%mesh)
       call this%CalculateSolutionGradient()
       call this%SetGradientBoundaryCondition() ! User-supplied
       call this%solutionGradient%AverageSides()
+      call this%SourceMethod() ! User supplied
+      call this%BoundaryFlux() ! User supplied
+      call this%FluxMethod() ! User supplied
+    else
+      ! Interior work overlaps with the halo exchange; BoundaryFlux is the
+      ! first consumer of extBoundary and runs after the exchange completes.
+      ! FluxMethod and BoundaryFlux write disjoint outputs (flux interior
+      ! vs. boundarynormal), so this reordering does not change any
+      ! floating-point results.
+      call this%SourceMethod() ! User supplied
+      call this%FluxMethod() ! User supplied
+      call this%solution%SideExchangeFinish(this%mesh)
+      call this%BoundaryFlux() ! User supplied
     endif
-
-    call this%SourceMethod() ! User supplied
-    call this%BoundaryFlux() ! User supplied
-    call this%FluxMethod() ! User supplied
 
     call this%flux%MappedDGDivergence(this%fluxDivergence%interior_gpu)
 

--- a/src/gpu/SELF_DGModel3D.f90
+++ b/src/gpu/SELF_DGModel3D.f90
@@ -376,20 +376,42 @@ contains
     integer :: ndof
 
     call this%solution%BoundaryInterp()
-    call this%solution%SideExchange(this%mesh)
 
+    ! Post the halo exchange for the prognostic variables; static variables
+    ! (nstepped+1:nvar) are carried in full by the first exchange only, and
+    ! their boundary traces do not change thereafter. The MPI messages are
+    ! in flight while the hooks, boundary conditions, source, and interior
+    ! flux evaluations below execute.
+    call this%solution%SideExchangeStart(this%mesh,this%nstepped)
+
+    ! The hooks and methods between SideExchangeStart and SideExchangeFinish
+    ! must not read extBoundary on interior (rank-shared) faces.
+    ! SetBoundaryCondition writes extBoundary only on physical-boundary
+    ! faces, which are disjoint from the faces the exchange fills.
     call this%PreTendencyHook() ! User-supplied
     call this%SetBoundaryCondition() ! User-supplied
 
     if(this%gradient_enabled) then
+      ! The BR gradient consumes extBoundary (through the side averages), so
+      ! the exchange must complete before the gradient is computed.
+      call this%solution%SideExchangeFinish(this%mesh)
       call this%CalculateSolutionGradient()
       call this%SetGradientBoundaryCondition() ! User-supplied
       call this%solutionGradient%AverageSides()
+      call this%SourceMethod() ! User supplied
+      call this%BoundaryFlux() ! User supplied
+      call this%FluxMethod() ! User supplied
+    else
+      ! Interior work overlaps with the halo exchange; BoundaryFlux is the
+      ! first consumer of extBoundary and runs after the exchange completes.
+      ! FluxMethod and BoundaryFlux write disjoint outputs (flux interior
+      ! vs. boundarynormal), so this reordering does not change any
+      ! floating-point results.
+      call this%SourceMethod() ! User supplied
+      call this%FluxMethod() ! User supplied
+      call this%solution%SideExchangeFinish(this%mesh)
+      call this%BoundaryFlux() ! User supplied
     endif
-
-    call this%SourceMethod() ! User supplied
-    call this%BoundaryFlux() ! User supplied
-    call this%FluxMethod() ! User supplied
 
     call this%flux%MappedDGDivergence(this%fluxDivergence%interior_gpu)
 

--- a/src/gpu/SELF_DomainDecomposition.f90
+++ b/src/gpu/SELF_DomainDecomposition.f90
@@ -29,11 +29,27 @@ module SELF_DomainDecomposition
   use SELF_DomainDecomposition_t
   use mpi
   use iso_c_binding
+  use iso_fortran_env,only:int64
 
   implicit none
 
   type,extends(DomainDecomposition_t) :: DomainDecomposition
     type(c_ptr) :: elemToRank_gpu
+
+    ! Aggregated MPI halo exchange tables, shared by every field on the mesh.
+    ! All locally-owned sides with a neighbor element on another rank are
+    ! enumerated once, grouped by neighbor rank and sorted by global side id
+    ! within each group, so that the two ranks sharing an interface enumerate
+    ! its sides in the same order and packed message buffers line up without
+    ! any per-message metadata. Field classes allocate their own packed
+    ! send/receive buffers (sized by their variable count) and share these
+    ! tables for the pack/unpack kernels and message posting.
+    logical :: halo_built = .false.
+    integer :: halo_nnbr = 0 ! Number of neighboring ranks
+    integer :: halo_nsides = 0 ! Total number of sides exchanged with other ranks
+    integer,allocatable :: halo_rank(:) ! (1:halo_nnbr) neighbor rank ids
+    integer,allocatable :: halo_offset(:) ! (1:halo_nnbr+1) side-list offsets per neighbor
+    type(c_ptr) :: halo_sides_gpu = c_null_ptr ! (element,side,flip) triplets, device copy
 
   contains
 
@@ -41,6 +57,8 @@ module SELF_DomainDecomposition
     procedure :: Free => Free_DomainDecomposition
 
     procedure :: SetElemToRank => SetElemToRank_DomainDecomposition
+
+    procedure :: BuildHaloExchange => BuildHaloExchange_DomainDecomposition
 
   endtype DomainDecomposition
 
@@ -116,6 +134,14 @@ contains
     if(allocated(this%requests)) deallocate(this%requests)
     if(allocated(this%stats)) deallocate(this%stats)
 
+    if(allocated(this%halo_rank)) deallocate(this%halo_rank)
+    if(allocated(this%halo_offset)) deallocate(this%halo_offset)
+    if(c_associated(this%halo_sides_gpu)) then
+      call gpuCheck(hipFree(this%halo_sides_gpu))
+      this%halo_sides_gpu = c_null_ptr
+    endif
+    this%halo_built = .false.
+
     print*,__FILE__," : Rank ",this%rankId+1,"/",this%nRanks," checking out."
     call MPI_FINALIZE(ierror)
 
@@ -146,5 +172,178 @@ contains
     call gpuCheck(hipMemcpy(this%elemToRank_gpu,c_loc(this%elemToRank),sizeof(this%elemToRank),hipMemcpyHostToDevice))
 
   endsubroutine SetElemToRank_DomainDecomposition
+
+  subroutine BuildHaloExchange_DomainDecomposition(this,sideInfo,nElem,nSidesPerElem)
+  !! Build the aggregated halo exchange tables for the mesh this domain
+  !! decomposition belongs to.
+  !!
+  !! Enumerates every locally-owned side whose neighbor element resides on
+  !! another rank, groups the sides by neighbor rank, and sorts each group by
+  !! global side id. Both ranks sharing an interface enumerate the interface
+  !! sides in the same order (the global side id is shared), so a packed send
+  !! buffer on one rank and the packed receive buffer on the other line up
+  !! without any per-message metadata. The (element,side,flip) triplets are
+  !! copied to the device for the field pack/unpack kernels.
+  !!
+  !!  Input
+  !!    - sideInfo : the mesh sideInfo array, (1:5, 1:nSidesPerElem, 1:nElem)
+  !!    - nElem : number of local elements
+  !!    - nSidesPerElem : 4 for 2-D (quadrilateral), 6 for 3-D (hexahedral)
+    implicit none
+    class(DomainDecomposition),intent(inout) :: this
+    integer,intent(in) :: nElem
+    integer,intent(in) :: nSidesPerElem
+    integer,intent(in) :: sideInfo(1:5,1:nSidesPerElem,1:nElem)
+    ! Local
+    integer :: e1,s1,e2,r2,n,nhalo
+    integer,allocatable :: elems(:),sides(:),flips(:),ranks(:)
+    integer,allocatable,target :: halosides(:)
+    integer(int64),allocatable :: keys(:)
+
+    nhalo = 0
+    do e1 = 1,nElem
+      do s1 = 1,nSidesPerElem
+        e2 = sideInfo(3,s1,e1)
+        if(e2 > 0) then
+          if(this%elemToRank(e2) /= this%rankId) then
+            nhalo = nhalo+1
+          endif
+        endif
+      enddo
+    enddo
+
+    this%halo_nsides = nhalo
+    this%halo_nnbr = 0
+    if(nhalo == 0) then
+      this%halo_built = .true.
+      return
+    endif
+
+    allocate(elems(1:nhalo),sides(1:nhalo),flips(1:nhalo), &
+             ranks(1:nhalo),keys(1:nhalo))
+
+    n = 0
+    do e1 = 1,nElem
+      do s1 = 1,nSidesPerElem
+        e2 = sideInfo(3,s1,e1)
+        if(e2 > 0) then
+          r2 = this%elemToRank(e2)
+          if(r2 /= this%rankId) then
+            n = n+1
+            elems(n) = e1
+            sides(n) = s1
+            flips(n) = sideInfo(4,s1,e1)-10*(sideInfo(4,s1,e1)/10)
+            ranks(n) = r2
+            ! Composite sort key: neighbor rank (major), global side id (minor).
+            keys(n) = int(r2,int64)*2147483648_int64+ &
+                      int(abs(sideInfo(2,s1,e1)),int64)
+          endif
+        endif
+      enddo
+    enddo
+
+    call HaloKeySort(keys,elems,sides,flips,ranks,nhalo)
+
+    ! Count the neighboring ranks and record the segment offsets
+    this%halo_nnbr = 1
+    do n = 2,nhalo
+      if(ranks(n) /= ranks(n-1)) this%halo_nnbr = this%halo_nnbr+1
+    enddo
+
+    allocate(this%halo_rank(1:this%halo_nnbr))
+    allocate(this%halo_offset(1:this%halo_nnbr+1))
+
+    this%halo_nnbr = 1
+    this%halo_rank(1) = ranks(1)
+    this%halo_offset(1) = 0
+    do n = 2,nhalo
+      if(ranks(n) /= ranks(n-1)) then
+        this%halo_nnbr = this%halo_nnbr+1
+        this%halo_rank(this%halo_nnbr) = ranks(n)
+        this%halo_offset(this%halo_nnbr) = n-1
+      endif
+    enddo
+    this%halo_offset(this%halo_nnbr+1) = nhalo
+
+    ! Flatten the (element,side,flip) triplets with 0-based element and side
+    ! indices for the device pack/unpack kernels
+    allocate(halosides(1:3*nhalo))
+    do n = 1,nhalo
+      halosides(3*n-2) = elems(n)-1
+      halosides(3*n-1) = sides(n)-1
+      halosides(3*n) = flips(n)
+    enddo
+
+    call gpuCheck(hipMalloc(this%halo_sides_gpu,sizeof(halosides)))
+    call gpuCheck(hipMemcpy(this%halo_sides_gpu,c_loc(halosides), &
+                            sizeof(halosides),hipMemcpyHostToDevice))
+
+    deallocate(elems,sides,flips,ranks,keys,halosides)
+
+    this%halo_built = .true.
+
+  endsubroutine BuildHaloExchange_DomainDecomposition
+
+  subroutine HaloKeySort(keys,elems,sides,flips,ranks,n)
+  !! Heap sort of the halo side list by ascending 64-bit key, permuting the
+  !! companion arrays alongside the keys. O(n log n), in place; the relative
+  !! order of equal keys is irrelevant because global side ids are unique.
+    implicit none
+    integer,intent(in) :: n
+    integer(int64),intent(inout) :: keys(1:n)
+    integer,intent(inout) :: elems(1:n),sides(1:n),flips(1:n),ranks(1:n)
+    ! Local
+    integer :: i,last
+
+    do i = n/2,1,-1
+      call HaloSiftDown(keys,elems,sides,flips,ranks,i,n)
+    enddo
+    do last = n,2,-1
+      call HaloSwap(keys,elems,sides,flips,ranks,1,last)
+      call HaloSiftDown(keys,elems,sides,flips,ranks,1,last-1)
+    enddo
+
+  endsubroutine HaloKeySort
+
+  subroutine HaloSiftDown(keys,elems,sides,flips,ranks,start,last)
+    implicit none
+    integer(int64),intent(inout) :: keys(:)
+    integer,intent(inout) :: elems(:),sides(:),flips(:),ranks(:)
+    integer,intent(in) :: start,last
+    ! Local
+    integer :: root,child
+
+    root = start
+    do while(2*root <= last)
+      child = 2*root
+      if(child < last) then
+        if(keys(child) < keys(child+1)) child = child+1
+      endif
+      if(keys(root) < keys(child)) then
+        call HaloSwap(keys,elems,sides,flips,ranks,root,child)
+        root = child
+      else
+        return
+      endif
+    enddo
+
+  endsubroutine HaloSiftDown
+
+  subroutine HaloSwap(keys,elems,sides,flips,ranks,i,j)
+    implicit none
+    integer(int64),intent(inout) :: keys(:)
+    integer,intent(inout) :: elems(:),sides(:),flips(:),ranks(:)
+    integer,intent(in) :: i,j
+    ! Local
+    integer(int64) :: k
+    integer :: t
+
+    k = keys(i); keys(i) = keys(j); keys(j) = k
+    t = elems(i); elems(i) = elems(j); elems(j) = t
+    t = sides(i); sides(i) = sides(j); sides(j) = t
+    t = flips(i); flips(i) = flips(j); flips(j) = t
+    t = ranks(i); ranks(i) = ranks(j); ranks(j) = t
+
+  endsubroutine HaloSwap
 
 endmodule SELF_DomainDecomposition

--- a/src/gpu/SELF_ECDGModel2D.f90
+++ b/src/gpu/SELF_ECDGModel2D.f90
@@ -56,20 +56,25 @@ contains
     integer :: ndof
 
     call this%solution%BoundaryInterp()
-    call this%solution%SideExchange(this%mesh)
+
+    ! Post the halo exchange for the prognostic variables; the MPI messages
+    ! are in flight while the hooks, boundary conditions, source, and the
+    ! two-point volume flux and its divergence below execute.
+    call this%solution%SideExchangeStart(this%mesh,this%nstepped)
 
     call this%PreTendencyHook()
     call this%SetBoundaryCondition()
 
     if(this%gradient_enabled) then
+      ! The BR gradient consumes extBoundary (through the side averages), so
+      ! the exchange must complete before the gradient is computed.
+      call this%solution%SideExchangeFinish(this%mesh)
       call this%CalculateSolutionGradient()
       call this%SetGradientBoundaryCondition()
       call this%solutionGradient%AverageSides()
     endif
 
     call this%SourceMethod()
-    call this%BoundaryFlux() ! CPU, uploads flux%boundaryNormal_gpu
-
     ! Two-point flux: concrete GPU models (e.g. ECAdvection2D) override
     ! TwoPointFluxMethod to run entirely on device.  Models that compute
     ! on the host should call twoPointFlux%UpdateDevice() at the end of
@@ -78,6 +83,14 @@ contains
 
     ! EC volume divergence (uses MappedTwoPointVectorDivergence_2D_gpu)
     call this%twoPointFlux%MappedDivergence(this%fluxDivergence%interior_gpu)
+
+    ! BoundaryFlux is the first consumer of extBoundary; the two-point volume
+    ! flux and its divergence above overlap with the halo exchange (a no-op
+    ! wait when gradients already finished it). BoundaryFlux writes only the
+    ! Riemann trace (flux boundarynormal), disjoint from the volume-term
+    ! outputs, so this reordering does not change any floating-point results.
+    call this%solution%SideExchangeFinish(this%mesh)
+    call this%BoundaryFlux()
 
     ! Add (1/J) * M^{-1} B^T f_Riemann
     call ECDGSurfaceContribution_2D_gpu( &

--- a/src/gpu/SELF_ECDGModel3D.f90
+++ b/src/gpu/SELF_ECDGModel3D.f90
@@ -50,23 +50,36 @@ contains
     integer :: ndof
 
     call this%solution%BoundaryInterp()
-    call this%solution%SideExchange(this%mesh)
+
+    ! Post the halo exchange for the prognostic variables; the MPI messages
+    ! are in flight while the hooks, boundary conditions, source, and the
+    ! two-point volume flux and its divergence below execute.
+    call this%solution%SideExchangeStart(this%mesh,this%nstepped)
 
     call this%PreTendencyHook()
     call this%SetBoundaryCondition()
 
     if(this%gradient_enabled) then
+      ! The BR gradient consumes extBoundary (through the side averages), so
+      ! the exchange must complete before the gradient is computed.
+      call this%solution%SideExchangeFinish(this%mesh)
       call this%CalculateSolutionGradient()
       call this%SetGradientBoundaryCondition()
       call this%solutionGradient%AverageSides()
     endif
 
     call this%SourceMethod()
-    call this%BoundaryFlux()
-
     call this%TwoPointFluxMethod()
 
     call this%twoPointFlux%MappedDivergence(this%fluxDivergence%interior_gpu)
+
+    ! BoundaryFlux is the first consumer of extBoundary; the two-point volume
+    ! flux and its divergence above overlap with the halo exchange (a no-op
+    ! wait when gradients already finished it). BoundaryFlux writes only the
+    ! Riemann trace (flux boundarynormal), disjoint from the volume-term
+    ! outputs, so this reordering does not change any floating-point results.
+    call this%solution%SideExchangeFinish(this%mesh)
+    call this%BoundaryFlux()
 
     call ECDGSurfaceContribution_3D_gpu( &
       this%flux%boundarynormal_gpu, &

--- a/src/gpu/SELF_ESAtmo2D.f90
+++ b/src/gpu/SELF_ESAtmo2D.f90
@@ -373,23 +373,36 @@ contains
     integer :: ndof,ndof_diff
 
     call this%solution%BoundaryInterp()
-    call this%solution%SideExchange(this%mesh)
+
+    ! Post the halo exchange for the prognostic variables; the MPI messages
+    ! are in flight while the hooks, boundary conditions, source, and the
+    ! two-point volume flux and its divergence below execute.
+    call this%solution%SideExchangeStart(this%mesh,this%nstepped)
 
     call this%PreTendencyHook()
     call this%SetBoundaryCondition()
 
     if(this%gradient_enabled) then
+      ! The BR gradient consumes extBoundary (through the side averages), so
+      ! the exchange must complete before the gradient is computed.
+      call this%solution%SideExchangeFinish(this%mesh)
       call this%CalculateSolutionGradient()
       call this%SetGradientBoundaryCondition()
       call this%solutionGradient%AverageSides()
     endif
 
     call this%SourceMethod()
-    call this%BoundaryFlux()
-
     call this%TwoPointFluxMethod()
 
     call this%twoPointFlux%MappedDivergence(this%fluxDivergence%interior_gpu)
+
+    ! BoundaryFlux is the first consumer of extBoundary; the two-point volume
+    ! flux and its divergence above overlap with the halo exchange (a no-op
+    ! wait when gradients already finished it). BoundaryFlux writes only the
+    ! Riemann trace (flux boundarynormal), disjoint from the volume-term
+    ! outputs, so this reordering does not change any floating-point results.
+    call this%solution%SideExchangeFinish(this%mesh)
+    call this%BoundaryFlux()
 
     call ECDGSurfaceContribution_2D_gpu( &
       this%flux%boundarynormal_gpu, &

--- a/src/gpu/SELF_ESAtmo3D.f90
+++ b/src/gpu/SELF_ESAtmo3D.f90
@@ -387,23 +387,36 @@ contains
     integer :: ndof,ndof_diff
 
     call this%solution%BoundaryInterp()
-    call this%solution%SideExchange(this%mesh)
+
+    ! Post the halo exchange for the prognostic variables; the MPI messages
+    ! are in flight while the hooks, boundary conditions, source, and the
+    ! two-point volume flux and its divergence below execute.
+    call this%solution%SideExchangeStart(this%mesh,this%nstepped)
 
     call this%PreTendencyHook()
     call this%SetBoundaryCondition()
 
     if(this%gradient_enabled) then
+      ! The BR gradient consumes extBoundary (through the side averages), so
+      ! the exchange must complete before the gradient is computed.
+      call this%solution%SideExchangeFinish(this%mesh)
       call this%CalculateSolutionGradient()
       call this%SetGradientBoundaryCondition()
       call this%solutionGradient%AverageSides()
     endif
 
     call this%SourceMethod()
-    call this%BoundaryFlux()
-
     call this%TwoPointFluxMethod()
 
     call this%twoPointFlux%MappedDivergence(this%fluxDivergence%interior_gpu)
+
+    ! BoundaryFlux is the first consumer of extBoundary; the two-point volume
+    ! flux and its divergence above overlap with the halo exchange (a no-op
+    ! wait when gradients already finished it). BoundaryFlux writes only the
+    ! Riemann trace (flux boundarynormal), disjoint from the volume-term
+    ! outputs, so this reordering does not change any floating-point results.
+    call this%solution%SideExchangeFinish(this%mesh)
+    call this%BoundaryFlux()
 
     call ECDGSurfaceContribution_3D_gpu( &
       this%flux%boundarynormal_gpu, &

--- a/src/gpu/SELF_GPUInterfaces.f90
+++ b/src/gpu/SELF_GPUInterfaces.f90
@@ -187,6 +187,26 @@ module SELF_GPUInterfaces
   endinterface
 
   interface
+    subroutine HaloPack_3D_gpu(boundary,sendbuf,halosides,n,nvar,nel,nhalo) &
+      bind(c,name="HaloPack_3D_gpu")
+      use iso_c_binding
+      implicit none
+      type(c_ptr),value :: boundary,sendbuf,halosides
+      integer(c_int),value :: n,nvar,nel,nhalo
+    endsubroutine HaloPack_3D_gpu
+  endinterface
+
+  interface
+    subroutine HaloUnpack_3D_gpu(recvbuf,extboundary,halosides,n,nvar,nel,nhalo) &
+      bind(c,name="HaloUnpack_3D_gpu")
+      use iso_c_binding
+      implicit none
+      type(c_ptr),value :: recvbuf,extboundary,halosides
+      integer(c_int),value :: n,nvar,nel,nhalo
+    endsubroutine HaloUnpack_3D_gpu
+  endinterface
+
+  interface
     subroutine DG_BoundaryContribution_3D_gpu(bmatrix,qweights,bf,df,N,nvar,nel) &
       bind(c,name="DG_BoundaryContribution_3D_gpu")
       use iso_c_binding

--- a/src/gpu/SELF_GPUInterfaces.f90
+++ b/src/gpu/SELF_GPUInterfaces.f90
@@ -138,16 +138,6 @@ module SELF_GPUInterfaces
   endinterface
 
   interface
-    subroutine ApplyFlip_2D_gpu(extBoundary,sideInfo,elemToRank,rankId,offset,N,nVar,nEl) &
-      bind(c,name="ApplyFlip_2D_gpu")
-      use iso_c_binding
-      implicit none
-      type(c_ptr),value :: extBoundary,sideInfo,elemToRank
-      integer(c_int),value :: rankId,offset,N,nVar,nEl
-    endsubroutine ApplyFlip_2D_gpu
-  endinterface
-
-  interface
     subroutine DG_BoundaryContribution_2D_gpu(bmatrix,qweights,bf,df,N,nvar,nel) &
       bind(c,name="DG_BoundaryContribution_2D_gpu")
       use iso_c_binding
@@ -177,13 +167,23 @@ module SELF_GPUInterfaces
   endinterface
 
   interface
-    subroutine ApplyFlip_3D_gpu(extBoundary,sideInfo,elemToRank,rankId,offset,N,nVar,nEl) &
-      bind(c,name="ApplyFlip_3D_gpu")
+    subroutine HaloPack_2D_gpu(boundary,sendbuf,halosides,n,nvar,nel,nhalo) &
+      bind(c,name="HaloPack_2D_gpu")
       use iso_c_binding
       implicit none
-      type(c_ptr),value :: extBoundary,sideInfo,elemToRank
-      integer(c_int),value :: rankId,offset,N,nVar,nEl
-    endsubroutine ApplyFlip_3D_gpu
+      type(c_ptr),value :: boundary,sendbuf,halosides
+      integer(c_int),value :: n,nvar,nel,nhalo
+    endsubroutine HaloPack_2D_gpu
+  endinterface
+
+  interface
+    subroutine HaloUnpack_2D_gpu(recvbuf,extboundary,halosides,n,nvar,nel,nhalo) &
+      bind(c,name="HaloUnpack_2D_gpu")
+      use iso_c_binding
+      implicit none
+      type(c_ptr),value :: recvbuf,extboundary,halosides
+      integer(c_int),value :: n,nvar,nel,nhalo
+    endsubroutine HaloUnpack_2D_gpu
   endinterface
 
   interface

--- a/src/gpu/SELF_MappedData.cpp
+++ b/src/gpu/SELF_MappedData.cpp
@@ -116,53 +116,6 @@ extern "C"
   }
 }
 
-__global__ void ApplyFlip_2D(real *extBoundary, int *sideInfo, int *elemToRank, int rankId, int offset, int N, int nVar, int nEl){
-
-  uint32_t idof = threadIdx.x + blockIdx.x*blockDim.x;
-  uint32_t ndof = nVar*nEl*4;
-  uint32_t s1 = (idof) % 4;
-  uint32_t e1 = (idof/4) % nEl;
-  uint32_t ivar = idof/4/nEl;
-  
-  if(idof < ndof){
-    int e2Global = sideInfo[INDEX3(2,s1,e1,5,4)];
-    int e2 = e2Global - offset;
-    int s2 = sideInfo[INDEX3(3,s1,e1,5,4)]/10;
-    int flip = sideInfo[INDEX3(3,s1,e1,5,4)]-s2*10;
-    real buff[24]; // warning : set fixed buffer size for applying flip. This limits the polynomial degree to 23 
-
-    if(e2Global != 0){
-      int neighborRank = elemToRank[e2Global-1];
-      if( neighborRank != rankId ){
-        if(flip == 1){
-          for( int i1 = 0; i1<N+1; i1++){
-            int i2 = N-i1;
-            buff[i1] = extBoundary[SCB_2D_INDEX(i2,s1,e1,ivar,N,nEl)];
-          }
-          for( int i1 = 0; i1<N+1; i1++){
-            extBoundary[SCB_2D_INDEX(i1,s1,e1,ivar,N,nEl)] = buff[i1];
-          }
-        }
-      }
-    }
-  }
-  
-}
-
-extern "C"
-{
-  void ApplyFlip_2D_gpu(real *extBoundary, int *sideInfo, int *elemToRank, int rankId, int offset, int N, int nVar, int nEl)
-  {
-    int ndof = 4*nEl*nVar;
-    int threads_per_block = 256;
-    int nblocks_x = ndof/threads_per_block + 1;
-
-    dim3 nblocks(nblocks_x,1,1);
-    dim3 nthreads(threads_per_block,1,1);
-    ApplyFlip_2D<<<nblocks,nthreads>>>(extBoundary, sideInfo, elemToRank, rankId, offset, N, nVar, nEl);
-  }
-}
-
 __global__ void SideExchange_3D(real *extBoundary, real *boundary, int *sideInfo, int *elemToRank, int rankId, int offset, int N, int nEl){
 
   uint32_t idof = threadIdx.x + blockIdx.x*blockDim.x;
@@ -244,80 +197,7 @@ extern "C"
   }
 }
 
-__global__ void ApplyFlip_3D(real *extBoundary, int *sideInfo, int *elemToRank, int rankId, int offset, int N, int nVar, int nEl){
-
-  uint32_t s1 = blockIdx.x;
-  uint32_t e1 = blockIdx.y;
-  uint32_t ivar = blockIdx.z;
-  uint32_t i = threadIdx.x;
-  uint32_t j = threadIdx.y;
-
-  __shared__ real extBuff[256];
-
-  extBuff[i+(N+1)*j] = extBoundary[SCB_3D_INDEX(i,j,s1,e1,ivar,N,nEl)];
-
-  __syncthreads();
-  
-  int e2Global = sideInfo[INDEX3(2,s1,e1,5,4)];
-  int e2 = e2Global - offset;
-  int s2 = sideInfo[INDEX3(3,s1,e1,5,4)]/10;
-  int flip = sideInfo[INDEX3(3,s1,e1,5,4)]-s2*10;
-
-  if(e2Global != 0){
-    int neighborRank = elemToRank[e2Global-1];
-    if( neighborRank != rankId ){
-
-      if(flip == 1){
-        int i2 = N-i;
-        int j2 = j;
-        extBoundary[SCB_3D_INDEX(i,j,s1,e1,ivar,N,nEl)] = extBuff[i2+(N+1)*j2];
-      }
-      else if(flip == 2){
-        int i2 = N-i;
-        int j2 = N-j;
-        extBoundary[SCB_3D_INDEX(i,j,s1,e1,ivar,N,nEl)] = extBuff[i2+(N+1)*j2];
-      }
-      else if(flip == 3){
-        int i2 = i;
-        int j2 = N-j;
-        extBoundary[SCB_3D_INDEX(i,j,s1,e1,ivar,N,nEl)] = extBuff[i2+(N+1)*j2];
-      }
-      else if(flip == 4){
-        int i2 = j;
-        int j2 = i;
-        extBoundary[SCB_3D_INDEX(i,j,s1,e1,ivar,N,nEl)] = extBuff[i2+(N+1)*j2];
-      }
-      else if(flip == 5){
-        int i2 = N-j;
-        int j2 = i;
-        extBoundary[SCB_3D_INDEX(i,j,s1,e1,ivar,N,nEl)] = extBuff[i2+(N+1)*j2];
-      }
-      else if(flip == 6){
-        int i2 = N-j;
-        int j2 = N-i;
-        extBoundary[SCB_3D_INDEX(i,j,s1,e1,ivar,N,nEl)] = extBuff[i2+(N+1)*j2];
-      }
-      else if(flip == 7){
-        int i2 = j;
-        int j2 = N-i;
-        extBoundary[SCB_3D_INDEX(i,j,s1,e1,ivar,N,nEl)] = extBuff[i2+(N+1)*j2];    
-      }
-    }
-  }
-  
-}
-
-extern "C"
-{
-  void ApplyFlip_3D_gpu(real *extBoundary, int *sideInfo, int *elemToRank, int rankId, int offset, int N, int nVar, int nEl)
-  {
-    dim3 nblocks(6,nEl,nVar);
-    dim3 nthreads(N+1,N+1,1);
-    ApplyFlip_3D<<<nblocks,nthreads>>>(extBoundary, sideInfo, elemToRank, rankId, offset, N, nVar, nEl);
-  }
-}
-
-// Aggregated MPI halo pack/unpack for the 3-D side exchange.
+// Aggregated MPI halo pack/unpack for the 2-D and 3-D side exchanges.
 //
 // haloSides holds (element, side, flip) integer triplets, with 0-based element
 // and side indices, for every locally-owned side whose neighbor element lives
@@ -326,9 +206,85 @@ extern "C"
 // ranks of an interface enumerate sides in the same order; no per-message
 // metadata is required. Buffer layout for entry n, variable ivar:
 //   buf[i + (N+1)*(j + (N+1)*(ivar + nVar*n))]
-// The sender packs its boundary trace in its native (i,j) orientation; the
-// receiver applies its side's flip permutation during the unpack (the same
-// permutation ApplyFlip_3D applies for the per-side message implementation).
+// The sender packs its boundary trace in its native orientation; the
+// receiver applies its side's flip permutation during the unpack.
+
+__global__ void HaloPack_2D(real *boundary, real *sendBuf, int *haloSides, int N, int nVar, int nEl, int nHalo){
+
+  uint32_t idof = threadIdx.x + blockIdx.x*blockDim.x;
+  uint32_t ndof = (N+1)*nHalo;
+
+  if(idof < ndof){
+    uint32_t i = idof % (N+1);
+    uint32_t n = idof/(N+1);
+    uint32_t ivar = blockIdx.y;
+    int e1 = haloSides[3*n];
+    int s1 = haloSides[3*n+1];
+
+    sendBuf[i + (N+1)*(ivar + nVar*n)] = boundary[SCB_2D_INDEX(i,s1,e1,ivar,N,nEl)];
+  }
+
+}
+
+extern "C"
+{
+  void HaloPack_2D_gpu(real *boundary, real *sendBuf, int *haloSides, int N, int nVar, int nEl, int nHalo)
+  {
+    int ndof = (N+1)*nHalo;
+    int threads_per_block = 256;
+    int nblocks_x = ndof/threads_per_block + 1;
+
+    dim3 nblocks(nblocks_x,nVar,1);
+    dim3 nthreads(threads_per_block,1,1);
+    HaloPack_2D<<<nblocks,nthreads>>>(boundary, sendBuf, haloSides, N, nVar, nEl, nHalo);
+    // The packed send buffer must be complete before MPI_Isend is posted on
+    // the host; synchronize the device before returning.
+#ifdef __HIP_PLATFORM_AMD__
+    CHECK(hipDeviceSynchronize());
+#else
+    CHECK(cudaDeviceSynchronize());
+#endif
+  }
+}
+
+__global__ void HaloUnpack_2D(real *recvBuf, real *extBoundary, int *haloSides, int N, int nVar, int nEl, int nHalo){
+
+  uint32_t idof = threadIdx.x + blockIdx.x*blockDim.x;
+  uint32_t ndof = (N+1)*nHalo;
+
+  if(idof < ndof){
+    uint32_t i = idof % (N+1);
+    uint32_t n = idof/(N+1);
+    uint32_t ivar = blockIdx.y;
+    int e1 = haloSides[3*n];
+    int s1 = haloSides[3*n+1];
+    int flip = haloSides[3*n+2];
+    int i2 = i;
+
+    // extBoundary(i) receives the neighbor's trace at (i2), reversing the
+    // trace when the neighbor's coordinate runs in the opposite direction.
+    if(flip == 1){
+      i2 = N-i;
+    }
+
+    extBoundary[SCB_2D_INDEX(i,s1,e1,ivar,N,nEl)] = recvBuf[i2 + (N+1)*(ivar + nVar*n)];
+  }
+
+}
+
+extern "C"
+{
+  void HaloUnpack_2D_gpu(real *recvBuf, real *extBoundary, int *haloSides, int N, int nVar, int nEl, int nHalo)
+  {
+    int ndof = (N+1)*nHalo;
+    int threads_per_block = 256;
+    int nblocks_x = ndof/threads_per_block + 1;
+
+    dim3 nblocks(nblocks_x,nVar,1);
+    dim3 nthreads(threads_per_block,1,1);
+    HaloUnpack_2D<<<nblocks,nthreads>>>(recvBuf, extBoundary, haloSides, N, nVar, nEl, nHalo);
+  }
+}
 
 __global__ void HaloPack_3D(real *boundary, real *sendBuf, int *haloSides, int N, int nVar, int nEl, int nHalo){
 
@@ -385,8 +341,8 @@ __global__ void HaloUnpack_3D(real *recvBuf, real *extBoundary, int *haloSides, 
     int i2 = i;
     int j2 = j;
 
-    // extBoundary(i,j) receives the neighbor's trace at (i2,j2); this is the
-    // same permutation ApplyFlip_3D applies in the per-side implementation.
+    // extBoundary(i,j) receives the neighbor's trace at (i2,j2), matching the
+    // relative orientation (flip) of the two element faces on the interface.
     if(flip == 1){
       i2 = N-i;
       j2 = j;

--- a/src/gpu/SELF_MappedData.cpp
+++ b/src/gpu/SELF_MappedData.cpp
@@ -317,6 +317,124 @@ extern "C"
   }
 }
 
+// Aggregated MPI halo pack/unpack for the 3-D side exchange.
+//
+// haloSides holds (element, side, flip) integer triplets, with 0-based element
+// and side indices, for every locally-owned side whose neighbor element lives
+// on another rank. Entries are grouped by neighbor rank and sorted by global
+// side id within each group so that the send and receive buffers on the two
+// ranks of an interface enumerate sides in the same order; no per-message
+// metadata is required. Buffer layout for entry n, variable ivar:
+//   buf[i + (N+1)*(j + (N+1)*(ivar + nVar*n))]
+// The sender packs its boundary trace in its native (i,j) orientation; the
+// receiver applies its side's flip permutation during the unpack (the same
+// permutation ApplyFlip_3D applies for the per-side message implementation).
+
+__global__ void HaloPack_3D(real *boundary, real *sendBuf, int *haloSides, int N, int nVar, int nEl, int nHalo){
+
+  uint32_t idof = threadIdx.x + blockIdx.x*blockDim.x;
+  uint32_t ndof = (N+1)*(N+1)*nHalo;
+
+  if(idof < ndof){
+    uint32_t i = idof % (N+1);
+    uint32_t j = (idof/(N+1)) % (N+1);
+    uint32_t n = idof/(N+1)/(N+1);
+    uint32_t ivar = blockIdx.y;
+    int e1 = haloSides[3*n];
+    int s1 = haloSides[3*n+1];
+
+    sendBuf[i + (N+1)*(j + (N+1)*(ivar + nVar*n))] = boundary[SCB_3D_INDEX(i,j,s1,e1,ivar,N,nEl)];
+  }
+
+}
+
+extern "C"
+{
+  void HaloPack_3D_gpu(real *boundary, real *sendBuf, int *haloSides, int N, int nVar, int nEl, int nHalo)
+  {
+    int ndof = (N+1)*(N+1)*nHalo;
+    int threads_per_block = 256;
+    int nblocks_x = ndof/threads_per_block + 1;
+
+    dim3 nblocks(nblocks_x,nVar,1);
+    dim3 nthreads(threads_per_block,1,1);
+    HaloPack_3D<<<nblocks,nthreads>>>(boundary, sendBuf, haloSides, N, nVar, nEl, nHalo);
+    // The packed send buffer must be complete before MPI_Isend is posted on
+    // the host; synchronize the device before returning.
+#ifdef __HIP_PLATFORM_AMD__
+    CHECK(hipDeviceSynchronize());
+#else
+    CHECK(cudaDeviceSynchronize());
+#endif
+  }
+}
+
+__global__ void HaloUnpack_3D(real *recvBuf, real *extBoundary, int *haloSides, int N, int nVar, int nEl, int nHalo){
+
+  uint32_t idof = threadIdx.x + blockIdx.x*blockDim.x;
+  uint32_t ndof = (N+1)*(N+1)*nHalo;
+
+  if(idof < ndof){
+    uint32_t i = idof % (N+1);
+    uint32_t j = (idof/(N+1)) % (N+1);
+    uint32_t n = idof/(N+1)/(N+1);
+    uint32_t ivar = blockIdx.y;
+    int e1 = haloSides[3*n];
+    int s1 = haloSides[3*n+1];
+    int flip = haloSides[3*n+2];
+    int i2 = i;
+    int j2 = j;
+
+    // extBoundary(i,j) receives the neighbor's trace at (i2,j2); this is the
+    // same permutation ApplyFlip_3D applies in the per-side implementation.
+    if(flip == 1){
+      i2 = N-i;
+      j2 = j;
+    }
+    else if(flip == 2){
+      i2 = N-i;
+      j2 = N-j;
+    }
+    else if(flip == 3){
+      i2 = i;
+      j2 = N-j;
+    }
+    else if(flip == 4){
+      i2 = j;
+      j2 = i;
+    }
+    else if(flip == 5){
+      i2 = N-j;
+      j2 = i;
+    }
+    else if(flip == 6){
+      i2 = N-j;
+      j2 = N-i;
+    }
+    else if(flip == 7){
+      i2 = j;
+      j2 = N-i;
+    }
+
+    extBoundary[SCB_3D_INDEX(i,j,s1,e1,ivar,N,nEl)] = recvBuf[i2 + (N+1)*(j2 + (N+1)*(ivar + nVar*n))];
+  }
+
+}
+
+extern "C"
+{
+  void HaloUnpack_3D_gpu(real *recvBuf, real *extBoundary, int *haloSides, int N, int nVar, int nEl, int nHalo)
+  {
+    int ndof = (N+1)*(N+1)*nHalo;
+    int threads_per_block = 256;
+    int nblocks_x = ndof/threads_per_block + 1;
+
+    dim3 nblocks(nblocks_x,nVar,1);
+    dim3 nthreads(threads_per_block,1,1);
+    HaloUnpack_3D<<<nblocks,nthreads>>>(recvBuf, extBoundary, haloSides, N, nVar, nEl, nHalo);
+  }
+}
+
 __global__ void ContravariantWeight_gpukernel(real *scalar, real *dsdx, real *tensor, int ndof){
 
   uint32_t ivar = blockIdx.y; // variable dimension

--- a/src/gpu/SELF_MappedScalar_2D.f90
+++ b/src/gpu/SELF_MappedScalar_2D.f90
@@ -37,12 +37,16 @@ module SELF_MappedScalar_2D
 
     type(c_ptr) :: jas_gpu ! jacobian weighted scalar for gradient calculation
 
-    ! Packed device buffers for the aggregated MPI halo exchange. The side
-    ! tables are shared across fields and live on mesh%decomp; the buffers
-    ! are per-field (sized by this field's variable count) and allocated
-    ! lazily on the first exchange.
+    ! Packed device buffers and persistent MPI requests for the aggregated
+    ! halo exchange. The side tables are shared across fields and live on
+    ! mesh%decomp; the buffers and requests are per-field (sized by this
+    ! field's variable count) and created lazily on the first exchange.
     type(c_ptr) :: halo_sendbuf_gpu = c_null_ptr ! packed device send buffer
     type(c_ptr) :: halo_recvbuf_gpu = c_null_ptr ! packed device receive buffer
+    integer,allocatable :: halo_reqs(:) ! persistent requests; receives in 1:nnbr, sends in nnbr+1:2*nnbr
+    integer :: halo_nactive = 0 ! variable count baked into halo_reqs
+    integer :: halo_inflight = 0 ! variable count of the exchange in flight (0 = none)
+    logical :: halo_static_done = .false. ! all variables have been exchanged at least once
 
   contains
     procedure,public :: Init => Init_MappedScalar2D
@@ -51,7 +55,8 @@ module SELF_MappedScalar_2D
     procedure,public :: SetInteriorFromEquation => SetInteriorFromEquation_MappedScalar2D
 
     procedure,public :: SideExchange => SideExchange_MappedScalar2D
-    procedure,private :: MPIExchangeAsync => MPIExchangeAsync_MappedScalar2D
+    procedure,public :: SideExchangeStart => SideExchangeStart_MappedScalar2D
+    procedure,public :: SideExchangeFinish => SideExchangeFinish_MappedScalar2D
 
     generic,public :: MappedGradient => MappedGradient_MappedScalar2D
     procedure,private :: MappedGradient_MappedScalar2D
@@ -132,6 +137,9 @@ contains
   subroutine Free_MappedScalar2D(this)
     implicit none
     class(MappedScalar2D),intent(inout) :: this
+    ! Local
+    integer :: n,iError
+    logical :: mpiIsFinalized
 
     this%nVar = 0
     this%nElem = 0
@@ -156,6 +164,22 @@ contains
     if(c_associated(this%halo_recvbuf_gpu)) call gpuCheck(hipFree(this%halo_recvbuf_gpu))
     this%halo_sendbuf_gpu = c_null_ptr
     this%halo_recvbuf_gpu = c_null_ptr
+
+    if(allocated(this%halo_reqs)) then
+      ! Persistent requests can only be released while MPI is still
+      ! initialized; if the mesh (and its MPI finalization) was freed first,
+      ! MPI has reclaimed them already.
+      call MPI_FINALIZED(mpiIsFinalized,iError)
+      if(.not. mpiIsFinalized) then
+        do n = 1,size(this%halo_reqs)
+          call MPI_REQUEST_FREE(this%halo_reqs(n),iError)
+        enddo
+      endif
+      deallocate(this%halo_reqs)
+    endif
+    this%halo_nactive = 0
+    this%halo_inflight = 0
+    this%halo_static_done = .false.
 
   endsubroutine Free_MappedScalar2D
 
@@ -192,81 +216,104 @@ contains
 
   endsubroutine SetInteriorFromEquation_MappedScalar2D
 
-  subroutine MPIExchangeAsync_MappedScalar2D(this,mesh)
-  !! Post the aggregated halo exchange: one MPI_Irecv/MPI_Isend pair per
-  !! neighboring rank, carrying every (side,variable) boundary trace shared
-  !! with that rank in a single packed device buffer. The pack kernel
-  !! synchronizes the device before returning so the send buffer is complete
-  !! before MPI_Isend is posted. Packed buffers are allocated on first use;
-  !! the shared side tables are built by SideExchange before this is called.
+  subroutine SideExchangeStart_MappedScalar2D(this,mesh,nactive)
+  !! Begin the aggregated halo exchange and launch the local (same-rank)
+  !! side exchange kernel.
+  !!
+  !! One persistent MPI_Recv_init/MPI_Send_init pair per neighboring rank is
+  !! (re)created the first time this is called (and again if the number of
+  !! exchanged variables changes), then re-armed with MPI_Startall on every
+  !! subsequent exchange; receives are always started before sends.
+  !!
+  !! When `nactive` is provided, only the leading `nactive` variables are
+  !! exchanged - the variable index is the outermost dimension of the
+  !! boundary arrays, so the leading variables form a contiguous prefix.
+  !! The first exchange always carries all variables so that the boundary
+  !! traces of static (non-stepped) variables are valid; static traces do
+  !! not change thereafter, so later exchanges may carry the prefix only.
+  !!
+  !! The matching SideExchangeFinish must be called before extBoundary is
+  !! read on interior faces. Between Start and Finish, callers may perform
+  !! any work that does not read interior-face extBoundary entries; the MPI
+  !! messages and the local exchange kernel launched here proceed
+  !! concurrently with that work.
     implicit none
     class(MappedScalar2D),intent(inout) :: this
     type(Mesh2D),intent(inout) :: mesh
+    integer,intent(in),optional :: nactive
     ! Local
-    integer :: n,npts,cnt,disp
+    integer :: n,nnbr,npts,cnt,disp,nact
     integer :: iError
-    integer :: msgCount
+    integer :: offset
     integer(c_size_t) :: worksize
     real(prec),pointer :: sendbuf(:)
     real(prec),pointer :: recvbuf(:)
 
-    npts = (this%interp%N+1)*this%nvar
-
-    if(.not. c_associated(this%halo_sendbuf_gpu)) then
-      worksize = int(mesh%decomp%halo_nsides,c_size_t)* &
-                 int(npts,c_size_t)*prec
-      call gpuCheck(hipMalloc(this%halo_sendbuf_gpu,worksize))
-      call gpuCheck(hipMalloc(this%halo_recvbuf_gpu,worksize))
-    endif
-
-    call HaloPack_2D_gpu(this%boundary_gpu,this%halo_sendbuf_gpu, &
-                         mesh%decomp%halo_sides_gpu,this%interp%N,this%nvar, &
-                         this%nelem,mesh%decomp%halo_nsides)
-
-    call c_f_pointer(this%halo_sendbuf_gpu,sendbuf,[mesh%decomp%halo_nsides*npts])
-    call c_f_pointer(this%halo_recvbuf_gpu,recvbuf,[mesh%decomp%halo_nsides*npts])
-
-    msgCount = 0
-    do n = 1,mesh%decomp%halo_nnbr
-
-      cnt = (mesh%decomp%halo_offset(n+1)-mesh%decomp%halo_offset(n))*npts
-      disp = mesh%decomp%halo_offset(n)*npts
-
-      msgCount = msgCount+1
-      call MPI_IRECV(recvbuf(disp+1),cnt, &
-                     mesh%decomp%mpiPrec, &
-                     mesh%decomp%halo_rank(n),0, &
-                     mesh%decomp%mpiComm, &
-                     mesh%decomp%requests(msgCount),iError)
-
-      msgCount = msgCount+1
-      call MPI_ISEND(sendbuf(disp+1),cnt, &
-                     mesh%decomp%mpiPrec, &
-                     mesh%decomp%halo_rank(n),0, &
-                     mesh%decomp%mpiComm, &
-                     mesh%decomp%requests(msgCount),iError)
-
-    enddo
-
-    mesh%decomp%msgCount = msgCount
-
-  endsubroutine MPIExchangeAsync_MappedScalar2D
-
-  subroutine SideExchange_MappedScalar2D(this,mesh)
-    implicit none
-    class(MappedScalar2D),intent(inout) :: this
-    type(Mesh2D),intent(inout) :: mesh
-    ! Local
-    integer :: offset
-
     offset = mesh%decomp%offsetElem(mesh%decomp%rankId+1)
 
     if(mesh%decomp%mpiEnabled) then
+
       if(.not. mesh%decomp%halo_built) then
         call mesh%decomp%BuildHaloExchange(mesh%sideInfo,mesh%nElem,4)
       endif
+
       if(mesh%decomp%halo_nsides > 0) then
-        call this%MPIExchangeAsync(mesh)
+
+        nact = this%nvar
+        if(present(nactive)) then
+          if(this%halo_static_done .and. nactive >= 1 .and. nactive <= this%nvar) then
+            nact = nactive
+          endif
+        endif
+
+        if(.not. c_associated(this%halo_sendbuf_gpu)) then
+          ! Buffers are sized for a full-variable exchange; prefix exchanges
+          ! use the leading portion.
+          worksize = int(mesh%decomp%halo_nsides,c_size_t)* &
+                     int((this%interp%N+1)*this%nvar,c_size_t)*prec
+          call gpuCheck(hipMalloc(this%halo_sendbuf_gpu,worksize))
+          call gpuCheck(hipMalloc(this%halo_recvbuf_gpu,worksize))
+        endif
+
+        ! Pack the send buffer; the pack kernel synchronizes the device
+        ! before returning so the buffer is complete before the sends start.
+        call HaloPack_2D_gpu(this%boundary_gpu,this%halo_sendbuf_gpu, &
+                             mesh%decomp%halo_sides_gpu,this%interp%N,nact, &
+                             this%nelem,mesh%decomp%halo_nsides)
+
+        nnbr = mesh%decomp%halo_nnbr
+
+        if(nact /= this%halo_nactive) then
+          ! (Re)create the persistent requests for this variable count
+          if(allocated(this%halo_reqs)) then
+            do n = 1,size(this%halo_reqs)
+              call MPI_REQUEST_FREE(this%halo_reqs(n),iError)
+            enddo
+            deallocate(this%halo_reqs)
+          endif
+          allocate(this%halo_reqs(1:2*nnbr))
+          npts = (this%interp%N+1)*nact
+          call c_f_pointer(this%halo_sendbuf_gpu,sendbuf,[mesh%decomp%halo_nsides*npts])
+          call c_f_pointer(this%halo_recvbuf_gpu,recvbuf,[mesh%decomp%halo_nsides*npts])
+          do n = 1,nnbr
+            cnt = (mesh%decomp%halo_offset(n+1)-mesh%decomp%halo_offset(n))*npts
+            disp = mesh%decomp%halo_offset(n)*npts
+            call MPI_RECV_INIT(recvbuf(disp+1),cnt,mesh%decomp%mpiPrec, &
+                               mesh%decomp%halo_rank(n),0,mesh%decomp%mpiComm, &
+                               this%halo_reqs(n),iError)
+            call MPI_SEND_INIT(sendbuf(disp+1),cnt,mesh%decomp%mpiPrec, &
+                               mesh%decomp%halo_rank(n),0,mesh%decomp%mpiComm, &
+                               this%halo_reqs(nnbr+n),iError)
+          enddo
+          this%halo_nactive = nact
+        endif
+
+        ! Arm the receives before the sends
+        call MPI_STARTALL(nnbr,this%halo_reqs(1:nnbr),iError)
+        call MPI_STARTALL(nnbr,this%halo_reqs(nnbr+1:2*nnbr),iError)
+
+        this%halo_inflight = nact
+
       endif
     endif
 
@@ -276,15 +323,44 @@ contains
                              this%boundary_gpu,mesh%sideinfo_gpu,mesh%decomp%elemToRank_gpu, &
                              mesh%decomp%rankid,offset,this%interp%N,this%nvar,this%nelem)
 
-    if(mesh%decomp%mpiEnabled) then
-      if(mesh%decomp%halo_nsides > 0) then
-        call mesh%decomp%FinalizeMPIExchangeAsync()
-        ! Unpack the received traces into extBoundary, applying side flips
-        call HaloUnpack_2D_gpu(this%halo_recvbuf_gpu,this%extboundary_gpu, &
-                               mesh%decomp%halo_sides_gpu,this%interp%N,this%nvar, &
-                               this%nelem,mesh%decomp%halo_nsides)
-      endif
+  endsubroutine SideExchangeStart_MappedScalar2D
+
+  subroutine SideExchangeFinish_MappedScalar2D(this,mesh)
+  !! Complete the aggregated halo exchange started by SideExchangeStart:
+  !! wait on the persistent requests and unpack the received traces into
+  !! extBoundary, applying side flips. The host blocks in MPI_Waitall (which
+  !! also drives MPI progress) while previously launched device kernels
+  !! continue to execute. No-op if no exchange is in flight.
+    implicit none
+    class(MappedScalar2D),intent(inout) :: this
+    type(Mesh2D),intent(inout) :: mesh
+    ! Local
+    integer :: iError
+
+    if(this%halo_inflight > 0) then
+
+      call MPI_WAITALL(2*mesh%decomp%halo_nnbr,this%halo_reqs, &
+                       MPI_STATUSES_IGNORE,iError)
+
+      ! Unpack the received traces into extBoundary, applying side flips
+      call HaloUnpack_2D_gpu(this%halo_recvbuf_gpu,this%extboundary_gpu, &
+                             mesh%decomp%halo_sides_gpu,this%interp%N, &
+                             this%halo_inflight,this%nelem,mesh%decomp%halo_nsides)
+
+      if(this%halo_inflight == this%nvar) this%halo_static_done = .true.
+      this%halo_inflight = 0
+
     endif
+
+  endsubroutine SideExchangeFinish_MappedScalar2D
+
+  subroutine SideExchange_MappedScalar2D(this,mesh)
+    implicit none
+    class(MappedScalar2D),intent(inout) :: this
+    type(Mesh2D),intent(inout) :: mesh
+
+    call this%SideExchangeStart(mesh)
+    call this%SideExchangeFinish(mesh)
 
   endsubroutine SideExchange_MappedScalar2D
 

--- a/src/gpu/SELF_MappedScalar_2D.f90
+++ b/src/gpu/SELF_MappedScalar_2D.f90
@@ -37,6 +37,13 @@ module SELF_MappedScalar_2D
 
     type(c_ptr) :: jas_gpu ! jacobian weighted scalar for gradient calculation
 
+    ! Packed device buffers for the aggregated MPI halo exchange. The side
+    ! tables are shared across fields and live on mesh%decomp; the buffers
+    ! are per-field (sized by this field's variable count) and allocated
+    ! lazily on the first exchange.
+    type(c_ptr) :: halo_sendbuf_gpu = c_null_ptr ! packed device send buffer
+    type(c_ptr) :: halo_recvbuf_gpu = c_null_ptr ! packed device receive buffer
+
   contains
     procedure,public :: Init => Init_MappedScalar2D
     procedure,public :: Free => Free_MappedScalar2D
@@ -145,6 +152,11 @@ contains
     call gpuCheck(hipFree(this%jas_gpu))
     call hipblasCheck(hipblasDestroy(this%blas_handle))
 
+    if(c_associated(this%halo_sendbuf_gpu)) call gpuCheck(hipFree(this%halo_sendbuf_gpu))
+    if(c_associated(this%halo_recvbuf_gpu)) call gpuCheck(hipFree(this%halo_recvbuf_gpu))
+    this%halo_sendbuf_gpu = c_null_ptr
+    this%halo_recvbuf_gpu = c_null_ptr
+
   endsubroutine Free_MappedScalar2D
 
   subroutine SetInteriorFromEquation_MappedScalar2D(this,geometry,time)
@@ -181,56 +193,59 @@ contains
   endsubroutine SetInteriorFromEquation_MappedScalar2D
 
   subroutine MPIExchangeAsync_MappedScalar2D(this,mesh)
+  !! Post the aggregated halo exchange: one MPI_Irecv/MPI_Isend pair per
+  !! neighboring rank, carrying every (side,variable) boundary trace shared
+  !! with that rank in a single packed device buffer. The pack kernel
+  !! synchronizes the device before returning so the send buffer is complete
+  !! before MPI_Isend is posted. Packed buffers are allocated on first use;
+  !! the shared side tables are built by SideExchange before this is called.
     implicit none
     class(MappedScalar2D),intent(inout) :: this
     type(Mesh2D),intent(inout) :: mesh
     ! Local
-    integer :: e1,s1,e2,s2,ivar
-    integer :: globalSideId,r2,tag
+    integer :: n,npts,cnt,disp
     integer :: iError
     integer :: msgCount
-    real(prec),pointer :: boundary(:,:,:,:)
-    real(prec),pointer :: extboundary(:,:,:,:)
+    integer(c_size_t) :: worksize
+    real(prec),pointer :: sendbuf(:)
+    real(prec),pointer :: recvbuf(:)
+
+    npts = (this%interp%N+1)*this%nvar
+
+    if(.not. c_associated(this%halo_sendbuf_gpu)) then
+      worksize = int(mesh%decomp%halo_nsides,c_size_t)* &
+                 int(npts,c_size_t)*prec
+      call gpuCheck(hipMalloc(this%halo_sendbuf_gpu,worksize))
+      call gpuCheck(hipMalloc(this%halo_recvbuf_gpu,worksize))
+    endif
+
+    call HaloPack_2D_gpu(this%boundary_gpu,this%halo_sendbuf_gpu, &
+                         mesh%decomp%halo_sides_gpu,this%interp%N,this%nvar, &
+                         this%nelem,mesh%decomp%halo_nsides)
+
+    call c_f_pointer(this%halo_sendbuf_gpu,sendbuf,[mesh%decomp%halo_nsides*npts])
+    call c_f_pointer(this%halo_recvbuf_gpu,recvbuf,[mesh%decomp%halo_nsides*npts])
 
     msgCount = 0
-    call c_f_pointer(this%boundary_gpu,boundary,[this%interp%N+1,4,this%nelem,this%nvar])
-    call c_f_pointer(this%extboundary_gpu,extboundary,[this%interp%N+1,4,this%nelem,this%nvar])
+    do n = 1,mesh%decomp%halo_nnbr
 
-    do ivar = 1,this%nvar
-      do e1 = 1,this%nElem
-        do s1 = 1,4
+      cnt = (mesh%decomp%halo_offset(n+1)-mesh%decomp%halo_offset(n))*npts
+      disp = mesh%decomp%halo_offset(n)*npts
 
-          e2 = mesh%sideInfo(3,s1,e1) ! Neighbor Element
-          if(e2 > 0) then
-            r2 = mesh%decomp%elemToRank(e2) ! Neighbor Rank
+      msgCount = msgCount+1
+      call MPI_IRECV(recvbuf(disp+1),cnt, &
+                     mesh%decomp%mpiPrec, &
+                     mesh%decomp%halo_rank(n),0, &
+                     mesh%decomp%mpiComm, &
+                     mesh%decomp%requests(msgCount),iError)
 
-            if(r2 /= mesh%decomp%rankId) then
+      msgCount = msgCount+1
+      call MPI_ISEND(sendbuf(disp+1),cnt, &
+                     mesh%decomp%mpiPrec, &
+                     mesh%decomp%halo_rank(n),0, &
+                     mesh%decomp%mpiComm, &
+                     mesh%decomp%requests(msgCount),iError)
 
-              s2 = mesh%sideInfo(4,s1,e1)/10
-              globalSideId = abs(mesh%sideInfo(2,s1,e1))
-              ! create unique tag for each side and each variable
-              tag = globalsideid+mesh%nUniqueSides*(ivar-1)
-
-              msgCount = msgCount+1
-              call MPI_IRECV(extBoundary(:,s1,e1,ivar), &
-                             (this%interp%N+1), &
-                             mesh%decomp%mpiPrec, &
-                             r2,tag, &
-                             mesh%decomp%mpiComm, &
-                             mesh%decomp%requests(msgCount),iError)
-
-              msgCount = msgCount+1
-              call MPI_ISEND(boundary(:,s1,e1,ivar), &
-                             (this%interp%N+1), &
-                             mesh%decomp%mpiPrec, &
-                             r2,tag, &
-                             mesh%decomp%mpiComm, &
-                             mesh%decomp%requests(msgCount),iError)
-            endif
-          endif
-
-        enddo
-      enddo
     enddo
 
     mesh%decomp%msgCount = msgCount
@@ -245,21 +260,30 @@ contains
     integer :: offset
 
     offset = mesh%decomp%offsetElem(mesh%decomp%rankId+1)
+
     if(mesh%decomp%mpiEnabled) then
-      call this%MPIExchangeAsync(mesh)
+      if(.not. mesh%decomp%halo_built) then
+        call mesh%decomp%BuildHaloExchange(mesh%sideInfo,mesh%nElem,4)
+      endif
+      if(mesh%decomp%halo_nsides > 0) then
+        call this%MPIExchangeAsync(mesh)
+      endif
     endif
 
-    ! Do the side exchange internal to this mpi process
+    ! The local (same-rank) side exchange runs on the device while the
+    ! aggregated MPI messages are in flight.
     call SideExchange_2D_gpu(this%extboundary_gpu, &
                              this%boundary_gpu,mesh%sideinfo_gpu,mesh%decomp%elemToRank_gpu, &
                              mesh%decomp%rankid,offset,this%interp%N,this%nvar,this%nelem)
 
     if(mesh%decomp%mpiEnabled) then
-      call mesh%decomp%FinalizeMPIExchangeAsync()
-      ! Apply side flips for data exchanged with MPI
-      call ApplyFlip_2D_gpu(this%extboundary_gpu,mesh%sideInfo_gpu, &
-                            mesh%decomp%elemToRank_gpu,mesh%decomp%rankId, &
-                            offset,this%interp%N,this%nVar,this%nElem)
+      if(mesh%decomp%halo_nsides > 0) then
+        call mesh%decomp%FinalizeMPIExchangeAsync()
+        ! Unpack the received traces into extBoundary, applying side flips
+        call HaloUnpack_2D_gpu(this%halo_recvbuf_gpu,this%extboundary_gpu, &
+                               mesh%decomp%halo_sides_gpu,this%interp%N,this%nvar, &
+                               this%nelem,mesh%decomp%halo_nsides)
+      endif
     endif
 
   endsubroutine SideExchange_MappedScalar2D

--- a/src/gpu/SELF_MappedScalar_3D.f90
+++ b/src/gpu/SELF_MappedScalar_3D.f90
@@ -37,12 +37,16 @@ module SELF_MappedScalar_3D
 
     type(c_ptr) :: jas_gpu ! jacobian weighted scalar for gradient calculation
 
-    ! Packed device buffers for the aggregated MPI halo exchange. The side
-    ! tables are shared across fields and live on mesh%decomp; the buffers
-    ! are per-field (sized by this field's variable count) and allocated
-    ! lazily on the first exchange.
+    ! Packed device buffers and persistent MPI requests for the aggregated
+    ! halo exchange. The side tables are shared across fields and live on
+    ! mesh%decomp; the buffers and requests are per-field (sized by this
+    ! field's variable count) and created lazily on the first exchange.
     type(c_ptr) :: halo_sendbuf_gpu = c_null_ptr ! packed device send buffer
     type(c_ptr) :: halo_recvbuf_gpu = c_null_ptr ! packed device receive buffer
+    integer,allocatable :: halo_reqs(:) ! persistent requests; receives in 1:nnbr, sends in nnbr+1:2*nnbr
+    integer :: halo_nactive = 0 ! variable count baked into halo_reqs
+    integer :: halo_inflight = 0 ! variable count of the exchange in flight (0 = none)
+    logical :: halo_static_done = .false. ! all variables have been exchanged at least once
 
   contains
     procedure,public :: Init => Init_MappedScalar3D
@@ -51,7 +55,8 @@ module SELF_MappedScalar_3D
     procedure,public :: SetInteriorFromEquation => SetInteriorFromEquation_MappedScalar3D
 
     procedure,public :: SideExchange => SideExchange_MappedScalar3D
-    procedure,private :: MPIExchangeAsync => MPIExchangeAsync_MappedScalar3D
+    procedure,public :: SideExchangeStart => SideExchangeStart_MappedScalar3D
+    procedure,public :: SideExchangeFinish => SideExchangeFinish_MappedScalar3D
 
     generic,public :: MappedGradient => MappedGradient_MappedScalar3D
     procedure,private :: MappedGradient_MappedScalar3D
@@ -134,6 +139,9 @@ contains
   subroutine Free_MappedScalar3D(this)
     implicit none
     class(MappedScalar3D),intent(inout) :: this
+    ! Local
+    integer :: n,iError
+    logical :: mpiIsFinalized
 
     this%nVar = 0
     this%nElem = 0
@@ -160,6 +168,22 @@ contains
     if(c_associated(this%halo_recvbuf_gpu)) call gpuCheck(hipFree(this%halo_recvbuf_gpu))
     this%halo_sendbuf_gpu = c_null_ptr
     this%halo_recvbuf_gpu = c_null_ptr
+
+    if(allocated(this%halo_reqs)) then
+      ! Persistent requests can only be released while MPI is still
+      ! initialized; if the mesh (and its MPI finalization) was freed first,
+      ! MPI has reclaimed them already.
+      call MPI_FINALIZED(mpiIsFinalized,iError)
+      if(.not. mpiIsFinalized) then
+        do n = 1,size(this%halo_reqs)
+          call MPI_REQUEST_FREE(this%halo_reqs(n),iError)
+        enddo
+      endif
+      deallocate(this%halo_reqs)
+    endif
+    this%halo_nactive = 0
+    this%halo_inflight = 0
+    this%halo_static_done = .false.
 
   endsubroutine Free_MappedScalar3D
 
@@ -200,81 +224,104 @@ contains
 
   endsubroutine SetInteriorFromEquation_MappedScalar3D
 
-  subroutine MPIExchangeAsync_MappedScalar3D(this,mesh)
-  !! Post the aggregated halo exchange: one MPI_Irecv/MPI_Isend pair per
-  !! neighboring rank, carrying every (side,variable) boundary trace shared
-  !! with that rank in a single packed device buffer. The pack kernel
-  !! synchronizes the device before returning so the send buffer is complete
-  !! before MPI_Isend is posted. Packed buffers are allocated on first use;
-  !! the shared side tables are built by SideExchange before this is called.
+  subroutine SideExchangeStart_MappedScalar3D(this,mesh,nactive)
+  !! Begin the aggregated halo exchange and launch the local (same-rank)
+  !! side exchange kernel.
+  !!
+  !! One persistent MPI_Recv_init/MPI_Send_init pair per neighboring rank is
+  !! (re)created the first time this is called (and again if the number of
+  !! exchanged variables changes), then re-armed with MPI_Startall on every
+  !! subsequent exchange; receives are always started before sends.
+  !!
+  !! When `nactive` is provided, only the leading `nactive` variables are
+  !! exchanged - the variable index is the outermost dimension of the
+  !! boundary arrays, so the leading variables form a contiguous prefix.
+  !! The first exchange always carries all variables so that the boundary
+  !! traces of static (non-stepped) variables are valid; static traces do
+  !! not change thereafter, so later exchanges may carry the prefix only.
+  !!
+  !! The matching SideExchangeFinish must be called before extBoundary is
+  !! read on interior faces. Between Start and Finish, callers may perform
+  !! any work that does not read interior-face extBoundary entries; the MPI
+  !! messages and the local exchange kernel launched here proceed
+  !! concurrently with that work.
     implicit none
     class(MappedScalar3D),intent(inout) :: this
     type(Mesh3D),intent(inout) :: mesh
+    integer,intent(in),optional :: nactive
     ! Local
-    integer :: n,npts,cnt,disp
+    integer :: n,nnbr,npts,cnt,disp,nact
     integer :: iError
-    integer :: msgCount
+    integer :: offset
     integer(c_size_t) :: worksize
     real(prec),pointer :: sendbuf(:)
     real(prec),pointer :: recvbuf(:)
 
-    npts = (this%interp%N+1)*(this%interp%N+1)*this%nvar
-
-    if(.not. c_associated(this%halo_sendbuf_gpu)) then
-      worksize = int(mesh%decomp%halo_nsides,c_size_t)* &
-                 int(npts,c_size_t)*prec
-      call gpuCheck(hipMalloc(this%halo_sendbuf_gpu,worksize))
-      call gpuCheck(hipMalloc(this%halo_recvbuf_gpu,worksize))
-    endif
-
-    call HaloPack_3D_gpu(this%boundary_gpu,this%halo_sendbuf_gpu, &
-                         mesh%decomp%halo_sides_gpu,this%interp%N,this%nvar, &
-                         this%nelem,mesh%decomp%halo_nsides)
-
-    call c_f_pointer(this%halo_sendbuf_gpu,sendbuf,[mesh%decomp%halo_nsides*npts])
-    call c_f_pointer(this%halo_recvbuf_gpu,recvbuf,[mesh%decomp%halo_nsides*npts])
-
-    msgCount = 0
-    do n = 1,mesh%decomp%halo_nnbr
-
-      cnt = (mesh%decomp%halo_offset(n+1)-mesh%decomp%halo_offset(n))*npts
-      disp = mesh%decomp%halo_offset(n)*npts
-
-      msgCount = msgCount+1
-      call MPI_IRECV(recvbuf(disp+1),cnt, &
-                     mesh%decomp%mpiPrec, &
-                     mesh%decomp%halo_rank(n),0, &
-                     mesh%decomp%mpiComm, &
-                     mesh%decomp%requests(msgCount),iError)
-
-      msgCount = msgCount+1
-      call MPI_ISEND(sendbuf(disp+1),cnt, &
-                     mesh%decomp%mpiPrec, &
-                     mesh%decomp%halo_rank(n),0, &
-                     mesh%decomp%mpiComm, &
-                     mesh%decomp%requests(msgCount),iError)
-
-    enddo
-
-    mesh%decomp%msgCount = msgCount
-
-  endsubroutine MPIExchangeAsync_MappedScalar3D
-
-  subroutine SideExchange_MappedScalar3D(this,mesh)
-    implicit none
-    class(MappedScalar3D),intent(inout) :: this
-    type(Mesh3D),intent(inout) :: mesh
-    ! Local
-    integer :: offset
-
     offset = mesh%decomp%offsetElem(mesh%decomp%rankId+1)
 
     if(mesh%decomp%mpiEnabled) then
+
       if(.not. mesh%decomp%halo_built) then
         call mesh%decomp%BuildHaloExchange(mesh%sideInfo,mesh%nElem,6)
       endif
+
       if(mesh%decomp%halo_nsides > 0) then
-        call this%MPIExchangeAsync(mesh)
+
+        nact = this%nvar
+        if(present(nactive)) then
+          if(this%halo_static_done .and. nactive >= 1 .and. nactive <= this%nvar) then
+            nact = nactive
+          endif
+        endif
+
+        if(.not. c_associated(this%halo_sendbuf_gpu)) then
+          ! Buffers are sized for a full-variable exchange; prefix exchanges
+          ! use the leading portion.
+          worksize = int(mesh%decomp%halo_nsides,c_size_t)* &
+                     int((this%interp%N+1)*(this%interp%N+1)*this%nvar,c_size_t)*prec
+          call gpuCheck(hipMalloc(this%halo_sendbuf_gpu,worksize))
+          call gpuCheck(hipMalloc(this%halo_recvbuf_gpu,worksize))
+        endif
+
+        ! Pack the send buffer; the pack kernel synchronizes the device
+        ! before returning so the buffer is complete before the sends start.
+        call HaloPack_3D_gpu(this%boundary_gpu,this%halo_sendbuf_gpu, &
+                             mesh%decomp%halo_sides_gpu,this%interp%N,nact, &
+                             this%nelem,mesh%decomp%halo_nsides)
+
+        nnbr = mesh%decomp%halo_nnbr
+
+        if(nact /= this%halo_nactive) then
+          ! (Re)create the persistent requests for this variable count
+          if(allocated(this%halo_reqs)) then
+            do n = 1,size(this%halo_reqs)
+              call MPI_REQUEST_FREE(this%halo_reqs(n),iError)
+            enddo
+            deallocate(this%halo_reqs)
+          endif
+          allocate(this%halo_reqs(1:2*nnbr))
+          npts = (this%interp%N+1)*(this%interp%N+1)*nact
+          call c_f_pointer(this%halo_sendbuf_gpu,sendbuf,[mesh%decomp%halo_nsides*npts])
+          call c_f_pointer(this%halo_recvbuf_gpu,recvbuf,[mesh%decomp%halo_nsides*npts])
+          do n = 1,nnbr
+            cnt = (mesh%decomp%halo_offset(n+1)-mesh%decomp%halo_offset(n))*npts
+            disp = mesh%decomp%halo_offset(n)*npts
+            call MPI_RECV_INIT(recvbuf(disp+1),cnt,mesh%decomp%mpiPrec, &
+                               mesh%decomp%halo_rank(n),0,mesh%decomp%mpiComm, &
+                               this%halo_reqs(n),iError)
+            call MPI_SEND_INIT(sendbuf(disp+1),cnt,mesh%decomp%mpiPrec, &
+                               mesh%decomp%halo_rank(n),0,mesh%decomp%mpiComm, &
+                               this%halo_reqs(nnbr+n),iError)
+          enddo
+          this%halo_nactive = nact
+        endif
+
+        ! Arm the receives before the sends
+        call MPI_STARTALL(nnbr,this%halo_reqs(1:nnbr),iError)
+        call MPI_STARTALL(nnbr,this%halo_reqs(nnbr+1:2*nnbr),iError)
+
+        this%halo_inflight = nact
+
       endif
     endif
 
@@ -284,15 +331,44 @@ contains
                              this%boundary_gpu,mesh%sideinfo_gpu,mesh%decomp%elemToRank_gpu, &
                              mesh%decomp%rankid,offset,this%interp%N,this%nvar,this%nelem)
 
-    if(mesh%decomp%mpiEnabled) then
-      if(mesh%decomp%halo_nsides > 0) then
-        call mesh%decomp%FinalizeMPIExchangeAsync()
-        ! Unpack the received traces into extBoundary, applying side flips
-        call HaloUnpack_3D_gpu(this%halo_recvbuf_gpu,this%extboundary_gpu, &
-                               mesh%decomp%halo_sides_gpu,this%interp%N,this%nvar, &
-                               this%nelem,mesh%decomp%halo_nsides)
-      endif
+  endsubroutine SideExchangeStart_MappedScalar3D
+
+  subroutine SideExchangeFinish_MappedScalar3D(this,mesh)
+  !! Complete the aggregated halo exchange started by SideExchangeStart:
+  !! wait on the persistent requests and unpack the received traces into
+  !! extBoundary, applying side flips. The host blocks in MPI_Waitall (which
+  !! also drives MPI progress) while previously launched device kernels
+  !! continue to execute. No-op if no exchange is in flight.
+    implicit none
+    class(MappedScalar3D),intent(inout) :: this
+    type(Mesh3D),intent(inout) :: mesh
+    ! Local
+    integer :: iError
+
+    if(this%halo_inflight > 0) then
+
+      call MPI_WAITALL(2*mesh%decomp%halo_nnbr,this%halo_reqs, &
+                       MPI_STATUSES_IGNORE,iError)
+
+      ! Unpack the received traces into extBoundary, applying side flips
+      call HaloUnpack_3D_gpu(this%halo_recvbuf_gpu,this%extboundary_gpu, &
+                             mesh%decomp%halo_sides_gpu,this%interp%N, &
+                             this%halo_inflight,this%nelem,mesh%decomp%halo_nsides)
+
+      if(this%halo_inflight == this%nvar) this%halo_static_done = .true.
+      this%halo_inflight = 0
+
     endif
+
+  endsubroutine SideExchangeFinish_MappedScalar3D
+
+  subroutine SideExchange_MappedScalar3D(this,mesh)
+    implicit none
+    class(MappedScalar3D),intent(inout) :: this
+    type(Mesh3D),intent(inout) :: mesh
+
+    call this%SideExchangeStart(mesh)
+    call this%SideExchangeFinish(mesh)
 
   endsubroutine SideExchange_MappedScalar3D
 

--- a/src/gpu/SELF_MappedScalar_3D.f90
+++ b/src/gpu/SELF_MappedScalar_3D.f90
@@ -30,7 +30,6 @@ module SELF_MappedScalar_3D
   use SELF_GPU
   use SELF_GPUInterfaces
   use iso_c_binding
-  use iso_fortran_env,only:int64
 
   implicit none
 
@@ -38,16 +37,10 @@ module SELF_MappedScalar_3D
 
     type(c_ptr) :: jas_gpu ! jacobian weighted scalar for gradient calculation
 
-    ! Aggregated MPI halo exchange tables. All locally-owned sides with a
-    ! neighbor element on another rank are enumerated once, grouped by
-    ! neighbor rank and sorted by global side id within each group, so that
-    ! a single message per neighbor rank carries every (side,variable) trace.
-    logical :: halo_built = .false.
-    integer :: halo_nnbr = 0 ! Number of neighboring ranks
-    integer :: halo_nsides = 0 ! Total number of sides exchanged with other ranks
-    integer,allocatable :: halo_rank(:) ! (1:halo_nnbr) neighbor rank ids
-    integer,allocatable :: halo_offset(:) ! (1:halo_nnbr+1) side-list offsets per neighbor
-    type(c_ptr) :: halo_sides_gpu = c_null_ptr ! (element,side,flip) triplets, device copy
+    ! Packed device buffers for the aggregated MPI halo exchange. The side
+    ! tables are shared across fields and live on mesh%decomp; the buffers
+    ! are per-field (sized by this field's variable count) and allocated
+    ! lazily on the first exchange.
     type(c_ptr) :: halo_sendbuf_gpu = c_null_ptr ! packed device send buffer
     type(c_ptr) :: halo_recvbuf_gpu = c_null_ptr ! packed device receive buffer
 
@@ -59,7 +52,6 @@ module SELF_MappedScalar_3D
 
     procedure,public :: SideExchange => SideExchange_MappedScalar3D
     procedure,private :: MPIExchangeAsync => MPIExchangeAsync_MappedScalar3D
-    procedure,private :: SetupHaloExchange => SetupHaloExchange_MappedScalar3D
 
     generic,public :: MappedGradient => MappedGradient_MappedScalar3D
     procedure,private :: MappedGradient_MappedScalar3D
@@ -164,15 +156,10 @@ contains
     call gpuCheck(hipFree(this%jas_gpu))
     call hipblasCheck(hipblasDestroy(this%blas_handle))
 
-    if(allocated(this%halo_rank)) deallocate(this%halo_rank)
-    if(allocated(this%halo_offset)) deallocate(this%halo_offset)
-    if(c_associated(this%halo_sides_gpu)) call gpuCheck(hipFree(this%halo_sides_gpu))
     if(c_associated(this%halo_sendbuf_gpu)) call gpuCheck(hipFree(this%halo_sendbuf_gpu))
     if(c_associated(this%halo_recvbuf_gpu)) call gpuCheck(hipFree(this%halo_recvbuf_gpu))
-    this%halo_sides_gpu = c_null_ptr
     this%halo_sendbuf_gpu = c_null_ptr
     this%halo_recvbuf_gpu = c_null_ptr
-    this%halo_built = .false.
 
   endsubroutine Free_MappedScalar3D
 
@@ -213,187 +200,13 @@ contains
 
   endsubroutine SetInteriorFromEquation_MappedScalar3D
 
-  subroutine SetupHaloExchange_MappedScalar3D(this,mesh)
-  !! Build the aggregated halo exchange tables for this field.
-  !!
-  !! Enumerates every locally-owned side whose neighbor element resides on
-  !! another rank, groups the sides by neighbor rank, and sorts each group by
-  !! global side id. Both ranks sharing an interface enumerate the interface
-  !! sides in the same order (the global side id is shared), so the packed
-  !! send buffer on one rank and the packed receive buffer on the other line
-  !! up without any per-message metadata. The (element,side,flip) triplets
-  !! are copied to the device for the pack/unpack kernels, and the packed
-  !! send/receive device buffers are allocated here.
-    implicit none
-    class(MappedScalar3D),intent(inout) :: this
-    type(Mesh3D),intent(inout) :: mesh
-    ! Local
-    integer :: e1,s1,e2,r2,n,nhalo
-    integer :: rankId
-    integer,allocatable :: elems(:),sides(:),flips(:),ranks(:)
-    integer,allocatable,target :: halosides(:)
-    integer(int64),allocatable :: keys(:)
-    integer(c_size_t) :: worksize
-
-    rankId = mesh%decomp%rankId
-
-    nhalo = 0
-    do e1 = 1,this%nElem
-      do s1 = 1,6
-        e2 = mesh%sideInfo(3,s1,e1)
-        if(e2 > 0) then
-          if(mesh%decomp%elemToRank(e2) /= rankId) then
-            nhalo = nhalo+1
-          endif
-        endif
-      enddo
-    enddo
-
-    this%halo_nsides = nhalo
-    this%halo_nnbr = 0
-    if(nhalo == 0) then
-      this%halo_built = .true.
-      return
-    endif
-
-    allocate(elems(1:nhalo),sides(1:nhalo),flips(1:nhalo), &
-             ranks(1:nhalo),keys(1:nhalo))
-
-    n = 0
-    do e1 = 1,this%nElem
-      do s1 = 1,6
-        e2 = mesh%sideInfo(3,s1,e1)
-        if(e2 > 0) then
-          r2 = mesh%decomp%elemToRank(e2)
-          if(r2 /= rankId) then
-            n = n+1
-            elems(n) = e1
-            sides(n) = s1
-            flips(n) = mesh%sideInfo(4,s1,e1)-10*(mesh%sideInfo(4,s1,e1)/10)
-            ranks(n) = r2
-            ! Composite sort key: neighbor rank (major), global side id (minor).
-            keys(n) = int(r2,int64)*2147483648_int64+ &
-                      int(abs(mesh%sideInfo(2,s1,e1)),int64)
-          endif
-        endif
-      enddo
-    enddo
-
-    call HaloKeySort(keys,elems,sides,flips,ranks,nhalo)
-
-    ! Count the neighboring ranks and record the segment offsets
-    this%halo_nnbr = 1
-    do n = 2,nhalo
-      if(ranks(n) /= ranks(n-1)) this%halo_nnbr = this%halo_nnbr+1
-    enddo
-
-    allocate(this%halo_rank(1:this%halo_nnbr))
-    allocate(this%halo_offset(1:this%halo_nnbr+1))
-
-    this%halo_nnbr = 1
-    this%halo_rank(1) = ranks(1)
-    this%halo_offset(1) = 0
-    do n = 2,nhalo
-      if(ranks(n) /= ranks(n-1)) then
-        this%halo_nnbr = this%halo_nnbr+1
-        this%halo_rank(this%halo_nnbr) = ranks(n)
-        this%halo_offset(this%halo_nnbr) = n-1
-      endif
-    enddo
-    this%halo_offset(this%halo_nnbr+1) = nhalo
-
-    ! Flatten the (element,side,flip) triplets with 0-based element and side
-    ! indices for the device pack/unpack kernels
-    allocate(halosides(1:3*nhalo))
-    do n = 1,nhalo
-      halosides(3*n-2) = elems(n)-1
-      halosides(3*n-1) = sides(n)-1
-      halosides(3*n) = flips(n)
-    enddo
-
-    call gpuCheck(hipMalloc(this%halo_sides_gpu,sizeof(halosides)))
-    call gpuCheck(hipMemcpy(this%halo_sides_gpu,c_loc(halosides), &
-                            sizeof(halosides),hipMemcpyHostToDevice))
-
-    worksize = int(this%interp%N+1,c_size_t)*(this%interp%N+1)* &
-               int(nhalo,c_size_t)*int(this%nvar,c_size_t)*prec
-    call gpuCheck(hipMalloc(this%halo_sendbuf_gpu,worksize))
-    call gpuCheck(hipMalloc(this%halo_recvbuf_gpu,worksize))
-
-    deallocate(elems,sides,flips,ranks,keys,halosides)
-
-    this%halo_built = .true.
-
-  endsubroutine SetupHaloExchange_MappedScalar3D
-
-  subroutine HaloKeySort(keys,elems,sides,flips,ranks,n)
-  !! Heap sort of the halo side list by ascending 64-bit key, permuting the
-  !! companion arrays alongside the keys. O(n log n), in place; the relative
-  !! order of equal keys is irrelevant because global side ids are unique.
-    implicit none
-    integer,intent(in) :: n
-    integer(int64),intent(inout) :: keys(1:n)
-    integer,intent(inout) :: elems(1:n),sides(1:n),flips(1:n),ranks(1:n)
-    ! Local
-    integer :: i,last
-
-    do i = n/2,1,-1
-      call HaloSiftDown(keys,elems,sides,flips,ranks,i,n)
-    enddo
-    do last = n,2,-1
-      call HaloSwap(keys,elems,sides,flips,ranks,1,last)
-      call HaloSiftDown(keys,elems,sides,flips,ranks,1,last-1)
-    enddo
-
-  endsubroutine HaloKeySort
-
-  subroutine HaloSiftDown(keys,elems,sides,flips,ranks,start,last)
-    implicit none
-    integer(int64),intent(inout) :: keys(:)
-    integer,intent(inout) :: elems(:),sides(:),flips(:),ranks(:)
-    integer,intent(in) :: start,last
-    ! Local
-    integer :: root,child
-
-    root = start
-    do while(2*root <= last)
-      child = 2*root
-      if(child < last) then
-        if(keys(child) < keys(child+1)) child = child+1
-      endif
-      if(keys(root) < keys(child)) then
-        call HaloSwap(keys,elems,sides,flips,ranks,root,child)
-        root = child
-      else
-        return
-      endif
-    enddo
-
-  endsubroutine HaloSiftDown
-
-  subroutine HaloSwap(keys,elems,sides,flips,ranks,i,j)
-    implicit none
-    integer(int64),intent(inout) :: keys(:)
-    integer,intent(inout) :: elems(:),sides(:),flips(:),ranks(:)
-    integer,intent(in) :: i,j
-    ! Local
-    integer(int64) :: k
-    integer :: t
-
-    k = keys(i); keys(i) = keys(j); keys(j) = k
-    t = elems(i); elems(i) = elems(j); elems(j) = t
-    t = sides(i); sides(i) = sides(j); sides(j) = t
-    t = flips(i); flips(i) = flips(j); flips(j) = t
-    t = ranks(i); ranks(i) = ranks(j); ranks(j) = t
-
-  endsubroutine HaloSwap
-
   subroutine MPIExchangeAsync_MappedScalar3D(this,mesh)
   !! Post the aggregated halo exchange: one MPI_Irecv/MPI_Isend pair per
   !! neighboring rank, carrying every (side,variable) boundary trace shared
   !! with that rank in a single packed device buffer. The pack kernel
   !! synchronizes the device before returning so the send buffer is complete
-  !! before MPI_Isend is posted.
+  !! before MPI_Isend is posted. Packed buffers are allocated on first use;
+  !! the shared side tables are built by SideExchange before this is called.
     implicit none
     class(MappedScalar3D),intent(inout) :: this
     type(Mesh3D),intent(inout) :: mesh
@@ -401,34 +214,43 @@ contains
     integer :: n,npts,cnt,disp
     integer :: iError
     integer :: msgCount
+    integer(c_size_t) :: worksize
     real(prec),pointer :: sendbuf(:)
     real(prec),pointer :: recvbuf(:)
 
-    call HaloPack_3D_gpu(this%boundary_gpu,this%halo_sendbuf_gpu, &
-                         this%halo_sides_gpu,this%interp%N,this%nvar, &
-                         this%nelem,this%halo_nsides)
-
     npts = (this%interp%N+1)*(this%interp%N+1)*this%nvar
-    call c_f_pointer(this%halo_sendbuf_gpu,sendbuf,[this%halo_nsides*npts])
-    call c_f_pointer(this%halo_recvbuf_gpu,recvbuf,[this%halo_nsides*npts])
+
+    if(.not. c_associated(this%halo_sendbuf_gpu)) then
+      worksize = int(mesh%decomp%halo_nsides,c_size_t)* &
+                 int(npts,c_size_t)*prec
+      call gpuCheck(hipMalloc(this%halo_sendbuf_gpu,worksize))
+      call gpuCheck(hipMalloc(this%halo_recvbuf_gpu,worksize))
+    endif
+
+    call HaloPack_3D_gpu(this%boundary_gpu,this%halo_sendbuf_gpu, &
+                         mesh%decomp%halo_sides_gpu,this%interp%N,this%nvar, &
+                         this%nelem,mesh%decomp%halo_nsides)
+
+    call c_f_pointer(this%halo_sendbuf_gpu,sendbuf,[mesh%decomp%halo_nsides*npts])
+    call c_f_pointer(this%halo_recvbuf_gpu,recvbuf,[mesh%decomp%halo_nsides*npts])
 
     msgCount = 0
-    do n = 1,this%halo_nnbr
+    do n = 1,mesh%decomp%halo_nnbr
 
-      cnt = (this%halo_offset(n+1)-this%halo_offset(n))*npts
-      disp = this%halo_offset(n)*npts
+      cnt = (mesh%decomp%halo_offset(n+1)-mesh%decomp%halo_offset(n))*npts
+      disp = mesh%decomp%halo_offset(n)*npts
 
       msgCount = msgCount+1
       call MPI_IRECV(recvbuf(disp+1),cnt, &
                      mesh%decomp%mpiPrec, &
-                     this%halo_rank(n),0, &
+                     mesh%decomp%halo_rank(n),0, &
                      mesh%decomp%mpiComm, &
                      mesh%decomp%requests(msgCount),iError)
 
       msgCount = msgCount+1
       call MPI_ISEND(sendbuf(disp+1),cnt, &
                      mesh%decomp%mpiPrec, &
-                     this%halo_rank(n),0, &
+                     mesh%decomp%halo_rank(n),0, &
                      mesh%decomp%mpiComm, &
                      mesh%decomp%requests(msgCount),iError)
 
@@ -448,10 +270,10 @@ contains
     offset = mesh%decomp%offsetElem(mesh%decomp%rankId+1)
 
     if(mesh%decomp%mpiEnabled) then
-      if(.not. this%halo_built) then
-        call this%SetupHaloExchange(mesh)
+      if(.not. mesh%decomp%halo_built) then
+        call mesh%decomp%BuildHaloExchange(mesh%sideInfo,mesh%nElem,6)
       endif
-      if(this%halo_nsides > 0) then
+      if(mesh%decomp%halo_nsides > 0) then
         call this%MPIExchangeAsync(mesh)
       endif
     endif
@@ -463,12 +285,12 @@ contains
                              mesh%decomp%rankid,offset,this%interp%N,this%nvar,this%nelem)
 
     if(mesh%decomp%mpiEnabled) then
-      if(this%halo_nsides > 0) then
+      if(mesh%decomp%halo_nsides > 0) then
         call mesh%decomp%FinalizeMPIExchangeAsync()
         ! Unpack the received traces into extBoundary, applying side flips
         call HaloUnpack_3D_gpu(this%halo_recvbuf_gpu,this%extboundary_gpu, &
-                               this%halo_sides_gpu,this%interp%N,this%nvar, &
-                               this%nelem,this%halo_nsides)
+                               mesh%decomp%halo_sides_gpu,this%interp%N,this%nvar, &
+                               this%nelem,mesh%decomp%halo_nsides)
       endif
     endif
 

--- a/src/gpu/SELF_MappedScalar_3D.f90
+++ b/src/gpu/SELF_MappedScalar_3D.f90
@@ -30,12 +30,26 @@ module SELF_MappedScalar_3D
   use SELF_GPU
   use SELF_GPUInterfaces
   use iso_c_binding
+  use iso_fortran_env,only:int64
 
   implicit none
 
   type,extends(MappedScalar3D_t),public :: MappedScalar3D
 
     type(c_ptr) :: jas_gpu ! jacobian weighted scalar for gradient calculation
+
+    ! Aggregated MPI halo exchange tables. All locally-owned sides with a
+    ! neighbor element on another rank are enumerated once, grouped by
+    ! neighbor rank and sorted by global side id within each group, so that
+    ! a single message per neighbor rank carries every (side,variable) trace.
+    logical :: halo_built = .false.
+    integer :: halo_nnbr = 0 ! Number of neighboring ranks
+    integer :: halo_nsides = 0 ! Total number of sides exchanged with other ranks
+    integer,allocatable :: halo_rank(:) ! (1:halo_nnbr) neighbor rank ids
+    integer,allocatable :: halo_offset(:) ! (1:halo_nnbr+1) side-list offsets per neighbor
+    type(c_ptr) :: halo_sides_gpu = c_null_ptr ! (element,side,flip) triplets, device copy
+    type(c_ptr) :: halo_sendbuf_gpu = c_null_ptr ! packed device send buffer
+    type(c_ptr) :: halo_recvbuf_gpu = c_null_ptr ! packed device receive buffer
 
   contains
     procedure,public :: Init => Init_MappedScalar3D
@@ -45,6 +59,7 @@ module SELF_MappedScalar_3D
 
     procedure,public :: SideExchange => SideExchange_MappedScalar3D
     procedure,private :: MPIExchangeAsync => MPIExchangeAsync_MappedScalar3D
+    procedure,private :: SetupHaloExchange => SetupHaloExchange_MappedScalar3D
 
     generic,public :: MappedGradient => MappedGradient_MappedScalar3D
     procedure,private :: MappedGradient_MappedScalar3D
@@ -149,6 +164,16 @@ contains
     call gpuCheck(hipFree(this%jas_gpu))
     call hipblasCheck(hipblasDestroy(this%blas_handle))
 
+    if(allocated(this%halo_rank)) deallocate(this%halo_rank)
+    if(allocated(this%halo_offset)) deallocate(this%halo_offset)
+    if(c_associated(this%halo_sides_gpu)) call gpuCheck(hipFree(this%halo_sides_gpu))
+    if(c_associated(this%halo_sendbuf_gpu)) call gpuCheck(hipFree(this%halo_sendbuf_gpu))
+    if(c_associated(this%halo_recvbuf_gpu)) call gpuCheck(hipFree(this%halo_recvbuf_gpu))
+    this%halo_sides_gpu = c_null_ptr
+    this%halo_sendbuf_gpu = c_null_ptr
+    this%halo_recvbuf_gpu = c_null_ptr
+    this%halo_built = .false.
+
   endsubroutine Free_MappedScalar3D
 
   subroutine SetInteriorFromEquation_MappedScalar3D(this,geometry,time)
@@ -188,57 +213,225 @@ contains
 
   endsubroutine SetInteriorFromEquation_MappedScalar3D
 
-  subroutine MPIExchangeAsync_MappedScalar3D(this,mesh)
+  subroutine SetupHaloExchange_MappedScalar3D(this,mesh)
+  !! Build the aggregated halo exchange tables for this field.
+  !!
+  !! Enumerates every locally-owned side whose neighbor element resides on
+  !! another rank, groups the sides by neighbor rank, and sorts each group by
+  !! global side id. Both ranks sharing an interface enumerate the interface
+  !! sides in the same order (the global side id is shared), so the packed
+  !! send buffer on one rank and the packed receive buffer on the other line
+  !! up without any per-message metadata. The (element,side,flip) triplets
+  !! are copied to the device for the pack/unpack kernels, and the packed
+  !! send/receive device buffers are allocated here.
     implicit none
     class(MappedScalar3D),intent(inout) :: this
     type(Mesh3D),intent(inout) :: mesh
     ! Local
-    integer :: e1,s1,e2,s2,ivar
-    integer :: globalSideId,r2,tag
+    integer :: e1,s1,e2,r2,n,nhalo
+    integer :: rankId
+    integer,allocatable :: elems(:),sides(:),flips(:),ranks(:)
+    integer,allocatable,target :: halosides(:)
+    integer(int64),allocatable :: keys(:)
+    integer(c_size_t) :: worksize
+
+    rankId = mesh%decomp%rankId
+
+    nhalo = 0
+    do e1 = 1,this%nElem
+      do s1 = 1,6
+        e2 = mesh%sideInfo(3,s1,e1)
+        if(e2 > 0) then
+          if(mesh%decomp%elemToRank(e2) /= rankId) then
+            nhalo = nhalo+1
+          endif
+        endif
+      enddo
+    enddo
+
+    this%halo_nsides = nhalo
+    this%halo_nnbr = 0
+    if(nhalo == 0) then
+      this%halo_built = .true.
+      return
+    endif
+
+    allocate(elems(1:nhalo),sides(1:nhalo),flips(1:nhalo), &
+             ranks(1:nhalo),keys(1:nhalo))
+
+    n = 0
+    do e1 = 1,this%nElem
+      do s1 = 1,6
+        e2 = mesh%sideInfo(3,s1,e1)
+        if(e2 > 0) then
+          r2 = mesh%decomp%elemToRank(e2)
+          if(r2 /= rankId) then
+            n = n+1
+            elems(n) = e1
+            sides(n) = s1
+            flips(n) = mesh%sideInfo(4,s1,e1)-10*(mesh%sideInfo(4,s1,e1)/10)
+            ranks(n) = r2
+            ! Composite sort key: neighbor rank (major), global side id (minor).
+            keys(n) = int(r2,int64)*2147483648_int64+ &
+                      int(abs(mesh%sideInfo(2,s1,e1)),int64)
+          endif
+        endif
+      enddo
+    enddo
+
+    call HaloKeySort(keys,elems,sides,flips,ranks,nhalo)
+
+    ! Count the neighboring ranks and record the segment offsets
+    this%halo_nnbr = 1
+    do n = 2,nhalo
+      if(ranks(n) /= ranks(n-1)) this%halo_nnbr = this%halo_nnbr+1
+    enddo
+
+    allocate(this%halo_rank(1:this%halo_nnbr))
+    allocate(this%halo_offset(1:this%halo_nnbr+1))
+
+    this%halo_nnbr = 1
+    this%halo_rank(1) = ranks(1)
+    this%halo_offset(1) = 0
+    do n = 2,nhalo
+      if(ranks(n) /= ranks(n-1)) then
+        this%halo_nnbr = this%halo_nnbr+1
+        this%halo_rank(this%halo_nnbr) = ranks(n)
+        this%halo_offset(this%halo_nnbr) = n-1
+      endif
+    enddo
+    this%halo_offset(this%halo_nnbr+1) = nhalo
+
+    ! Flatten the (element,side,flip) triplets with 0-based element and side
+    ! indices for the device pack/unpack kernels
+    allocate(halosides(1:3*nhalo))
+    do n = 1,nhalo
+      halosides(3*n-2) = elems(n)-1
+      halosides(3*n-1) = sides(n)-1
+      halosides(3*n) = flips(n)
+    enddo
+
+    call gpuCheck(hipMalloc(this%halo_sides_gpu,sizeof(halosides)))
+    call gpuCheck(hipMemcpy(this%halo_sides_gpu,c_loc(halosides), &
+                            sizeof(halosides),hipMemcpyHostToDevice))
+
+    worksize = int(this%interp%N+1,c_size_t)*(this%interp%N+1)* &
+               int(nhalo,c_size_t)*int(this%nvar,c_size_t)*prec
+    call gpuCheck(hipMalloc(this%halo_sendbuf_gpu,worksize))
+    call gpuCheck(hipMalloc(this%halo_recvbuf_gpu,worksize))
+
+    deallocate(elems,sides,flips,ranks,keys,halosides)
+
+    this%halo_built = .true.
+
+  endsubroutine SetupHaloExchange_MappedScalar3D
+
+  subroutine HaloKeySort(keys,elems,sides,flips,ranks,n)
+  !! Heap sort of the halo side list by ascending 64-bit key, permuting the
+  !! companion arrays alongside the keys. O(n log n), in place; the relative
+  !! order of equal keys is irrelevant because global side ids are unique.
+    implicit none
+    integer,intent(in) :: n
+    integer(int64),intent(inout) :: keys(1:n)
+    integer,intent(inout) :: elems(1:n),sides(1:n),flips(1:n),ranks(1:n)
+    ! Local
+    integer :: i,last
+
+    do i = n/2,1,-1
+      call HaloSiftDown(keys,elems,sides,flips,ranks,i,n)
+    enddo
+    do last = n,2,-1
+      call HaloSwap(keys,elems,sides,flips,ranks,1,last)
+      call HaloSiftDown(keys,elems,sides,flips,ranks,1,last-1)
+    enddo
+
+  endsubroutine HaloKeySort
+
+  subroutine HaloSiftDown(keys,elems,sides,flips,ranks,start,last)
+    implicit none
+    integer(int64),intent(inout) :: keys(:)
+    integer,intent(inout) :: elems(:),sides(:),flips(:),ranks(:)
+    integer,intent(in) :: start,last
+    ! Local
+    integer :: root,child
+
+    root = start
+    do while(2*root <= last)
+      child = 2*root
+      if(child < last) then
+        if(keys(child) < keys(child+1)) child = child+1
+      endif
+      if(keys(root) < keys(child)) then
+        call HaloSwap(keys,elems,sides,flips,ranks,root,child)
+        root = child
+      else
+        return
+      endif
+    enddo
+
+  endsubroutine HaloSiftDown
+
+  subroutine HaloSwap(keys,elems,sides,flips,ranks,i,j)
+    implicit none
+    integer(int64),intent(inout) :: keys(:)
+    integer,intent(inout) :: elems(:),sides(:),flips(:),ranks(:)
+    integer,intent(in) :: i,j
+    ! Local
+    integer(int64) :: k
+    integer :: t
+
+    k = keys(i); keys(i) = keys(j); keys(j) = k
+    t = elems(i); elems(i) = elems(j); elems(j) = t
+    t = sides(i); sides(i) = sides(j); sides(j) = t
+    t = flips(i); flips(i) = flips(j); flips(j) = t
+    t = ranks(i); ranks(i) = ranks(j); ranks(j) = t
+
+  endsubroutine HaloSwap
+
+  subroutine MPIExchangeAsync_MappedScalar3D(this,mesh)
+  !! Post the aggregated halo exchange: one MPI_Irecv/MPI_Isend pair per
+  !! neighboring rank, carrying every (side,variable) boundary trace shared
+  !! with that rank in a single packed device buffer. The pack kernel
+  !! synchronizes the device before returning so the send buffer is complete
+  !! before MPI_Isend is posted.
+    implicit none
+    class(MappedScalar3D),intent(inout) :: this
+    type(Mesh3D),intent(inout) :: mesh
+    ! Local
+    integer :: n,npts,cnt,disp
     integer :: iError
     integer :: msgCount
-    real(prec),pointer :: boundary(:,:,:,:,:)
-    real(prec),pointer :: extboundary(:,:,:,:,:)
+    real(prec),pointer :: sendbuf(:)
+    real(prec),pointer :: recvbuf(:)
+
+    call HaloPack_3D_gpu(this%boundary_gpu,this%halo_sendbuf_gpu, &
+                         this%halo_sides_gpu,this%interp%N,this%nvar, &
+                         this%nelem,this%halo_nsides)
+
+    npts = (this%interp%N+1)*(this%interp%N+1)*this%nvar
+    call c_f_pointer(this%halo_sendbuf_gpu,sendbuf,[this%halo_nsides*npts])
+    call c_f_pointer(this%halo_recvbuf_gpu,recvbuf,[this%halo_nsides*npts])
 
     msgCount = 0
-    call c_f_pointer(this%boundary_gpu,boundary,[this%interp%N+1,this%interp%N+1,6,this%nelem,this%nvar])
-    call c_f_pointer(this%extboundary_gpu,extboundary,[this%interp%N+1,this%interp%N+1,6,this%nelem,this%nvar])
+    do n = 1,this%halo_nnbr
 
-    do ivar = 1,this%nvar
-      do e1 = 1,this%nElem
-        do s1 = 1,6
+      cnt = (this%halo_offset(n+1)-this%halo_offset(n))*npts
+      disp = this%halo_offset(n)*npts
 
-          e2 = mesh%sideInfo(3,s1,e1) ! Neighbor Element
-          if(e2 > 0) then
-            r2 = mesh%decomp%elemToRank(e2) ! Neighbor Rank
+      msgCount = msgCount+1
+      call MPI_IRECV(recvbuf(disp+1),cnt, &
+                     mesh%decomp%mpiPrec, &
+                     this%halo_rank(n),0, &
+                     mesh%decomp%mpiComm, &
+                     mesh%decomp%requests(msgCount),iError)
 
-            if(r2 /= mesh%decomp%rankId) then
+      msgCount = msgCount+1
+      call MPI_ISEND(sendbuf(disp+1),cnt, &
+                     mesh%decomp%mpiPrec, &
+                     this%halo_rank(n),0, &
+                     mesh%decomp%mpiComm, &
+                     mesh%decomp%requests(msgCount),iError)
 
-              s2 = mesh%sideInfo(4,s1,e1)/10
-              globalSideId = abs(mesh%sideInfo(2,s1,e1))
-              ! create unique tag for each side and each variable
-              tag = globalsideid+mesh%nUniqueSides*(ivar-1)
-
-              msgCount = msgCount+1
-              call MPI_IRECV(extBoundary(:,:,s1,e1,ivar), &
-                             (this%interp%N+1)*(this%interp%N+1), &
-                             mesh%decomp%mpiPrec, &
-                             r2,tag, &
-                             mesh%decomp%mpiComm, &
-                             mesh%decomp%requests(msgCount),iError)
-
-              msgCount = msgCount+1
-              call MPI_ISEND(boundary(:,:,s1,e1,ivar), &
-                             (this%interp%N+1)*(this%interp%N+1), &
-                             mesh%decomp%mpiPrec, &
-                             r2,tag, &
-                             mesh%decomp%mpiComm, &
-                             mesh%decomp%requests(msgCount),iError)
-            endif
-          endif
-
-        enddo
-      enddo
     enddo
 
     mesh%decomp%msgCount = msgCount
@@ -255,19 +448,28 @@ contains
     offset = mesh%decomp%offsetElem(mesh%decomp%rankId+1)
 
     if(mesh%decomp%mpiEnabled) then
-      call this%MPIExchangeAsync(mesh)
+      if(.not. this%halo_built) then
+        call this%SetupHaloExchange(mesh)
+      endif
+      if(this%halo_nsides > 0) then
+        call this%MPIExchangeAsync(mesh)
+      endif
     endif
 
+    ! The local (same-rank) side exchange runs on the device while the
+    ! aggregated MPI messages are in flight.
     call SideExchange_3D_gpu(this%extboundary_gpu, &
                              this%boundary_gpu,mesh%sideinfo_gpu,mesh%decomp%elemToRank_gpu, &
                              mesh%decomp%rankid,offset,this%interp%N,this%nvar,this%nelem)
 
     if(mesh%decomp%mpiEnabled) then
-      call mesh%decomp%FinalizeMPIExchangeAsync()
-      ! Apply side flips for data exchanged with MPI
-      call ApplyFlip_3D_gpu(this%extboundary_gpu,mesh%sideInfo_gpu, &
-                            mesh%decomp%elemToRank_gpu,mesh%decomp%rankId, &
-                            offset,this%interp%N,this%nVar,this%nElem)
+      if(this%halo_nsides > 0) then
+        call mesh%decomp%FinalizeMPIExchangeAsync()
+        ! Unpack the received traces into extBoundary, applying side flips
+        call HaloUnpack_3D_gpu(this%halo_recvbuf_gpu,this%extboundary_gpu, &
+                               this%halo_sides_gpu,this%interp%N,this%nvar, &
+                               this%nelem,this%halo_nsides)
+      endif
     endif
 
   endsubroutine SideExchange_MappedScalar3D

--- a/src/gpu/SELF_MappedVector_2D.f90
+++ b/src/gpu/SELF_MappedVector_2D.f90
@@ -36,7 +36,15 @@ module SELF_MappedVector_2D
 
   type,extends(MappedVector2D_t),public :: MappedVector2D
 
+    ! Packed device buffers for the aggregated MPI halo exchange. The side
+    ! tables are shared across fields and live on mesh%decomp; the buffers
+    ! are per-field (sized for 2*nvar variables, since both vector components
+    ! are exchanged) and allocated lazily on the first exchange.
+    type(c_ptr) :: halo_sendbuf_gpu = c_null_ptr ! packed device send buffer
+    type(c_ptr) :: halo_recvbuf_gpu = c_null_ptr ! packed device receive buffer
+
   contains
+    procedure,public :: Free => Free_MappedVector2D
     procedure,public :: SetInteriorFromEquation => SetInteriorFromEquation_MappedVector2D
 
     procedure,public :: SideExchange => SideExchange_MappedVector2D
@@ -61,6 +69,19 @@ module SELF_MappedVector_2D
   endinterface
 
 contains
+
+  subroutine Free_MappedVector2D(this)
+    implicit none
+    class(MappedVector2D),intent(inout) :: this
+
+    call Free_Vector2D(this)
+
+    if(c_associated(this%halo_sendbuf_gpu)) call gpuCheck(hipFree(this%halo_sendbuf_gpu))
+    if(c_associated(this%halo_recvbuf_gpu)) call gpuCheck(hipFree(this%halo_recvbuf_gpu))
+    this%halo_sendbuf_gpu = c_null_ptr
+    this%halo_recvbuf_gpu = c_null_ptr
+
+  endsubroutine Free_MappedVector2D
 
   subroutine SetInteriorFromEquation_MappedVector2D(this,geometry,time)
   !!  Sets the this % interior attribute using the eqn attribute,
@@ -99,58 +120,60 @@ contains
   endsubroutine SetInteriorFromEquation_MappedVector2D
 
   subroutine MPIExchangeAsync_MappedVector2D(this,mesh)
+  !! Post the aggregated halo exchange: one MPI_Irecv/MPI_Isend pair per
+  !! neighboring rank, carrying every (side,variable,component) boundary
+  !! trace shared with that rank in a single packed device buffer. The
+  !! boundary array is laid out with the component index outermost, so the
+  !! pack/unpack kernels treat the vector as 2*nvar scalar variables. Packed
+  !! buffers are allocated on first use; the shared side tables are built by
+  !! SideExchange before this is called.
     implicit none
     class(MappedVector2D),intent(inout) :: this
     type(Mesh2D),intent(inout) :: mesh
     ! Local
-    integer :: e1,s1,e2,s2,ivar,idir
-    integer :: globalSideId,r2,tag
+    integer :: n,npts,cnt,disp
     integer :: iError
     integer :: msgCount
-    real(prec),pointer :: boundary(:,:,:,:,:)
-    real(prec),pointer :: extboundary(:,:,:,:,:)
+    integer(c_size_t) :: worksize
+    real(prec),pointer :: sendbuf(:)
+    real(prec),pointer :: recvbuf(:)
+
+    npts = (this%interp%N+1)*2*this%nvar
+
+    if(.not. c_associated(this%halo_sendbuf_gpu)) then
+      worksize = int(mesh%decomp%halo_nsides,c_size_t)* &
+                 int(npts,c_size_t)*prec
+      call gpuCheck(hipMalloc(this%halo_sendbuf_gpu,worksize))
+      call gpuCheck(hipMalloc(this%halo_recvbuf_gpu,worksize))
+    endif
+
+    call HaloPack_2D_gpu(this%boundary_gpu,this%halo_sendbuf_gpu, &
+                         mesh%decomp%halo_sides_gpu,this%interp%N,2*this%nvar, &
+                         this%nelem,mesh%decomp%halo_nsides)
+
+    call c_f_pointer(this%halo_sendbuf_gpu,sendbuf,[mesh%decomp%halo_nsides*npts])
+    call c_f_pointer(this%halo_recvbuf_gpu,recvbuf,[mesh%decomp%halo_nsides*npts])
 
     msgCount = 0
-    call c_f_pointer(this%boundary_gpu,boundary,[this%interp%N+1,4,this%nelem,this%nvar,2])
-    call c_f_pointer(this%extboundary_gpu,extboundary,[this%interp%N+1,4,this%nelem,this%nvar,2])
+    do n = 1,mesh%decomp%halo_nnbr
 
-    do idir = 1,2
-      do ivar = 1,this%nvar
-        do e1 = 1,this%nElem
-          do s1 = 1,4
+      cnt = (mesh%decomp%halo_offset(n+1)-mesh%decomp%halo_offset(n))*npts
+      disp = mesh%decomp%halo_offset(n)*npts
 
-            e2 = mesh%sideInfo(3,s1,e1) ! Neighbor Element
-            if(e2 > 0) then
-              r2 = mesh%decomp%elemToRank(e2) ! Neighbor Rank
+      msgCount = msgCount+1
+      call MPI_IRECV(recvbuf(disp+1),cnt, &
+                     mesh%decomp%mpiPrec, &
+                     mesh%decomp%halo_rank(n),0, &
+                     mesh%decomp%mpiComm, &
+                     mesh%decomp%requests(msgCount),iError)
 
-              if(r2 /= mesh%decomp%rankId) then
+      msgCount = msgCount+1
+      call MPI_ISEND(sendbuf(disp+1),cnt, &
+                     mesh%decomp%mpiPrec, &
+                     mesh%decomp%halo_rank(n),0, &
+                     mesh%decomp%mpiComm, &
+                     mesh%decomp%requests(msgCount),iError)
 
-                s2 = mesh%sideInfo(4,s1,e1)/10
-                globalSideId = abs(mesh%sideInfo(2,s1,e1))
-                ! create unique tag for each side and each variable
-                tag = globalsideid+mesh%nUniqueSides*(ivar-1+this%nvar*(idir-1))
-
-                msgCount = msgCount+1
-                call MPI_IRECV(extBoundary(:,s1,e1,ivar,idir), &
-                               (this%interp%N+1), &
-                               mesh%decomp%mpiPrec, &
-                               r2,tag, &
-                               mesh%decomp%mpiComm, &
-                               mesh%decomp%requests(msgCount),iError)
-
-                msgCount = msgCount+1
-                call MPI_ISEND(boundary(:,s1,e1,ivar,idir), &
-                               (this%interp%N+1), &
-                               mesh%decomp%mpiPrec, &
-                               r2,tag, &
-                               mesh%decomp%mpiComm, &
-                               mesh%decomp%requests(msgCount),iError)
-              endif
-            endif
-
-          enddo
-        enddo
-      enddo
     enddo
 
     mesh%decomp%msgCount = msgCount
@@ -167,20 +190,28 @@ contains
     offset = mesh%decomp%offsetElem(mesh%decomp%rankid+1)
 
     if(mesh%decomp%mpiEnabled) then
-      call this%MPIExchangeAsync(mesh)
+      if(.not. mesh%decomp%halo_built) then
+        call mesh%decomp%BuildHaloExchange(mesh%sideInfo,mesh%nElem,4)
+      endif
+      if(mesh%decomp%halo_nsides > 0) then
+        call this%MPIExchangeAsync(mesh)
+      endif
     endif
 
-    ! Do the side exchange internal to this mpi process
+    ! The local (same-rank) side exchange runs on the device while the
+    ! aggregated MPI messages are in flight.
     call SideExchange_2D_gpu(this%extboundary_gpu, &
                              this%boundary_gpu,mesh%sideinfo_gpu,mesh%decomp%elemToRank_gpu, &
                              mesh%decomp%rankid,offset,this%interp%N,2*this%nvar,this%nelem)
 
     if(mesh%decomp%mpiEnabled) then
-      call mesh%decomp%FinalizeMPIExchangeAsync()
-      ! Apply side flips for data exchanged with MPI
-      call ApplyFlip_2D_gpu(this%extboundary_gpu,mesh%sideInfo_gpu, &
-                            mesh%decomp%elemToRank_gpu,mesh%decomp%rankId, &
-                            offset,this%interp%N,2*this%nVar,this%nElem)
+      if(mesh%decomp%halo_nsides > 0) then
+        call mesh%decomp%FinalizeMPIExchangeAsync()
+        ! Unpack the received traces into extBoundary, applying side flips
+        call HaloUnpack_2D_gpu(this%halo_recvbuf_gpu,this%extboundary_gpu, &
+                               mesh%decomp%halo_sides_gpu,this%interp%N,2*this%nvar, &
+                               this%nelem,mesh%decomp%halo_nsides)
+      endif
     endif
 
   endsubroutine SideExchange_MappedVector2D

--- a/src/gpu/SELF_MappedVector_3D.f90
+++ b/src/gpu/SELF_MappedVector_3D.f90
@@ -36,8 +36,16 @@ module SELF_MappedVector_3D
 
   type,extends(MappedVector3D_t),public :: MappedVector3D
 
+    ! Packed device buffers for the aggregated MPI halo exchange. The side
+    ! tables are shared across fields and live on mesh%decomp; the buffers
+    ! are per-field (sized for 3*nvar variables, since all three vector
+    ! components are exchanged) and allocated lazily on the first exchange.
+    type(c_ptr) :: halo_sendbuf_gpu = c_null_ptr ! packed device send buffer
+    type(c_ptr) :: halo_recvbuf_gpu = c_null_ptr ! packed device receive buffer
+
   contains
 
+    procedure,public :: Free => Free_MappedVector3D
     procedure,public :: SideExchange => SideExchange_MappedVector3D
     procedure,public :: MPIExchangeAsync => MPIExchangeAsync_MappedVector3D
 
@@ -62,6 +70,20 @@ module SELF_MappedVector_3D
   endinterface
 
 contains
+
+  subroutine Free_MappedVector3D(this)
+    implicit none
+    class(MappedVector3D),intent(inout) :: this
+
+    call Free_Vector3D(this)
+
+    if(c_associated(this%halo_sendbuf_gpu)) call gpuCheck(hipFree(this%halo_sendbuf_gpu))
+    if(c_associated(this%halo_recvbuf_gpu)) call gpuCheck(hipFree(this%halo_recvbuf_gpu))
+    this%halo_sendbuf_gpu = c_null_ptr
+    this%halo_recvbuf_gpu = c_null_ptr
+
+  endsubroutine Free_MappedVector3D
+
   subroutine SetInteriorFromEquation_MappedVector3D(this,geometry,time)
     !!  Sets the this % interior attribute using the eqn attribute,
     !!  geometry (for physical positions), and provided simulation time.
@@ -106,58 +128,60 @@ contains
   endsubroutine SetInteriorFromEquation_MappedVector3D
 
   subroutine MPIExchangeAsync_MappedVector3D(this,mesh)
+  !! Post the aggregated halo exchange: one MPI_Irecv/MPI_Isend pair per
+  !! neighboring rank, carrying every (side,variable,component) boundary
+  !! trace shared with that rank in a single packed device buffer. The
+  !! boundary array is laid out with the component index outermost, so the
+  !! pack/unpack kernels treat the vector as 3*nvar scalar variables. Packed
+  !! buffers are allocated on first use; the shared side tables are built by
+  !! SideExchange before this is called.
     implicit none
     class(MappedVector3D),intent(inout) :: this
     type(Mesh3D),intent(inout) :: mesh
     ! Local
-    integer :: e1,s1,e2,s2,ivar,idir
-    integer :: globalSideId,r2,tag
+    integer :: n,npts,cnt,disp
     integer :: iError
     integer :: msgCount
-    real(prec),pointer :: boundary(:,:,:,:,:,:)
-    real(prec),pointer :: extboundary(:,:,:,:,:,:)
+    integer(c_size_t) :: worksize
+    real(prec),pointer :: sendbuf(:)
+    real(prec),pointer :: recvbuf(:)
+
+    npts = (this%interp%N+1)*(this%interp%N+1)*3*this%nvar
+
+    if(.not. c_associated(this%halo_sendbuf_gpu)) then
+      worksize = int(mesh%decomp%halo_nsides,c_size_t)* &
+                 int(npts,c_size_t)*prec
+      call gpuCheck(hipMalloc(this%halo_sendbuf_gpu,worksize))
+      call gpuCheck(hipMalloc(this%halo_recvbuf_gpu,worksize))
+    endif
+
+    call HaloPack_3D_gpu(this%boundary_gpu,this%halo_sendbuf_gpu, &
+                         mesh%decomp%halo_sides_gpu,this%interp%N,3*this%nvar, &
+                         this%nelem,mesh%decomp%halo_nsides)
+
+    call c_f_pointer(this%halo_sendbuf_gpu,sendbuf,[mesh%decomp%halo_nsides*npts])
+    call c_f_pointer(this%halo_recvbuf_gpu,recvbuf,[mesh%decomp%halo_nsides*npts])
 
     msgCount = 0
-    call c_f_pointer(this%boundary_gpu,boundary,[this%interp%N+1,this%interp%N+1,6,this%nelem,this%nvar,3])
-    call c_f_pointer(this%extboundary_gpu,extboundary,[this%interp%N+1,this%interp%N+1,6,this%nelem,this%nvar,3])
+    do n = 1,mesh%decomp%halo_nnbr
 
-    do idir = 1,3
-      do ivar = 1,this%nvar
-        do e1 = 1,this%nElem
-          do s1 = 1,6
+      cnt = (mesh%decomp%halo_offset(n+1)-mesh%decomp%halo_offset(n))*npts
+      disp = mesh%decomp%halo_offset(n)*npts
 
-            e2 = mesh%sideInfo(3,s1,e1) ! Neighbor Element
-            if(e2 > 0) then
-              r2 = mesh%decomp%elemToRank(e2) ! Neighbor Rank
+      msgCount = msgCount+1
+      call MPI_IRECV(recvbuf(disp+1),cnt, &
+                     mesh%decomp%mpiPrec, &
+                     mesh%decomp%halo_rank(n),0, &
+                     mesh%decomp%mpiComm, &
+                     mesh%decomp%requests(msgCount),iError)
 
-              if(r2 /= mesh%decomp%rankId) then
+      msgCount = msgCount+1
+      call MPI_ISEND(sendbuf(disp+1),cnt, &
+                     mesh%decomp%mpiPrec, &
+                     mesh%decomp%halo_rank(n),0, &
+                     mesh%decomp%mpiComm, &
+                     mesh%decomp%requests(msgCount),iError)
 
-                s2 = mesh%sideInfo(4,s1,e1)/10
-                globalSideId = abs(mesh%sideInfo(2,s1,e1))
-                ! create unique tag for each side and each variable
-                tag = globalsideid+mesh%nUniqueSides*(ivar-1+this%nvar*(idir-1))
-
-                msgCount = msgCount+1
-                call MPI_IRECV(extBoundary(:,:,s1,e1,ivar,idir), &
-                               (this%interp%N+1)*(this%interp%N+1), &
-                               mesh%decomp%mpiPrec, &
-                               r2,tag, &
-                               mesh%decomp%mpiComm, &
-                               mesh%decomp%requests(msgCount),iError)
-
-                msgCount = msgCount+1
-                call MPI_ISEND(boundary(:,:,s1,e1,ivar,idir), &
-                               (this%interp%N+1)*(this%interp%N+1), &
-                               mesh%decomp%mpiPrec, &
-                               r2,tag, &
-                               mesh%decomp%mpiComm, &
-                               mesh%decomp%requests(msgCount),iError)
-              endif
-            endif
-
-          enddo
-        enddo
-      enddo
     enddo
 
     mesh%decomp%msgCount = msgCount
@@ -174,18 +198,28 @@ contains
     offset = mesh%decomp%offsetElem(mesh%decomp%rankId+1)
 
     if(mesh%decomp%mpiEnabled) then
-      call this%MPIExchangeAsync(mesh)
+      if(.not. mesh%decomp%halo_built) then
+        call mesh%decomp%BuildHaloExchange(mesh%sideInfo,mesh%nElem,6)
+      endif
+      if(mesh%decomp%halo_nsides > 0) then
+        call this%MPIExchangeAsync(mesh)
+      endif
     endif
+
+    ! The local (same-rank) side exchange runs on the device while the
+    ! aggregated MPI messages are in flight.
     call SideExchange_3D_gpu(this%extboundary_gpu, &
                              this%boundary_gpu,mesh%sideinfo_gpu,mesh%decomp%elemToRank_gpu, &
                              mesh%decomp%rankid,offset,this%interp%N,3*this%nvar,this%nelem)
 
     if(mesh%decomp%mpiEnabled) then
-      call mesh%decomp%FinalizeMPIExchangeAsync()
-      ! Apply side flips for data exchanged with MPI
-      call ApplyFlip_3D_gpu(this%extboundary_gpu,mesh%sideInfo_gpu, &
-                            mesh%decomp%elemToRank_gpu,mesh%decomp%rankId, &
-                            offset,this%interp%N,3*this%nVar,this%nElem)
+      if(mesh%decomp%halo_nsides > 0) then
+        call mesh%decomp%FinalizeMPIExchangeAsync()
+        ! Unpack the received traces into extBoundary, applying side flips
+        call HaloUnpack_3D_gpu(this%halo_recvbuf_gpu,this%extboundary_gpu, &
+                               mesh%decomp%halo_sides_gpu,this%interp%N,3*this%nvar, &
+                               this%nelem,mesh%decomp%halo_nsides)
+      endif
     endif
 
   endsubroutine SideExchange_MappedVector3D


### PR DESCRIPTION
## Summary

MPI optimizations from #84, targeting the dominant multi-GPU scaling bottleneck: the GPU exchange classes posted one `MPI_Irecv`/`MPI_Isend` pair **per side per variable (per component)** — 512-byte GPU-direct messages at degree 7 fp64. A 48³-element mesh on 2 ranks posts ~28k requests per exchange, three exchanges per RK3 step; the exchange consumed ~97% of step time, and the tiny-message flood also inflated UCX/ROCm device memory by 30–50 GB/rank.

This PR aggregates the halo exchange into **one message per neighbor rank**, for **every GPU class that performs side exchanges**: `MappedScalar2D`, `MappedScalar3D`, `MappedVector2D`, `MappedVector3D`. (Two-point vector classes perform no side exchange; CPU `_t` paths are unchanged.)

**Design**

- Halo side tables are shared per mesh: `DomainDecomposition%BuildHaloExchange` enumerates locally-owned sides with remote neighbors once, groups them by neighbor rank and sorts by global side id — both ranks of an interface enumerate its sides identically, so packed buffers line up with no metadata exchange. Built lazily on the first `SideExchange` of any field.
- `HaloPack_2D/3D` gather all (side,variable) traces into a contiguous device buffer (device sync before `MPI_Isend`); one Irecv/Isend pair per neighbor moves packed device buffers (GPU-aware MPI, as before); the local same-rank exchange kernel overlaps with message flight; `HaloUnpack_2D/3D` scatter received traces into `extBoundary`, applying the receiver-side flip.
- Vector classes reuse the scalar kernels with `2*nvar`/`3*nvar` variables (component index is outermost in the boundary arrays — the same equivalence `SideExchange_*_gpu` already exploits). Per-field packed buffers are allocated on first use.
- The now-unreachable `ApplyFlip_2D/3D` GPU kernels are **removed** — flips happen in the unpack. `ApplyFlip_3D` also carried the out-of-bounds `sideInfo` stride bug (#144), which is thereby eliminated from the GPU backend. The CPU `ApplyFlip` methods remain in use by the CPU backend and are untouched.

This subsumes the `MPI_Type_create_indexed` idea from #84 — explicit pack/unpack kernels are strictly better for device-resident buffers.

## Benchmark: LinearEuler3D, degree 7, fp64, RK3, single 8×MI300X node

Enroot/pyxis containers (ROCm 6.4.3, OpenMPI 5.0.8 `--with-rocm`, UCX 1.20), one rank per GPU, via the new `examples/bench_lineareuler3d_scaling.f90` driver (one cuboid tile per rank). Numbers below are **after the aggregation commits (1–2)**; the third commit improves them further (see its section):

| Mesh | GPUs | main s/step | commits 1–2 s/step | speedup |
|---|---|---|---|---|
| 24³ | 1 | 0.01745 | 0.01780 | 1.0 (no-MPI parity) |
| 48³ | 2 | 3.135 | 0.110 | **28×** |
| 48³ | 4 | 2.258 | 0.0759 | **30×** |
| 48³ | 8 | 1.730 | 0.048 | **36×** |
| 64³ | 8 | 2.927 | 0.112 | **26×** |

- **Final PR state (all three commits)** at 48³ vs main: 3.135→0.098 s/step on 2 GPUs (**32×**), 2.258→0.060 on 4 (**37×**), 1.730→0.037 best-observed on 8 (**47×**).
- Aggregate throughput at 48³ / 8 GPUs: 33M → ~1.2B DOF/s per prognostic variable after commits 1–2, ~1.5B at the final PR state.
- 48³ numbers are stable across repeats (np8 repeat runs within 3%). The 64³/8-GPU case (~114 GB/GPU) shows large run-to-run variance on the cluster (0.11–2.2 s/step across repeats, **on both the per-side and aggregated implementations**) — it appears environmental (UCX/ROCm-IPC under high memory pressure), and even the worst aggregated run beat the baseline.
- 48³ on 1 GPU OOMs (192 GB): see #143 (lazy allocation of `jas_gpu`/interp work arrays); 96³/184³ at degree 7 fp64 exceed node memory regardless of exchange strategy (~2.4 MB/element).

## Correctness

- Final benchmark entropy matches main **digit-for-digit** at 2, 4, and 8 ranks (pure transport change; no FP reordering).
- Full ctest suite passes on gfx942 at every stage of this PR: 12/12 MPI tests (2 ranks; includes scalar BR gradient 2-D/3-D, vector DG divergence 2-D/3-D with side exchange, advection-diffusion 2-D/3-D RK3 + pickup) and 46/46 serial 3-D tests. Identical 100% pass rate on the unmodified baseline image.
- Single-rank paths untouched (halo tables built only when `mpiEnabled`).


## Third commit: overlap, persistent requests, prognostic-only messages

Follow-up refinements attacking the residual ~10 ms/stage of exchange latency (the data volume itself is <0.2 ms):

- **Persistent MPI requests**: buffers, peers, and counts are fixed after the first exchange, so each field creates `MPI_Recv_init`/`MPI_Send_init` pairs once and re-arms them with `MPI_Startall`; receives always start before sends.
- **Comm/compute overlap**: `SideExchange` is split into `SideExchangeStart` (pack + post + local exchange kernel) and `SideExchangeFinish` (Waitall + unpack). `CalculateTendency` (GPU DGModel2D/3D) finishes the exchange only where `extBoundary` is first consumed — before the BR gradient when gradients are enabled, otherwise after `SourceMethod`/`FluxMethod`, right before `BoundaryFlux`. Kernels launch asynchronously, so the host sits in `MPI_Waitall` (driving MPI progress) while the GPU runs interior work. `FluxMethod`/`BoundaryFlux` write disjoint outputs, so the reorder changes no floating-point results. The fused `SideExchange(mesh)` remains (= Start+Finish); all other call sites unchanged.
- **Prognostic-only messages** (uses `nstepped`): after one full-variable exchange (static traces are filled exactly once and never change), only variables `1:nstepped` are packed and sent — a 33% volume cut for LinearEuler3D (4 of 6 variables stepped). `DGModel3D` now defaults `nstepped = nvar` in `Init`, mirroring `DGModel2D`.

**Same-node interleaved A/B** vs. the second commit (LinearEuler3D deg 7 fp64, 8×MI300X): 48³ — **12% faster** at 2 GPUs (0.110→0.098 s/step), **~19%** at 4 (0.075→0.060), **~25%** at 8 (0.051→0.037 best-to-best); single-GPU parity. Cumulative vs. the per-side baseline at 48³: **32–47×**. Final entropy matches the baseline digit-for-digit in every run, and the full ctest suite passes (12 MPI + 46 serial 3-D). Freeing persistent requests is `MPI_FINALIZED`-guarded so field/mesh destruction order doesn't matter.


## Fourth commit: overlap for the EC-DG / ES-Atmo tendencies

`ECDGModel2D/3D` and `ESAtmo2D/3D` override `CalculateTendency`, so they used the aggregated persistent-request exchange (via the fused `SideExchange`) but not the overlap. This commit applies the same Start/Finish split: the exchange is posted after `BoundaryInterp` and completed immediately before `BoundaryFlux`, with `BoundaryFlux` moved after the two-point volume flux and its divergence (disjoint outputs — no floating-point change). The overlap window for these models is the **two-point volume flux**, the most expensive kernel family in the code, so the exchange should hide almost completely. Gradient-enabled runs finish the exchange before the BR gradient, as in the DGModel tendencies.

Validation: full ctest suite passes (134/134, including the EC entropy-conservation and ES-Atmo motionless/hydrostatic-balance checks). Multi-rank GPU runs of the EC/ES-Atmo models crash with a GPU memory fault **before and after this change, including on pre-#142 main** (same-node A/B across three images) — a pre-existing bug in these models' MPI path, which has no MPI test coverage today; tracked in #147.

## Follow-ons

(Of the #84 checklist: item 1, moving `MPI_Waitall` away from the posts for overlap, is implemented by the third commit here; item 2, indexed MPI datatypes, is subsumed by the GPU pack/unpack aggregation. Item 3 remains below.)

- `MPI_Dist_graph_create_adjacent` for topology-aware placement (#84 item 3) — most relevant multi-node.
- Extend the Start/Finish split and persistent requests to `MappedVector2D/3D` (they aggregate per neighbor but still post plain Isend/Irecv and only expose the fused exchange); fusing the solution+gradient exchanges would also halve the message count for parabolic models.
- UCX/ROCm-IPC tuning for the 64³/8-GPU run-to-run variance (0.1–2.2 s/step on both implementations at ~114 GB/GPU memory pressure).
- Lazy allocation of optional GPU work arrays (#143) to roughly 3× the reachable problem size per GPU.
- Fix the pre-existing multi-rank GPU crash in the EC-DG / ES-Atmo models and add 2-rank ctest coverage for them (#147).

Part of #84.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


