### PR TITLE
Support externally managed MPI communicators in domain decomposition

### DIFF
--- a/docs/GettingStarted/multi-gpu.md
+++ b/docs/GettingStarted/multi-gpu.md
@@ -8,10 +8,40 @@ SELF builds come with domain-decomposition enabled by default, which allows you 
 3. **Mapping Policies**: Use `mpirun`'s mapping and binding options to control how MPI processes are distributed across nodes and resources.
 
 
-When deploying SELF on multi-GPU platforms, each MPI rank is assigned to a single GPU. The GPU assignment algorithm is simple and is implemented in the `Init_DomainDecomposition` method defined in the `src/gpu/SELF_DomainDecomposition.f90` module. Each MPI rank queries HIP or CUDA for the number of GPU devices on your server. The device id assigned to the MPI process is set as the modulo of the MPI rank id and the number of devices.
+When deploying SELF on multi-GPU platforms, each MPI rank is assigned to a single GPU. The GPU assignment algorithm is simple and is implemented in the `Init_DomainDecomposition` method defined in the `src/gpu/SELF_DomainDecomposition.f90` module. Each MPI rank queries HIP or CUDA for the number of GPU devices on your server. SELF then splits the communicator with `MPI_Comm_split_type(MPI_COMM_TYPE_SHARED)` to find where the rank sits *within its own node*, and sets the device id to the modulo of that node-local rank and the number of devices.
 
-If you are working on clusters of multi-GPU accelerated nodes, this implies that all servers have the same number of GPUs. Additionally, if you are explicitly setting your process affinity, you will want to assign MPI ranks to pack servers sequentially.
+Using the node-local rank rather than the global rank means device assignment no longer depends on how the launcher orders ranks across nodes. It does still assume that every node exposes the same number of GPUs.
 
+
+## Using an externally managed communicator
+
+By default SELF owns the MPI lifecycle: the first mesh you create calls `MPI_Init` if nobody else has, and freeing the last mesh calls `MPI_Finalize`. That is what you want for a Fortran program whose `main` is SELF's.
+
+It is *not* what you want when SELF is a library inside a host process that already runs MPI — most commonly a Python driver, where importing `mpi4py.MPI` has already initialized MPI and will finalize it at interpreter exit. For that case, every mesh constructor and reader takes an optional `comm` argument:
+
+```fortran
+  integer :: solverComm
+
+  ! The caller initializes MPI and owns the communicator.
+  call MPI_Init(ierror)
+  call MPI_Comm_dup(MPI_COMM_WORLD,solverComm,ierror)
+
+  call mesh % StructuredMesh( nxPerTile=10, nyPerTile=10, &
+                              nTileX=2, nTileY=2, &
+                              dx=0.05_prec, dy=0.05_prec, &
+                              bcids, comm=solverComm )
+```
+
+When `comm` is present:
+
+- SELF calls neither `MPI_Init` nor `MPI_Finalize`. Freeing the mesh releases SELF's decomposition data and nothing more.
+- MPI must already be initialized. SELF stops with a diagnostic if it is not.
+- The communicator need not be `MPI_COMM_WORLD` or a duplicate of it. A subset communicator works, and SELF decomposes the mesh across exactly the ranks in it — ranks outside the communicator never need to call into SELF.
+- SELF stores the handle you pass without duplicating it. Keep the communicator alive until after `mesh % free()`.
+
+From Python via `mpi4py`, the handle comes from `comm.py2f()`, which yields the Fortran integer handle SELF expects.
+
+Without `comm`, behavior is unchanged, except that `MPI_Init` and `MPI_Finalize` are guarded: SELF initializes MPI only if no one else has, and finalizes only MPI that it initialized, only once the last live mesh has been freed. Several meshes may therefore coexist in one process, and tearing one down will not disturb the others.
 
 ## `mpirun` Options for Sequential Affinity:
 Use these options when launching your application with `mpirun`:

--- a/src/SELF_DomainDecomposition_t.f90
+++ b/src/SELF_DomainDecomposition_t.f90
@@ -37,6 +37,7 @@ module SELF_DomainDecomposition_t
   type DomainDecomposition_t
     logical :: mpiEnabled = .false.
     logical :: initialized = .false.
+    logical :: ownsMpi = .false. ! true when SELF called mpi_init and is responsible for MPI_Finalize
     integer :: mpiComm
     integer :: mpiPrec
     integer :: rankId
@@ -63,11 +64,13 @@ module SELF_DomainDecomposition_t
 
 contains
 
-  subroutine Init_DomainDecomposition_t(this)
+  subroutine Init_DomainDecomposition_t(this,comm)
     implicit none
     class(DomainDecomposition_t),intent(inout) :: this
+    integer,intent(in),optional :: comm
     ! Local
     integer       :: ierror
+    logical       :: mpiIsInitialized
 
     this%mpiComm = 0
     this%mpiPrec = prec
@@ -75,10 +78,26 @@ contains
     this%nRanks = 1
     this%nElem = 0
     this%mpiEnabled = .false.
+    this%ownsMpi = .false.
 
-    this%mpiComm = MPI_COMM_WORLD
-    print*,__FILE__," : Initializing MPI"
-    call mpi_init(ierror)
+    call MPI_Initialized(mpiIsInitialized,ierror)
+
+    if(present(comm)) then
+      ! The caller (e.g. mpi4py) owns the MPI lifecycle and provides the communicator.
+      if(.not. mpiIsInitialized) then
+        error stop __FILE__//" : A communicator was provided but MPI is not initialized."// &
+          " Initialize MPI (e.g. via mpi4py or MPI_Init) before creating a mesh with an external communicator."
+      endif
+      this%mpiComm = comm
+    else
+      this%mpiComm = MPI_COMM_WORLD
+      if(.not. mpiIsInitialized) then
+        print*,__FILE__," : Initializing MPI"
+        call mpi_init(ierror)
+        this%ownsMpi = .true.
+      endif
+    endif
+
     call mpi_comm_rank(this%mpiComm,this%rankId,ierror)
     call mpi_comm_size(this%mpiComm,this%nRanks,ierror)
     print*,__FILE__," : Rank ",this%rankId+1,"/",this%nRanks," checking in."
@@ -99,8 +118,6 @@ contains
 
     this%initialized = .true.
 
-    this%initialized = .true.
-
   endsubroutine Init_DomainDecomposition_t
 
   subroutine Free_DomainDecomposition_t(this)
@@ -108,6 +125,7 @@ contains
     class(DomainDecomposition_t),intent(inout) :: this
     ! Local
     integer :: ierror
+    logical :: mpiIsFinalized
 
     if(associated(this%offSetElem)) then
       deallocate(this%offSetElem)
@@ -119,10 +137,12 @@ contains
     if(allocated(this%requests)) deallocate(this%requests)
     if(allocated(this%stats)) deallocate(this%stats)
 
-    !if(this%mpiEnabled) then
-    print*,__FILE__," : Rank ",this%rankId+1,"/",this%nRanks," checking out."
-    call MPI_FINALIZE(ierror)
-    !endif
+    call MPI_Finalized(mpiIsFinalized,ierror)
+    if(this%ownsMpi .and. .not. mpiIsFinalized) then
+      print*,__FILE__," : Rank ",this%rankId+1,"/",this%nRanks," checking out."
+      call MPI_FINALIZE(ierror)
+    endif
+    this%ownsMpi = .false.
 
   endsubroutine Free_DomainDecomposition_t
 

--- a/src/SELF_DomainDecomposition_t.f90
+++ b/src/SELF_DomainDecomposition_t.f90
@@ -38,7 +38,7 @@ module SELF_DomainDecomposition_t
     logical :: mpiEnabled = .false.
     logical :: initialized = .false.
     logical :: ownsMpi = .false. ! true when SELF called mpi_init and is responsible for MPI_Finalize
-    integer :: mpiComm
+    integer :: mpiComm = MPI_COMM_NULL
     integer :: mpiPrec
     integer :: rankId
     integer :: nRanks
@@ -62,23 +62,35 @@ module SELF_DomainDecomposition_t
 
   endtype DomainDecomposition_t
 
+  ! Process-wide bookkeeping for the MPI lifecycle.
+  !
+  ! Several decompositions can be live at once -- a process may hold more than
+  ! one mesh, which is the normal case for a long-lived Python driver. SELF may
+  ! only finalize MPI that it initialized itself, and only once the last
+  ! decomposition has been freed; otherwise the first mesh to be torn down
+  ! pulls MPI out from under the meshes that are still in use.
+  integer,private :: nLiveDecomps = 0
+  logical,private :: selfInitializedMpi = .false.
+
 contains
 
-  subroutine Init_DomainDecomposition_t(this,comm)
+  subroutine AcquireMPI(mpiComm,ownsMpi,comm)
+  !! Resolve the communicator a new decomposition will run on and register it
+  !! with the process-wide lifecycle bookkeeping.
+  !!
+  !! With `comm` present the caller (e.g. mpi4py) already owns MPI and SELF
+  !! calls neither MPI_Init nor MPI_Finalize. Without it SELF falls back to
+  !! MPI_COMM_WORLD, initializing MPI only if nobody else has yet.
+  !!
+  !! Shared by the CPU and GPU DomainDecomposition Init implementations so the
+  !! two cannot drift apart.
     implicit none
-    class(DomainDecomposition_t),intent(inout) :: this
+    integer,intent(out) :: mpiComm
+    logical,intent(out) :: ownsMpi
     integer,intent(in),optional :: comm
     ! Local
-    integer       :: ierror
-    logical       :: mpiIsInitialized
-
-    this%mpiComm = 0
-    this%mpiPrec = prec
-    this%rankId = 0
-    this%nRanks = 1
-    this%nElem = 0
-    this%mpiEnabled = .false.
-    this%ownsMpi = .false.
+    integer :: ierror
+    logical :: mpiIsInitialized
 
     call MPI_Initialized(mpiIsInitialized,ierror)
 
@@ -88,15 +100,65 @@ contains
         error stop __FILE__//" : A communicator was provided but MPI is not initialized."// &
           " Initialize MPI (e.g. via mpi4py or MPI_Init) before creating a mesh with an external communicator."
       endif
-      this%mpiComm = comm
+      mpiComm = comm
     else
-      this%mpiComm = MPI_COMM_WORLD
+      mpiComm = MPI_COMM_WORLD
       if(.not. mpiIsInitialized) then
         print*,__FILE__," : Initializing MPI"
         call mpi_init(ierror)
-        this%ownsMpi = .true.
+        selfInitializedMpi = .true.
       endif
     endif
+
+    nLiveDecomps = nLiveDecomps+1
+    ownsMpi = selfInitializedMpi
+
+  endsubroutine AcquireMPI
+
+  subroutine ReleaseMPI(ownsMpi,rankId,nRanks)
+  !! Retire one decomposition from the process-wide lifecycle bookkeeping and,
+  !! if it was the last one and SELF initialized MPI, finalize.
+  !!
+  !! Shared by the CPU and GPU DomainDecomposition Free implementations.
+    implicit none
+    logical,intent(inout) :: ownsMpi
+    integer,intent(in) :: rankId
+    integer,intent(in) :: nRanks
+    ! Local
+    integer :: ierror
+    logical :: mpiIsFinalized
+
+    ownsMpi = .false.
+    nLiveDecomps = max(nLiveDecomps-1,0)
+
+    ! Other meshes are still live; they need MPI to stay up.
+    if(nLiveDecomps > 0) return
+
+    call MPI_Finalized(mpiIsFinalized,ierror)
+    if(selfInitializedMpi .and. .not. mpiIsFinalized) then
+      print*,__FILE__," : Rank ",rankId+1,"/",nRanks," checking out."
+      call MPI_FINALIZE(ierror)
+    endif
+    selfInitializedMpi = .false.
+
+  endsubroutine ReleaseMPI
+
+  subroutine Init_DomainDecomposition_t(this,comm)
+    implicit none
+    class(DomainDecomposition_t),intent(inout) :: this
+    integer,intent(in),optional :: comm
+    ! Local
+    integer       :: ierror
+
+    this%mpiComm = MPI_COMM_NULL
+    this%mpiPrec = prec
+    this%rankId = 0
+    this%nRanks = 1
+    this%nElem = 0
+    this%mpiEnabled = .false.
+    this%ownsMpi = .false.
+
+    call AcquireMPI(this%mpiComm,this%ownsMpi,comm)
 
     call mpi_comm_rank(this%mpiComm,this%rankId,ierror)
     call mpi_comm_size(this%mpiComm,this%nRanks,ierror)
@@ -123,9 +185,6 @@ contains
   subroutine Free_DomainDecomposition_t(this)
     implicit none
     class(DomainDecomposition_t),intent(inout) :: this
-    ! Local
-    integer :: ierror
-    logical :: mpiIsFinalized
 
     if(associated(this%offSetElem)) then
       deallocate(this%offSetElem)
@@ -137,12 +196,12 @@ contains
     if(allocated(this%requests)) deallocate(this%requests)
     if(allocated(this%stats)) deallocate(this%stats)
 
-    call MPI_Finalized(mpiIsFinalized,ierror)
-    if(this%ownsMpi .and. .not. mpiIsFinalized) then
-      print*,__FILE__," : Rank ",this%rankId+1,"/",this%nRanks," checking out."
-      call MPI_FINALIZE(ierror)
+    ! Guard against a second Free, and against freeing a decomposition that was
+    ! never initialized, both of which would corrupt the live-decomposition count.
+    if(this%initialized) then
+      call ReleaseMPI(this%ownsMpi,this%rankId,this%nRanks)
+      this%initialized = .false.
     endif
-    this%ownsMpi = .false.
 
   endsubroutine Free_DomainDecomposition_t
 

--- a/src/SELF_Mesh_1D.f90
+++ b/src/SELF_Mesh_1D.f90
@@ -62,12 +62,13 @@ module SELF_Mesh_1D
 
 contains
 
-  subroutine Init_Mesh1D(this,nElem,nNodes,nBCs)
+  subroutine Init_Mesh1D(this,nElem,nNodes,nBCs,comm)
     implicit none
     class(Mesh1D),intent(out) :: this
     integer,intent(in) :: nElem
     integer,intent(in) :: nNodes
     integer,intent(in) :: nBCs
+    integer,intent(in),optional :: comm
 
     this%nGeo = 1
     this%nElem = nElem
@@ -84,7 +85,7 @@ contains
     allocate(this%BCType(1:4,1:nBCs))
 
     allocate(this%BCNames(1:nBCs))
-    call this%decomp%Init()
+    call this%decomp%Init(comm)
 
   endsubroutine Init_Mesh1D
 
@@ -106,11 +107,12 @@ contains
 
   endsubroutine Free_Mesh1D
 
-  subroutine UniformBlockMesh_Mesh1D(this,nElem,x)
+  subroutine UniformBlockMesh_Mesh1D(this,nElem,x,comm)
     implicit none
     class(Mesh1D),intent(out) :: this
     integer,intent(in) :: nElem
     real(prec),intent(in) :: x(1:2)
+    integer,intent(in),optional :: comm
     ! Local
     integer :: iel,ngeo
     integer :: nid,nNodes
@@ -124,7 +126,7 @@ contains
     ngeo = 1
 
     nNodes = nElem*(nGeo+1)
-    call this%Init(nElem,nNodes,2)
+    call this%Init(nElem,nNodes,2,comm)
     this%quadrature = GAUSS_LOBATTO
 
     ! Set the hopr_nodeCoords

--- a/src/SELF_Mesh_2D_t.f90
+++ b/src/SELF_Mesh_2D_t.f90
@@ -274,7 +274,7 @@ contains
 
   endsubroutine ResetBoundaryConditionType_Mesh2D_t
 
-  subroutine UniformStructuredMesh_Mesh2D_t(this,nxPerTile,nyPerTile,nTileX,nTileY,dx,dy,bcids)
+  subroutine UniformStructuredMesh_Mesh2D_t(this,nxPerTile,nyPerTile,nTileX,nTileY,dx,dy,bcids,comm)
   !!
   !! Create a structured mesh and store it in SELF's unstructured mesh format.
   !! The mesh is created in tiles of size (tnx,tny). Tiling is used to determine
@@ -290,7 +290,8 @@ contains
   !!    - dx : Element width in the x-direction
   !!    - dy : Element width in the y-direction
   !!    - bcids(1:4) : Boundary condition flags for the south, east, north, and west sides of the domain
-  !!    - enableDomainDecomposition : Boolean to determine if domain decomposition is used.
+  !!    - comm (optional) : Externally managed MPI communicator (Fortran integer handle). When
+  !!      provided, the caller owns MPI initialization/finalization.
   !!
   !!  Output
   !!    - this : mesh2d_t object with vertices, edges, and element information
@@ -310,6 +311,7 @@ contains
     real(prec),intent(in) :: dx
     real(prec),intent(in) :: dy
     integer,intent(in) :: bcids(1:4)
+    integer,intent(in),optional :: comm
     ! Local
     integer :: nX,nY,nGeo,nBCs
     integer :: nGlobalElem
@@ -327,7 +329,7 @@ contains
     integer :: e1,e2
     integer :: nedges
 
-    call this%decomp%init()
+    call this%decomp%init(comm)
 
     nX = nTileX*nxPerTile
     nY = nTileY*nyPerTile
@@ -502,7 +504,7 @@ contains
 
   endsubroutine UniformStructuredMesh_Mesh2D_t
 
-  subroutine SimpleMortarMesh_Mesh2D_t(this,dx,bcids)
+  subroutine SimpleMortarMesh_Mesh2D_t(this,dx,bcids,comm)
   !!
   !! Create the smallest 2:1 nonconforming (mortar) mesh: one "big" element of size
   !! 2*dx x 2*dx whose east edge is shared with the west edges of two "small" dx x dx
@@ -533,6 +535,7 @@ contains
     class(Mesh2D_t),intent(out) :: this
     real(prec),intent(in) :: dx
     integer,intent(in) :: bcids(1:4)
+    integer,intent(in),optional :: comm
     ! Local
     integer,parameter :: nGlobalElem = 3
     integer,parameter :: nUniqueSides = 10
@@ -543,7 +546,7 @@ contains
     integer :: nLocalElems
     integer :: nGeo,nBCs
 
-    call this%decomp%init()
+    call this%decomp%init(comm)
 
     nGeo = 1 ! Bilinear element geometry
     nBCs = 4
@@ -647,7 +650,7 @@ contains
 
   endsubroutine SimpleMortarMesh_Mesh2D_t
 
-  subroutine DoubleMortarMesh_Mesh2D_t(this,dx,bcids)
+  subroutine DoubleMortarMesh_Mesh2D_t(this,dx,bcids,comm)
   !!
   !! Create a six-element mesh with two 2:1 mortar interfaces, used to validate the
   !! mortar machinery in configurations the SimpleMortarMesh cannot reach:
@@ -681,6 +684,7 @@ contains
     class(Mesh2D_t),intent(out) :: this
     real(prec),intent(in) :: dx
     integer,intent(in) :: bcids(1:4)
+    integer,intent(in),optional :: comm
     ! Local
     integer,parameter :: nGlobalElem = 6
     integer,parameter :: nUniqueSides = 18
@@ -691,7 +695,7 @@ contains
     integer :: nLocalElems
     integer :: nGeo,nBCs
 
-    call this%decomp%init()
+    call this%decomp%init(comm)
 
     nGeo = 1 ! Bilinear element geometry
     nBCs = 4
@@ -859,12 +863,13 @@ contains
 
   endsubroutine DoubleMortarMesh_Mesh2D_t
 
-  subroutine Read_HOPr_Mesh2D_t(this,meshFile)
+  subroutine Read_HOPr_Mesh2D_t(this,meshFile,comm)
     ! From https://www.hopr-project.org/externals/Meshformat.pdf, Algorithm 6
     ! Adapted for 2D Mesh : Note that HOPR does not have 2D mesh output.
     implicit none
     class(Mesh2D_t),intent(out) :: this
     character(*),intent(in) :: meshFile
+    integer,intent(in),optional :: comm
     ! Local
     integer(HID_T) :: fileId
     integer(HID_T) :: offset(1:2),gOffset(1)
@@ -888,7 +893,7 @@ contains
     integer,dimension(:),allocatable :: hopr_globalNodeIDs
     integer,dimension(:,:),allocatable :: bcType
 
-    call this%decomp%init()
+    call this%decomp%init(comm)
 
     print*,__FILE__//' : Reading HOPr mesh from'//trim(meshfile)
     if(this%decomp%mpiEnabled) then
@@ -1029,7 +1034,7 @@ contains
 
   endsubroutine Read_HOPr_Mesh2D_t
 
-  subroutine Read_HOHQMesh_Mesh2D_t(this,meshFile)
+  subroutine Read_HOHQMesh_Mesh2D_t(this,meshFile,comm)
     !! Reader for HOHQMesh text mesh files in the ISM and ISM-MM
     !! formats. The format is auto-detected from the first line:
     !!   * Line equal to "ISM-MM" (trimmed) => ISM-MM with per-element
@@ -1055,6 +1060,7 @@ contains
     implicit none
     class(Mesh2D_t),intent(out) :: this
     character(*),intent(in) :: meshFile
+    integer,intent(in),optional :: comm
     ! Local
     integer :: iUnit
     integer :: ios
@@ -1090,7 +1096,7 @@ contains
     character(LEN=SELF_MESH_MATNAME_LENGTH),allocatable :: matNamesLocal(:)
     logical :: isISM_MM
 
-    call this%decomp%init()
+    call this%decomp%init(comm)
 
     open(newunit=iUnit,file=trim(meshFile),status='old',action='read', &
          form='formatted',iostat=ios)

--- a/src/SELF_Mesh_3D_t.f90
+++ b/src/SELF_Mesh_3D_t.f90
@@ -366,7 +366,7 @@ contains
   endfunction gid2eid
 
   subroutine UniformStructuredMesh_Mesh3D_t(this,nxPerTile,nyPerTile,nzPerTile, &
-                                            nTileX,nTileY,nTileZ,dx,dy,dz,bcids)
+                                            nTileX,nTileY,nTileZ,dx,dy,dz,bcids,comm)
   !!
   !! Create a structured mesh and store it in SELF's unstructured mesh format.
   !! The mesh is created in tiles of size (tnx,tny,tnz). Tiling is used to determine
@@ -385,7 +385,8 @@ contains
   !!    - dy : Element width in the y-direction
   !!    - dz : Element width in the z-direction
   !!    - bcids(1:6) : Boundary condition flags for the south, east, north, and west sides of the domain
-  !!    - enableDomainDecomposition : Boolean to determine if domain decomposition is used.
+  !!    - comm (optional) : Externally managed MPI communicator (Fortran integer handle). When
+  !!      provided, the caller owns MPI initialization/finalization.
   !!
   !!  Output
   !!    - this : mesh2d_t object with vertices, faces, and element information
@@ -408,6 +409,7 @@ contains
     real(prec),intent(in) :: dy
     real(prec),intent(in) :: dz
     integer,intent(in) :: bcids(1:6)
+    integer,intent(in),optional :: comm
     ! Local
     integer :: nX,nY,nZ,nGeo,nBCs
     integer :: nGlobalElem
@@ -425,7 +427,7 @@ contains
     integer :: e1,e2,s1,s2
     integer :: nfaces
 
-    call this%decomp%init()
+    call this%decomp%init(comm)
 
     nX = nTileX*nxPerTile
     nY = nTileY*nyPerTile
@@ -716,7 +718,7 @@ contains
   endsubroutine UniformStructuredMesh_Mesh3D_t
 
   subroutine UniformPeriodicMesh_Mesh3D_t(this,nxPerTile,nyPerTile,nzPerTile, &
-                                          nTileX,nTileY,nTileZ,dx,dy,dz)
+                                          nTileX,nTileY,nTileZ,dx,dy,dz,comm)
   !!
   !! Create a fully triply-periodic structured hexahedral mesh and store it in
   !! SELF's unstructured mesh format. Element geometry and ordering are identical
@@ -766,6 +768,7 @@ contains
     real(prec),intent(in) :: dx
     real(prec),intent(in) :: dy
     real(prec),intent(in) :: dz
+    integer,intent(in),optional :: comm
     ! Local
     integer :: nX,nY,nZ,nGeo,nBCs
     integer :: nGlobalElem
@@ -784,7 +787,7 @@ contains
     integer :: e1,e2
     integer :: gx,gy,gz,gxm,gxp,gym,gyp,gzm,gzp
 
-    call this%decomp%init()
+    call this%decomp%init(comm)
 
     nX = nTileX*nxPerTile
     nY = nTileY*nyPerTile
@@ -933,11 +936,12 @@ contains
 
   endsubroutine UniformPeriodicMesh_Mesh3D_t
 
-  subroutine Read_HOPr_Mesh3D_t(this,meshFile)
+  subroutine Read_HOPr_Mesh3D_t(this,meshFile,comm)
     ! From https://www.hopr-project.org/externals/Meshformat.pdf, Algorithm 6
     implicit none
     class(Mesh3D_t),intent(out) :: this
     character(*),intent(in) :: meshFile
+    integer,intent(in),optional :: comm
     ! Local
     integer(HID_T) :: fileId
     integer(HID_T) :: offset(1:2),gOffset(1)
@@ -958,7 +962,7 @@ contains
     integer,dimension(:),allocatable :: hopr_globalNodeIDs
     integer,dimension(:,:),allocatable :: bcType
 
-    call this%decomp%init()
+    call this%decomp%init(comm)
 
     if(this%decomp%mpiEnabled) then
       call Open_HDF5(meshFile,H5F_ACC_RDONLY_F,fileId,this%decomp%mpiComm)

--- a/src/gpu/SELF_DomainDecomposition.f90
+++ b/src/gpu/SELF_DomainDecomposition.f90
@@ -71,10 +71,9 @@ contains
     ! Local
     integer       :: ierror
     integer       :: nodeComm,localRank
-    logical       :: mpiIsInitialized
     integer(c_int) :: num_devices,hip_err,device_id
 
-    this%mpiComm = 0
+    this%mpiComm = MPI_COMM_NULL
     this%mpiPrec = prec
     this%rankId = 0
     this%nRanks = 1
@@ -82,23 +81,7 @@ contains
     this%mpiEnabled = .false.
     this%ownsMpi = .false.
 
-    call MPI_Initialized(mpiIsInitialized,ierror)
-
-    if(present(comm)) then
-      ! The caller (e.g. mpi4py) owns the MPI lifecycle and provides the communicator.
-      if(.not. mpiIsInitialized) then
-        error stop __FILE__//" : A communicator was provided but MPI is not initialized."// &
-          " Initialize MPI (e.g. via mpi4py or MPI_Init) before creating a mesh with an external communicator."
-      endif
-      this%mpiComm = comm
-    else
-      this%mpiComm = MPI_COMM_WORLD
-      if(.not. mpiIsInitialized) then
-        print*,__FILE__," : Initializing MPI"
-        call mpi_init(ierror)
-        this%ownsMpi = .true.
-      endif
-    endif
+    call AcquireMPI(this%mpiComm,this%ownsMpi,comm)
 
     call mpi_comm_rank(this%mpiComm,this%rankId,ierror)
     call mpi_comm_size(this%mpiComm,this%nRanks,ierror)
@@ -144,9 +127,6 @@ contains
   subroutine Free_DomainDecomposition(this)
     implicit none
     class(DomainDecomposition),intent(inout) :: this
-    ! Local
-    integer :: ierror
-    logical :: mpiIsFinalized
 
     if(associated(this%offSetElem)) then
       deallocate(this%offSetElem)
@@ -167,12 +147,12 @@ contains
     endif
     this%halo_built = .false.
 
-    call MPI_Finalized(mpiIsFinalized,ierror)
-    if(this%ownsMpi .and. .not. mpiIsFinalized) then
-      print*,__FILE__," : Rank ",this%rankId+1,"/",this%nRanks," checking out."
-      call MPI_FINALIZE(ierror)
+    ! Guard against a second Free, and against freeing a decomposition that was
+    ! never initialized, both of which would corrupt the live-decomposition count.
+    if(this%initialized) then
+      call ReleaseMPI(this%ownsMpi,this%rankId,this%nRanks)
+      this%initialized = .false.
     endif
-    this%ownsMpi = .false.
 
   endsubroutine Free_DomainDecomposition
 

--- a/src/gpu/SELF_DomainDecomposition.f90
+++ b/src/gpu/SELF_DomainDecomposition.f90
@@ -64,11 +64,14 @@ module SELF_DomainDecomposition
 
 contains
 
-  subroutine Init_DomainDecomposition(this)
+  subroutine Init_DomainDecomposition(this,comm)
     implicit none
     class(DomainDecomposition),intent(inout) :: this
+    integer,intent(in),optional :: comm
     ! Local
     integer       :: ierror
+    integer       :: nodeComm,localRank
+    logical       :: mpiIsInitialized
     integer(c_int) :: num_devices,hip_err,device_id
 
     this%mpiComm = 0
@@ -77,10 +80,26 @@ contains
     this%nRanks = 1
     this%nElem = 0
     this%mpiEnabled = .false.
+    this%ownsMpi = .false.
 
-    this%mpiComm = MPI_COMM_WORLD
-    print*,__FILE__," : Initializing MPI"
-    call mpi_init(ierror)
+    call MPI_Initialized(mpiIsInitialized,ierror)
+
+    if(present(comm)) then
+      ! The caller (e.g. mpi4py) owns the MPI lifecycle and provides the communicator.
+      if(.not. mpiIsInitialized) then
+        error stop __FILE__//" : A communicator was provided but MPI is not initialized."// &
+          " Initialize MPI (e.g. via mpi4py or MPI_Init) before creating a mesh with an external communicator."
+      endif
+      this%mpiComm = comm
+    else
+      this%mpiComm = MPI_COMM_WORLD
+      if(.not. mpiIsInitialized) then
+        print*,__FILE__," : Initializing MPI"
+        call mpi_init(ierror)
+        this%ownsMpi = .true.
+      endif
+    endif
+
     call mpi_comm_rank(this%mpiComm,this%rankId,ierror)
     call mpi_comm_size(this%mpiComm,this%nRanks,ierror)
     print*,__FILE__," : Rank ",this%rankId+1,"/",this%nRanks," checking in."
@@ -102,16 +121,21 @@ contains
     hip_err = hipGetDeviceCount(num_devices)
     if(hip_err /= 0) then
       print*,'Failed to get device count on rank',this%rankId
-      call MPI_Abort(MPI_COMM_WORLD,hip_err,ierror)
+      call MPI_Abort(this%mpiComm,hip_err,ierror)
     endif
 
-    ! Assign GPU device ID based on MPI rank
-    device_id = modulo(this%rankId,num_devices) ! Assumes that mpi ranks are packed sequentially on a node until the node is filled up.
+    ! Assign GPU device ID based on node-local MPI rank so multi-node
+    ! placement is independent of the launcher's global rank ordering.
+    call MPI_Comm_split_type(this%mpiComm,MPI_COMM_TYPE_SHARED,this%rankId, &
+                             MPI_INFO_NULL,nodeComm,ierror)
+    call MPI_Comm_rank(nodeComm,localRank,ierror)
+    call MPI_Comm_free(nodeComm,ierror)
+    device_id = modulo(localRank,num_devices)
     hip_err = hipSetDevice(device_id)
     print*,__FILE__," : Rank ",this%rankId+1," assigned to device ",device_id
     if(hip_err /= 0) then
       print*,'Failed to set device for rank',this%rankId,'to device',device_id
-      call MPI_Abort(MPI_COMM_WORLD,hip_err,ierror)
+      call MPI_Abort(this%mpiComm,hip_err,ierror)
     endif
 
     this%initialized = .true.
@@ -122,6 +146,7 @@ contains
     class(DomainDecomposition),intent(inout) :: this
     ! Local
     integer :: ierror
+    logical :: mpiIsFinalized
 
     if(associated(this%offSetElem)) then
       deallocate(this%offSetElem)
@@ -142,8 +167,12 @@ contains
     endif
     this%halo_built = .false.
 
-    print*,__FILE__," : Rank ",this%rankId+1,"/",this%nRanks," checking out."
-    call MPI_FINALIZE(ierror)
+    call MPI_Finalized(mpiIsFinalized,ierror)
+    if(this%ownsMpi .and. .not. mpiIsFinalized) then
+      print*,__FILE__," : Rank ",this%rankId+1,"/",this%nRanks," checking out."
+      call MPI_FINALIZE(ierror)
+    endif
+    this%ownsMpi = .false.
 
   endsubroutine Free_DomainDecomposition
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -179,6 +179,7 @@ add_fortran_tests (
     "points_dirac_delta_3d_ndim_mismatch.f90"
     "points_dirac_delta_2d_nvar_mismatch.f90"
     "points_dirac_delta_3d_nvar_mismatch.f90"
+    "domaindecomposition_two_meshes.f90"
     )
 
 # Mark the four DiracDelta guard tests as expected-to-fail: each program
@@ -209,4 +210,6 @@ add_mpi_fortran_tests( "mappedvectordgdivergence_2d_linear_mpi.f90"
                        "advection_diffusion_3d_rk3_mpi.f90"
                        "advection_diffusion_3d_rk3_pickup_mpi.f90"
                        "structuredmesh_external_comm_2d.f90"
-                       "structuredmesh_external_comm_3d.f90" )
+                       "structuredmesh_external_comm_3d.f90"
+                       "structuredmesh_subcomm_2d.f90"
+                       "read_hopr_external_comm_2d.f90" )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -207,4 +207,6 @@ add_mpi_fortran_tests( "mappedvectordgdivergence_2d_linear_mpi.f90"
                        "advection_diffusion_2d_rk3_mpi.f90"
                        "advection_diffusion_2d_rk3_pickup_mpi.f90"
                        "advection_diffusion_3d_rk3_mpi.f90"
-                       "advection_diffusion_3d_rk3_pickup_mpi.f90" )
+                       "advection_diffusion_3d_rk3_pickup_mpi.f90"
+                       "structuredmesh_external_comm_2d.f90"
+                       "structuredmesh_external_comm_3d.f90" )

--- a/test/domaindecomposition_two_meshes.f90
+++ b/test/domaindecomposition_two_meshes.f90
@@ -1,0 +1,95 @@
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+!
+! Maintainers : support@fluidnumerics.com
+! Official Repository : https://github.com/FluidNumerics/self/
+!
+! Copyright © 2024 Fluid Numerics LLC
+!
+! Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+!
+! 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+!    the documentation and/or other materials provided with the distribution.
+!
+! 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+!    this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+! HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+! LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+! THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+! THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+!
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+
+program domaindecomposition_two_meshes
+!! Two meshes coexisting in one process, with SELF owning the MPI lifecycle.
+!!
+!! SELF initializes MPI when the first mesh is created and must keep it alive
+!! until the last mesh is gone. Freeing the first mesh while the second is
+!! still in use must NOT finalize MPI -- otherwise every subsequent operation
+!! on the survivor runs against a finalized library.
+!!
+!! This is the no-comm counterpart to structuredmesh_external_comm_2d: there
+!! the caller owns MPI, here SELF does.
+
+  use self_data
+  use SELF_Mesh_2D
+  use mpi
+
+  implicit none
+  type(Mesh2D),target :: meshA,meshB
+  integer :: bcids(1:4)
+  integer :: ierror
+  integer :: survivorRank,survivorSize
+  logical :: mpiIsFinalized
+
+  bcids(1:4) = [SELF_BC_NONORMALFLOW, & ! South
+                SELF_BC_NONORMALFLOW, & ! East
+                SELF_BC_NONORMALFLOW, & ! North
+                SELF_BC_NONORMALFLOW] ! West
+
+  ! First mesh: MPI is not yet up, so SELF initializes it and takes ownership.
+  call meshA%StructuredMesh(5,5,2,2,0.1_prec,0.1_prec,bcids)
+
+  ! Second mesh: MPI is already up. SELF must reuse it and must NOT re-init.
+  call meshB%StructuredMesh(5,5,2,2,0.1_prec,0.1_prec,bcids)
+
+  ! Retire the mesh that owns MPI while the other is still live.
+  call meshA%free()
+
+  call MPI_Finalized(mpiIsFinalized,ierror)
+  if(mpiIsFinalized) then
+    print*,"Error: freeing the first mesh finalized MPI while a second mesh is still live"
+    stop 1
+  endif
+
+  ! The survivor's communicator must still be usable.
+  call MPI_Comm_rank(meshB%decomp%mpiComm,survivorRank,ierror)
+  if(ierror /= MPI_SUCCESS) then
+    print*,"Error: the surviving mesh's communicator is no longer valid",ierror
+    stop 1
+  endif
+  call MPI_Comm_size(meshB%decomp%mpiComm,survivorSize,ierror)
+  if(ierror /= MPI_SUCCESS) then
+    print*,"Error: MPI_Comm_size failed on the surviving mesh's communicator",ierror
+    stop 1
+  endif
+  if(survivorRank /= meshB%decomp%rankId .or. survivorSize /= meshB%decomp%nRanks) then
+    print*,"Error: surviving mesh decomposition is inconsistent with its communicator", &
+      survivorRank,meshB%decomp%rankId,survivorSize,meshB%decomp%nRanks
+    stop 1
+  endif
+
+  ! Freeing the last mesh releases MPI.
+  call meshB%free()
+
+  call MPI_Finalized(mpiIsFinalized,ierror)
+  if(.not. mpiIsFinalized) then
+    print*,"Error: freeing the last SELF-owned mesh did not finalize MPI"
+    stop 1
+  endif
+
+endprogram domaindecomposition_two_meshes

--- a/test/read_hopr_external_comm_2d.f90
+++ b/test/read_hopr_external_comm_2d.f90
@@ -24,65 +24,48 @@
 !
 ! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
 
-program structuredmesh_external_comm_2d
-!! Exercises the externally-managed MPI lifecycle used by Python (mpi4py)
-!! callers: the program initializes MPI itself, hands a duplicated
-!! communicator to StructuredMesh, runs a LinearEuler2D model, frees the
-!! mesh, and verifies SELF did NOT finalize MPI before finalizing itself.
+program read_hopr_external_comm_2d
+!! Reads a HOPr mesh through an externally managed communicator.
+!!
+!! Read_HOPr takes the same optional `comm` as the structured constructors,
+!! but it is the only entry point that forwards the communicator into parallel
+!! HDF5 (h5pset_fapl_mpio_f). That makes it the highest-risk consumer of an
+!! external handle and it had no coverage: a communicator that MPI accepts can
+!! still be rejected -- or silently ignored -- by the HDF5 file access property
+!! list.
+!!
+!! The caller owns the MPI lifecycle here, exactly as mpi4py does.
 
   use self_data
-  use self_LinearEuler2D
+  use SELF_Mesh_2D
   use mpi
 
   implicit none
-  real(prec),parameter :: rho0 = 1.225_prec
-  real(prec),parameter :: rhoprime = 0.01_prec
-  real(prec),parameter :: c = 1.0_prec
-  real(prec),parameter :: Lr = 0.06_prec
-  real(prec),parameter :: x0 = 0.5_prec
-  real(prec),parameter :: y0 = 0.5_prec
-  character(SELF_INTEGRATOR_LENGTH),parameter :: integrator = 'rk3'
-  integer,parameter :: controlDegree = 7
-  integer,parameter :: targetDegree = 15
-  real(prec),parameter :: dt = 2.0_prec*10.0_prec**(-4)
-  real(prec),parameter :: endtime = 5.0_prec*10.0_prec**(-3)
-  real(prec),parameter :: iointerval = 5.0_prec*10.0_prec**(-3)
-  real(prec) :: ef
-  type(LinearEuler2D) :: modelobj
-  type(Lagrange),target :: interp
   type(Mesh2D),target :: mesh
-  type(SEMQuad),target :: geometry
-  integer :: bcids(1:4)
+  character(LEN=255) :: WORKSPACE
   integer :: dupComm,dupRank,dupSize
   integer :: cmpResult,ierror
+  integer :: nElemLocal,nElemTotal
   logical :: mpiIsFinalized
 
-  ! The caller owns the MPI lifecycle (mpi4py does exactly this on import).
   call mpi_init(ierror)
   call MPI_Comm_dup(MPI_COMM_WORLD,dupComm,ierror)
-
-  bcids(1:4) = [SELF_BC_NONORMALFLOW, & ! South
-                SELF_BC_NONORMALFLOW, & ! East
-                SELF_BC_NONORMALFLOW, & ! North
-                SELF_BC_NONORMALFLOW] ! West
-
-  call mesh%StructuredMesh(5,5,2,2,0.1_prec,0.1_prec,bcids,comm=dupComm)
-
-  ! The decomposition must be running on the communicator we handed over. A dup
-  ! of MPI_COMM_WORLD has the same size and rank ordering, so rank/size alone
-  ! cannot catch `comm` being dropped -- compare the handles instead. Note that
-  ! a dup is MPI_CONGRUENT with MPI_COMM_WORLD, so the telling check is that the
-  ! decomposition is not *identical* to MPI_COMM_WORLD.
   call MPI_Comm_rank(dupComm,dupRank,ierror)
   call MPI_Comm_size(dupComm,dupSize,ierror)
+
+  call get_environment_variable("WORKSPACE",WORKSPACE)
+  call mesh%Read_HOPr(trim(WORKSPACE)//"/share/mesh/Block2D/Block2D_mesh.h5",comm=dupComm)
+
   call MPI_Comm_compare(mesh%decomp%mpiComm,dupComm,cmpResult,ierror)
   if(cmpResult /= MPI_IDENT .and. cmpResult /= MPI_CONGRUENT) then
-    print*,"Error: mesh decomposition is not using the provided communicator"
+    print*,"Error: Read_HOPr did not use the provided communicator"
     stop 1
   endif
+  ! A dup is MPI_CONGRUENT with MPI_COMM_WORLD, so the check that actually
+  ! detects `comm` being dropped is that the handle is not MPI_COMM_WORLD itself.
   call MPI_Comm_compare(mesh%decomp%mpiComm,MPI_COMM_WORLD,cmpResult,ierror)
   if(cmpResult == MPI_IDENT) then
-    print*,"Error: mesh decomposition fell back to MPI_COMM_WORLD instead of the provided communicator"
+    print*,"Error: Read_HOPr fell back to MPI_COMM_WORLD instead of the provided communicator"
     stop 1
   endif
   if(mesh%decomp%nRanks /= dupSize .or. mesh%decomp%rankId /= dupRank) then
@@ -91,31 +74,19 @@ program structuredmesh_external_comm_2d
     stop 1
   endif
 
-  call interp%Init(N=controlDegree, &
-                   controlNodeType=GAUSS, &
-                   M=targetDegree, &
-                   targetNodeType=UNIFORM)
-
-  call geometry%Init(interp,mesh%nElem)
-  call geometry%GenerateFromMesh(mesh)
-
-  call modelobj%Init(mesh,geometry)
-  modelobj%prescribed_bcs_enabled = .false.
-  modelobj%tecplot_enabled = .false.
-  modelobj%rho0 = rho0
-
-  call modelobj%SphericalSoundWave(rhoprime,Lr,x0,y0,c)
-
-  call modelobj%SetTimeIntegrator(integrator)
-  call modelobj%ForwardStep(endtime,dt,iointerval)
-
-  ef = modelobj%entropy
-  if(ef /= ef) then
-    print*,"Error: Final entropy is inf or nan",ef
+  ! Every element of the global mesh must be owned by exactly one rank.
+  nElemLocal = mesh%nElem
+  if(nElemLocal <= 0) then
+    print*,"Error: rank",dupRank,"was assigned no elements"
+    stop 1
+  endif
+  call MPI_Allreduce(nElemLocal,nElemTotal,1,MPI_INTEGER,MPI_SUM,dupComm,ierror)
+  if(nElemTotal /= mesh%decomp%nElem) then
+    print*,"Error: local element counts do not sum to the global element count", &
+      nElemTotal,mesh%decomp%nElem
     stop 1
   endif
 
-  call modelobj%free()
   call mesh%free() ! must NOT finalize MPI: the communicator is externally managed
 
   call MPI_Finalized(mpiIsFinalized,ierror)
@@ -124,10 +95,7 @@ program structuredmesh_external_comm_2d
     stop 1
   endif
 
-  call geometry%free()
-  call interp%free()
-
   call MPI_Comm_free(dupComm,ierror)
   call mpi_finalize(ierror)
 
-endprogram structuredmesh_external_comm_2d
+endprogram read_hopr_external_comm_2d

--- a/test/structuredmesh_external_comm_2d.f90
+++ b/test/structuredmesh_external_comm_2d.f90
@@ -1,0 +1,109 @@
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+!
+! Maintainers : support@fluidnumerics.com
+! Official Repository : https://github.com/FluidNumerics/self/
+!
+! Copyright © 2024 Fluid Numerics LLC
+!
+! Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+!
+! 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+!    the documentation and/or other materials provided with the distribution.
+!
+! 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+!    this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+! HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+! LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+! THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+! THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+!
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+
+program structuredmesh_external_comm_2d
+!! Exercises the externally-managed MPI lifecycle used by Python (mpi4py)
+!! callers: the program initializes MPI itself, hands a duplicated
+!! communicator to StructuredMesh, runs a LinearEuler2D model, frees the
+!! mesh, and verifies SELF did NOT finalize MPI before finalizing itself.
+
+  use self_data
+  use self_LinearEuler2D
+  use mpi
+
+  implicit none
+  real(prec),parameter :: rho0 = 1.225_prec
+  real(prec),parameter :: rhoprime = 0.01_prec
+  real(prec),parameter :: c = 1.0_prec
+  real(prec),parameter :: Lr = 0.06_prec
+  real(prec),parameter :: x0 = 0.5_prec
+  real(prec),parameter :: y0 = 0.5_prec
+  character(SELF_INTEGRATOR_LENGTH),parameter :: integrator = 'rk3'
+  integer,parameter :: controlDegree = 7
+  integer,parameter :: targetDegree = 15
+  real(prec),parameter :: dt = 2.0_prec*10.0_prec**(-4)
+  real(prec),parameter :: endtime = 5.0_prec*10.0_prec**(-3)
+  real(prec),parameter :: iointerval = 5.0_prec*10.0_prec**(-3)
+  real(prec) :: ef
+  type(LinearEuler2D) :: modelobj
+  type(Lagrange),target :: interp
+  type(Mesh2D),target :: mesh
+  type(SEMQuad),target :: geometry
+  integer :: bcids(1:4)
+  integer :: dupComm,ierror
+  logical :: mpiIsFinalized
+
+  ! The caller owns the MPI lifecycle (mpi4py does exactly this on import).
+  call mpi_init(ierror)
+  call MPI_Comm_dup(MPI_COMM_WORLD,dupComm,ierror)
+
+  bcids(1:4) = [SELF_BC_NONORMALFLOW, & ! South
+                SELF_BC_NONORMALFLOW, & ! East
+                SELF_BC_NONORMALFLOW, & ! North
+                SELF_BC_NONORMALFLOW] ! West
+
+  call mesh%StructuredMesh(5,5,2,2,0.1_prec,0.1_prec,bcids,comm=dupComm)
+
+  call interp%Init(N=controlDegree, &
+                   controlNodeType=GAUSS, &
+                   M=targetDegree, &
+                   targetNodeType=UNIFORM)
+
+  call geometry%Init(interp,mesh%nElem)
+  call geometry%GenerateFromMesh(mesh)
+
+  call modelobj%Init(mesh,geometry)
+  modelobj%prescribed_bcs_enabled = .false.
+  modelobj%tecplot_enabled = .false.
+  modelobj%rho0 = rho0
+
+  call modelobj%SphericalSoundWave(rhoprime,Lr,x0,y0,c)
+
+  call modelobj%SetTimeIntegrator(integrator)
+  call modelobj%ForwardStep(endtime,dt,iointerval)
+
+  ef = modelobj%entropy
+  if(ef /= ef) then
+    print*,"Error: Final entropy is inf or nan",ef
+    stop 1
+  endif
+
+  call modelobj%free()
+  call mesh%free() ! must NOT finalize MPI: the communicator is externally managed
+
+  call MPI_Finalized(mpiIsFinalized,ierror)
+  if(mpiIsFinalized) then
+    print*,"Error: SELF finalized MPI despite an externally provided communicator"
+    stop 1
+  endif
+
+  call geometry%free()
+  call interp%free()
+
+  call MPI_Comm_free(dupComm,ierror)
+  call mpi_finalize(ierror)
+
+endprogram structuredmesh_external_comm_2d

--- a/test/structuredmesh_external_comm_3d.f90
+++ b/test/structuredmesh_external_comm_3d.f90
@@ -1,0 +1,114 @@
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+!
+! Maintainers : support@fluidnumerics.com
+! Official Repository : https://github.com/FluidNumerics/self/
+!
+! Copyright © 2024 Fluid Numerics LLC
+!
+! Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+!
+! 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+!    the documentation and/or other materials provided with the distribution.
+!
+! 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+!    this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+! HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+! LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+! THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+! THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+!
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+
+program structuredmesh_external_comm_3d
+!! Exercises the externally-managed MPI lifecycle used by Python (mpi4py)
+!! callers: the program initializes MPI itself, hands a duplicated
+!! communicator to StructuredMesh, runs a LinearEuler3D model, frees the
+!! mesh, and verifies SELF did NOT finalize MPI before finalizing itself.
+
+  use self_data
+  use self_LinearEuler3D
+  use mpi
+
+  implicit none
+  real(prec),parameter :: rho0 = 1.225_prec
+  real(prec),parameter :: rhoprime = 0.01_prec
+  real(prec),parameter :: c = 1.0_prec
+  real(prec),parameter :: Lr = 0.06_prec
+  real(prec),parameter :: x0 = 0.5_prec
+  real(prec),parameter :: y0 = 0.5_prec
+  real(prec),parameter :: z0 = 0.5_prec
+  character(SELF_INTEGRATOR_LENGTH),parameter :: integrator = 'rk3'
+  integer,parameter :: controlDegree = 7
+  integer,parameter :: targetDegree = 15
+  real(prec),parameter :: dt = 5.0_prec*10.0_prec**(-4)
+  real(prec),parameter :: endtime = 5.0_prec*10.0_prec**(-3)
+  real(prec),parameter :: iointerval = 5.0_prec*10.0_prec**(-3)
+  real(prec) :: ef
+  type(LinearEuler3D) :: modelobj
+  type(Lagrange),target :: interp
+  type(Mesh3D),target :: mesh
+  type(SEMHex),target :: geometry
+  integer :: bcids(1:6)
+  integer :: dupComm,ierror
+  logical :: mpiIsFinalized
+
+  ! The caller owns the MPI lifecycle (mpi4py does exactly this on import).
+  call mpi_init(ierror)
+  call MPI_Comm_dup(MPI_COMM_WORLD,dupComm,ierror)
+
+  bcids(1:6) = [SELF_BC_RADIATION, & ! Bottom
+                SELF_BC_RADIATION, & ! South
+                SELF_BC_RADIATION, & ! East
+                SELF_BC_RADIATION, & ! North
+                SELF_BC_RADIATION, & ! West
+                SELF_BC_RADIATION] ! Top
+
+  call mesh%StructuredMesh(5,5,5,1,1,1, &
+                           0.2_prec,0.2_prec,0.2_prec,bcids,comm=dupComm)
+
+  call interp%Init(N=controlDegree, &
+                   controlNodeType=GAUSS, &
+                   M=targetDegree, &
+                   targetNodeType=UNIFORM)
+
+  call geometry%Init(interp,mesh%nElem)
+  call geometry%GenerateFromMesh(mesh)
+
+  call modelobj%Init(mesh,geometry)
+  modelobj%prescribed_bcs_enabled = .false.
+  modelobj%tecplot_enabled = .false.
+  modelobj%rho0 = rho0
+  modelobj%c = c
+
+  call modelobj%SphericalSoundWave(rhoprime,Lr,x0,y0,z0)
+
+  call modelobj%SetTimeIntegrator(integrator)
+  call modelobj%ForwardStep(endtime,dt,iointerval)
+
+  ef = modelobj%entropy
+  if(ef /= ef) then
+    print*,"Error: Final entropy is inf or nan",ef
+    stop 1
+  endif
+
+  call modelobj%free()
+  call mesh%free() ! must NOT finalize MPI: the communicator is externally managed
+
+  call MPI_Finalized(mpiIsFinalized,ierror)
+  if(mpiIsFinalized) then
+    print*,"Error: SELF finalized MPI despite an externally provided communicator"
+    stop 1
+  endif
+
+  call geometry%free()
+  call interp%free()
+
+  call MPI_Comm_free(dupComm,ierror)
+  call mpi_finalize(ierror)
+
+endprogram structuredmesh_external_comm_3d

--- a/test/structuredmesh_external_comm_3d.f90
+++ b/test/structuredmesh_external_comm_3d.f90
@@ -54,7 +54,8 @@ program structuredmesh_external_comm_3d
   type(Mesh3D),target :: mesh
   type(SEMHex),target :: geometry
   integer :: bcids(1:6)
-  integer :: dupComm,ierror
+  integer :: dupComm,dupRank,dupSize
+  integer :: cmpResult,ierror
   logical :: mpiIsFinalized
 
   ! The caller owns the MPI lifecycle (mpi4py does exactly this on import).
@@ -70,6 +71,29 @@ program structuredmesh_external_comm_3d
 
   call mesh%StructuredMesh(5,5,5,1,1,1, &
                            0.2_prec,0.2_prec,0.2_prec,bcids,comm=dupComm)
+
+  ! The decomposition must be running on the communicator we handed over. A dup
+  ! of MPI_COMM_WORLD has the same size and rank ordering, so rank/size alone
+  ! cannot catch `comm` being dropped -- compare the handles instead. Note that
+  ! a dup is MPI_CONGRUENT with MPI_COMM_WORLD, so the telling check is that the
+  ! decomposition is not *identical* to MPI_COMM_WORLD.
+  call MPI_Comm_rank(dupComm,dupRank,ierror)
+  call MPI_Comm_size(dupComm,dupSize,ierror)
+  call MPI_Comm_compare(mesh%decomp%mpiComm,dupComm,cmpResult,ierror)
+  if(cmpResult /= MPI_IDENT .and. cmpResult /= MPI_CONGRUENT) then
+    print*,"Error: mesh decomposition is not using the provided communicator"
+    stop 1
+  endif
+  call MPI_Comm_compare(mesh%decomp%mpiComm,MPI_COMM_WORLD,cmpResult,ierror)
+  if(cmpResult == MPI_IDENT) then
+    print*,"Error: mesh decomposition fell back to MPI_COMM_WORLD instead of the provided communicator"
+    stop 1
+  endif
+  if(mesh%decomp%nRanks /= dupSize .or. mesh%decomp%rankId /= dupRank) then
+    print*,"Error: decomposition rank/size disagree with the provided communicator", &
+      mesh%decomp%rankId,dupRank,mesh%decomp%nRanks,dupSize
+    stop 1
+  endif
 
   call interp%Init(N=controlDegree, &
                    controlNodeType=GAUSS, &

--- a/test/structuredmesh_subcomm_2d.f90
+++ b/test/structuredmesh_subcomm_2d.f90
@@ -1,0 +1,149 @@
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+!
+! Maintainers : support@fluidnumerics.com
+! Official Repository : https://github.com/FluidNumerics/self/
+!
+! Copyright © 2024 Fluid Numerics LLC
+!
+! Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+!
+! 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+!    the documentation and/or other materials provided with the distribution.
+!
+! 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+!    this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+! HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+! LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+! THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+! THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+!
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+
+program structuredmesh_subcomm_2d
+!! Builds a mesh on a communicator that is a strict SUBSET of MPI_COMM_WORLD.
+!!
+!! structuredmesh_external_comm_2d passes a dup of MPI_COMM_WORLD, which has
+!! the same size and rank ordering as MPI_COMM_WORLD -- so it cannot tell a
+!! working implementation apart from one that quietly ignores `comm` and uses
+!! MPI_COMM_WORLD instead. This test can: the last world rank is excluded from
+!! the mesh communicator and never calls into SELF, so any collective SELF
+!! performs on MPI_COMM_WORLD deadlocks, and any size/rank SELF reads from
+!! MPI_COMM_WORLD disagrees with the subcommunicator.
+!!
+!! This is the shape a Python caller produces when it hands SELF a communicator
+!! from mpi4py that covers only the ranks assigned to the solver.
+
+  use self_data
+  use self_LinearEuler2D
+  use mpi
+
+  implicit none
+  real(prec),parameter :: rho0 = 1.225_prec
+  real(prec),parameter :: rhoprime = 0.01_prec
+  real(prec),parameter :: c = 1.0_prec
+  real(prec),parameter :: Lr = 0.06_prec
+  real(prec),parameter :: x0 = 0.5_prec
+  real(prec),parameter :: y0 = 0.5_prec
+  character(SELF_INTEGRATOR_LENGTH),parameter :: integrator = 'rk3'
+  integer,parameter :: controlDegree = 7
+  integer,parameter :: targetDegree = 15
+  real(prec),parameter :: dt = 2.0_prec*10.0_prec**(-4)
+  real(prec),parameter :: endtime = 5.0_prec*10.0_prec**(-3)
+  real(prec),parameter :: iointerval = 5.0_prec*10.0_prec**(-3)
+  real(prec) :: ef
+  type(LinearEuler2D) :: modelobj
+  type(Lagrange),target :: interp
+  type(Mesh2D),target :: mesh
+  type(SEMQuad),target :: geometry
+  integer :: bcids(1:4)
+  integer :: worldRank,worldSize
+  integer :: subComm,subRank,subSize,color
+  integer :: cmpResult,ierror
+
+  call mpi_init(ierror)
+  call MPI_Comm_rank(MPI_COMM_WORLD,worldRank,ierror)
+  call MPI_Comm_size(MPI_COMM_WORLD,worldSize,ierror)
+
+  ! Exclude the highest world rank from the solver communicator. With the
+  ! default two-rank test launch this leaves a single-rank subcommunicator;
+  ! with more ranks it leaves a genuine multi-rank decomposition.
+  if(worldRank < worldSize-1) then
+    color = 0
+  else
+    color = MPI_UNDEFINED
+  endif
+  call MPI_Comm_split(MPI_COMM_WORLD,color,worldRank,subComm,ierror)
+
+  if(color /= MPI_UNDEFINED) then
+
+    call MPI_Comm_rank(subComm,subRank,ierror)
+    call MPI_Comm_size(subComm,subSize,ierror)
+
+    bcids(1:4) = [SELF_BC_NONORMALFLOW, & ! South
+                  SELF_BC_NONORMALFLOW, & ! East
+                  SELF_BC_NONORMALFLOW, & ! North
+                  SELF_BC_NONORMALFLOW] ! West
+
+    call mesh%StructuredMesh(5,5,2,2,0.1_prec,0.1_prec,bcids,comm=subComm)
+
+    ! The decomposition must describe the subcommunicator, not MPI_COMM_WORLD.
+    call MPI_Comm_compare(mesh%decomp%mpiComm,subComm,cmpResult,ierror)
+    if(cmpResult /= MPI_IDENT .and. cmpResult /= MPI_CONGRUENT) then
+      print*,"Error: mesh decomposition is not using the provided communicator"
+      stop 1
+    endif
+    if(mesh%decomp%nRanks /= subSize .or. mesh%decomp%rankId /= subRank) then
+      print*,"Error: decomposition rank/size disagree with the subcommunicator", &
+        mesh%decomp%rankId,subRank,mesh%decomp%nRanks,subSize
+      stop 1
+    endif
+    if(mesh%decomp%nRanks == worldSize) then
+      print*,"Error: decomposition spans MPI_COMM_WORLD rather than the subcommunicator"
+      stop 1
+    endif
+
+    call interp%Init(N=controlDegree, &
+                     controlNodeType=GAUSS, &
+                     M=targetDegree, &
+                     targetNodeType=UNIFORM)
+
+    call geometry%Init(interp,mesh%nElem)
+    call geometry%GenerateFromMesh(mesh)
+
+    call modelobj%Init(mesh,geometry)
+    modelobj%prescribed_bcs_enabled = .false.
+    modelobj%tecplot_enabled = .false.
+    modelobj%rho0 = rho0
+
+    call modelobj%SphericalSoundWave(rhoprime,Lr,x0,y0,c)
+
+    call modelobj%SetTimeIntegrator(integrator)
+    call modelobj%ForwardStep(endtime,dt,iointerval)
+
+    ef = modelobj%entropy
+    if(ef /= ef) then
+      print*,"Error: Final entropy is inf or nan",ef
+      stop 1
+    endif
+
+    call modelobj%free()
+    call mesh%free() ! must NOT finalize MPI: the communicator is externally managed
+    call geometry%free()
+    call interp%free()
+
+    call MPI_Comm_free(subComm,ierror)
+
+  endif
+
+  ! Ranks outside the solver communicator rejoin here. Reaching this barrier
+  ! at all is the proof that SELF ran no MPI_COMM_WORLD collectives.
+  call MPI_Barrier(MPI_COMM_WORLD,ierror)
+
+  call mpi_finalize(ierror)
+
+endprogram structuredmesh_subcomm_2d


### PR DESCRIPTION
## Motivation

SELF currently owns the MPI lifecycle unconditionally: creating a mesh calls `MPI_Init`, freeing one calls `MPI_Finalize`. That is right when SELF's `main` is the program, and wrong when SELF is a library inside a host process that already runs MPI. The concrete driver is a Python front end where `import mpi4py.MPI` has already initialized MPI and will finalize it at interpreter exit — SELF cannot be allowed to do either. This is what SELF-UCT needs to run its forward solver multi-GPU from Python.

## What this does

Adds an optional `comm` argument to `DomainDecomposition%Init` and threads it through every mesh entry point — the structured constructors, the mortar mesh generators, and the HOPr/HOHQMesh readers, in 1-D, 2-D and 3-D. SELF uses legacy `use mpi` integer handles, so mpi4py's `comm.py2f()` passes straight through as a `c_int`; no `MPI_Comm_f2c` is involved.

When `comm` is provided the caller owns the lifecycle: SELF calls neither `MPI_Init` nor `MPI_Finalize`, and stops with a diagnostic if MPI is not already initialized. The communicator need not be `MPI_COMM_WORLD` or a duplicate of it — a subset communicator works, and ranks outside it never have to call into SELF.

**The MPI lifecycle is now reference-counted.** Guarding `MPI_Init` alone is not enough: with two meshes and no external communicator, the first gets `ownsMpi = .true.` and the second `.false.`, so freeing the first finalizes MPI while the second is still in use. Process-wide bookkeeping (`nLiveDecomps`, `selfInitializedMpi`) now sits behind two shared helpers, `AcquireMPI` and `ReleaseMPI`, which the CPU and GPU `Init`/`Free` implementations both call rather than each carrying its own copy of the logic. MPI is finalized only when SELF initialized it, and only once the last decomposition is freed. Several meshes can therefore coexist in one process — the normal case for a long-lived Python driver.

Two smaller fixes fall out of this:

- `initialized` was written but never read anywhere. It now guards the reference count against a double `Free`, and is cleared on the way out.
- `mpiComm` had no default initializer, so a mesh built through the plain `Init` path — which never initializes `decomp` — handed an undefined integer to MPI. It defaults to `MPI_COMM_NULL`.

On GPU, device assignment now derives from the node-local rank via `MPI_Comm_split_type(MPI_COMM_TYPE_SHARED)` rather than the global rank, so placement no longer depends on how the launcher orders ranks across nodes. `MPI_Abort` uses the decomposition's communicator instead of `MPI_COMM_WORLD`.

## Behavior change for existing callers

Without `comm`, behavior is the same except that `MPI_Init`/`MPI_Finalize` are now guarded rather than unconditional. Previously, creating two meshes in one process called `MPI_Init` twice, and freeing either called `MPI_Finalize`. Both are now correct.

## Tests

Five tests cover the external-communicator lifecycle:

| Test | Covers |
|---|---|
| `structuredmesh_external_comm_2d` / `_3d` | caller-initialized MPI, `StructuredMesh(comm=)`, a `LinearEuler` run, and that `mesh%free()` does not finalize MPI |
| `structuredmesh_subcomm_2d` | a mesh on a strict **subset** of `MPI_COMM_WORLD`; the excluded rank never enters SELF |
| `read_hopr_external_comm_2d` | `Read_HOPr(comm=)` — the only entry point that forwards the handle into parallel HDF5 |
| `domaindecomposition_two_meshes` | two meshes live at once with SELF owning MPI; freeing one must not finalize |

Note on the subset test: passing a *duplicate* of `MPI_COMM_WORLD` cannot distinguish this feature working from it being ignored, since a dup has the same size and rank ordering. The subset test can — a stray `MPI_COMM_WORLD` collective inside SELF would deadlock against the rank that never calls in, and the size disagrees. This was verified by temporarily making `AcquireMPI` ignore `comm`: the subset test fails, and that same experiment is what showed a `MPI_Comm_compare` assertion accepting `MPI_CONGRUENT` was too loose, so the dup-based tests now additionally assert the handle is not `MPI_IDENT` with `MPI_COMM_WORLD`.

Full suite is green: **139/139**, CPU build, FP64, `mpirun -n 2`.

## Not covered

- `SELF_MPIEXEC_NUMPROCS` is 2 everywhere in CI, so multi-neighbor halo grouping is never exercised regardless of this change.
- The node-local device selection only differs from the old global-rank behavior on multi-node runs, and no CI config allocates more than one node.
- No GitHub Actions workflow builds with `SELF_ENABLE_GPU=ON`, so `src/gpu/SELF_DomainDecomposition.f90` — the largest single file in this change — is not compiled by any PR-blocking check. It is covered by the buildkite MI210/V100 jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
