### PR TITLE
AMR Stage 7: local time stepping in 2-D

### DIFF
--- a/docs/Learning/AdaptiveMeshRefinement.md
+++ b/docs/Learning/AdaptiveMeshRefinement.md
@@ -716,14 +716,34 @@ demo cadence (Stage-6 device-side transfer remains the later optimization). Back
   exactly `h_root / 2^maxLevel`, so `dt_epoch = dt_base / 2^maxLevel` with `dt_base` chosen
   for the base mesh by the usual explicit-DG bound `dt ≈ C·h/(c·N²)`. Deterministic, free,
   and no geometry reduction is needed.
-- **Later (optional):** local time stepping (LTS) — leaves at level ℓ subcycle with
-  `dt/2^ℓ`. This touches the RK update and requires time-interpolated interface/mortar data
-  between levels, i.e. exactly the time-integration and flux-exchange machinery that is
-  frozen by policy; it needs its own design + review round (call it Stage 7). Cost analysis
-  for this demo says it is not needed to start: with the refined band confined to the
-  wavefront annulus, a global fine `dt` costs `nElem_total × fine-step-count`, and most
-  elements are coarse *and cheap*; LTS buys roughly `2^maxLevel×` on the coarse bulk — worth
-  having, not blocking.
+- **Local time stepping (Stage 7) — implemented**, opt-in, in
+  `src/SELF_LocalTimeStepping_2D.f90`. Leaves at level ℓ subcycle with `dtBase/2^ℓ` under a
+  Berger–Oliger recursion: advance level ℓ once, recurse twice on level ℓ+1 at half the step,
+  then reflux the interface. The enabling observation is that `EmitMesh` only ever emits a
+  conforming side between two leaves of the *same* level, so **every** level jump is a 2:1
+  mortar and all cross-rate coupling flows through `mortarInfo`; `SideExchange` stays purely
+  intra-level.
+
+  Coarse→fine coupling interpolates the big side's edge trace in time (quadratic through
+  `t0-dtP, t0, t0+dtP`, linear until the history is deep enough) and lets the ordinary
+  `MortarExchange` restrict it onto the small sides, so the MPI path is reused unchanged.
+  Fine→coarse coupling uses **flux registers**: because a Williamson 2N step telescopes into
+  `U^{n+1} = U^n + dt Σ_m c_m R_m` and the DG surface term enters `R` linearly through
+  `flux%boundaryNormal`, the time-integrated interface flux of each side can be accumulated
+  exactly and the difference applied afterwards. Conservation across a level interface is
+  therefore exact to round-off (verified at 1e-16 in `test/lts_2d_conservation.f90` on both a
+  two-level and a three-level mesh); for a *linear* system the correction is exact in full,
+  for a nonlinear one it is the standard AMR refluxing approximation.
+
+  Entry point: `ForwardStepLTS(model, sched, tn, dtBase, ioInterval)` — note it takes
+  `dtBase`, the level-0 step, not the level-derived global `dt` that `RecommendedTimeStep`
+  returns. Current scope: RK3 only, CPU only, hyperbolic (`gradient_enabled = .false.`)
+  only; each of those is a hard error rather than a silent fallback.
+
+  Cost analysis for the demo said this was worth having but not blocking: with the refined
+  band confined to the wavefront annulus, a global fine `dt` costs
+  `nElem_total × fine-step-count`, and most elements are coarse *and cheap*, so LTS buys
+  roughly `2^maxLevel×` on the coarse bulk.
 
 ### 5.5 Gap 4 — The example and its CI-scale test — **implemented**
 
@@ -774,7 +794,7 @@ band tracking the expanding wavefront.
   this needs a localized-forcing hook plus per-epoch source relocation (the containing
   element changes identity on regrid). Physically nicer (continuous-wave and pulse-train
   experiments); not required for the first demo.
-- **LTS (Stage 7)** as scoped in §5.4, and **device-side transfer (Stage 6)**.
+- **LTS on GPU and for parabolic (gradient-enabled) models** — the element-subset form of the operators is CPU-only for now; see §5.4.
 - **Storage compaction** of orphaned forest nodes on long runs (§4, Stage 2 "next").
 
 ### 5.8 Suggested PR sequence
@@ -785,7 +805,7 @@ band tracking the expanding wavefront.
 | 2 | AMR controller (halo flags, regrid orchestration, level-based dt) + adapt-epoch soundwave test | 1 |
 | 3 | Ultrasound example, CI-scale test, plotting script, docs | 2 |
 | 4 | GPU epoch test; device-side transfer (Stage 6a) and amortized capacity (Stage 6b) - both done, profiling justified them | 2 |
-| 5 | (design first) LTS; time-dependent point forcing | 3 |
+| 5 | LTS (done: element/mortar subsetting, Berger–Oliger recursion, flux registers); time-dependent point forcing | 3 |
 
 ---
 

--- a/examples/linear_euler2d_amr_ultrasound_pointsource.f90
+++ b/examples/linear_euler2d_amr_ultrasound_pointsource.f90
@@ -74,6 +74,11 @@ program LinearEuler2D_AMR_Ultrasound_PointSource
 !!   SELF_AMR_ULTRASOUND_LR        source half-width in m, overriding the maxLevel-derived
 !!                                 value; f0 ~ c0/(4*Lr).
 !!   SELF_AMR_ULTRASOUND_EPOCHLEN  adaptation cadence in s, overriding stepsPerEpoch * dt.
+!!   SELF_AMR_ULTRASOUND_LTS       set to anything other than "0" to use local time stepping
+!!                                 (AMR Stage 7): level ell advances at dtBase/2**ell rather
+!!                                 than every element paying dtBase/2**maxLevel. Default off,
+!!                                 so CI stays on the single-rate path; the BENCH_ block
+!!                                 reports which was used, so a sweep is interpretable.
 !!
 !! The run prints a CONFIG_* block (resolved resolution, f0, points per wavelength) and a
 !! BENCH_* block (wall-clock split between time integration and adaptation) so a sweep over
@@ -89,6 +94,7 @@ program LinearEuler2D_AMR_Ultrasound_PointSource
   use self_mesh_2d
   use SELF_Geometry_2D
   use SELF_AMRController_2D
+  use SELF_LocalTimeStepping_2D
 
   implicit none
 
@@ -121,6 +127,8 @@ program LinearEuler2D_AMR_Ultrasound_PointSource
   integer :: nEpochs,epoch,i,envstat
   integer :: maxLevel
   logical :: adapted
+  logical :: useLTS
+  type(LTSSchedule2D) :: ltsSched
   real(prec) :: e0,ef,dt
   real(prec) :: Lr,LrRamp,epochLength,hFinest,lambda,f0,ppw
   character(32) :: envstr
@@ -136,6 +144,16 @@ program LinearEuler2D_AMR_Ultrasound_PointSource
   call get_environment_variable("SELF_AMR_ULTRASOUND_EPOCHS",envstr,status=envstat)
   if(envstat == 0) then
     read(envstr,*) nEpochs
+  endif
+
+  ! Local time stepping (AMR Stage 7), off by default so the CI timings and the reference
+  ! output stay on the single-rate path. With it on, level ell is advanced at dtBase/2**ell
+  ! instead of every element paying the finest level's rate; the wavefront band is thin, so
+  ! the coarse bulk is where the saving is. CPU builds only - see SELF_LocalTimeStepping_2D.
+  useLTS = .false.
+  call get_environment_variable("SELF_AMR_ULTRASOUND_LTS",envstr,status=envstat)
+  if(envstat == 0) then
+    useLTS = (trim(envstr) /= "0")
   endif
 
   ! ---- Refinement depth and the quantities that must track it ----
@@ -262,12 +280,24 @@ program LinearEuler2D_AMR_Ultrasound_PointSource
   tAdapt = 0.0_real64
   nStepsTotal = 0
   do epoch = 1,nEpochs
-    dt = controller%RecommendedTimeStep(dtBase)
+    ! With local time stepping the level-0 elements keep dtBase and level ell subcycles at
+    ! dtBase/2**ell, so the single-rate level-derived dt is exactly what LTS avoids paying
+    ! on the coarse bulk. dt is still reported for the epoch print, as the finest rate in use.
+    if(useLTS) then
+      dt = dtBase
+    else
+      dt = controller%RecommendedTimeStep(dtBase)
+    endif
     call system_clock(c0clk)
-    ! ioInterval = (tn - t) exactly, so ForwardStep's io count is exactly 1 per epoch
-    ! regardless of accumulated floating-point drift in t.
-    call modelobj%ForwardStep(tn=modelobj%t+epochLength,dt=dt, &
-                              ioInterval=(modelobj%t+epochLength)-modelobj%t)
+    ! ioInterval = (tn - t) exactly, so the io count is exactly 1 per epoch regardless of
+    ! accumulated floating-point drift in t.
+    if(useLTS) then
+      call ForwardStepLTS(modelobj,ltsSched,tn=modelobj%t+epochLength,dtBase=dtBase, &
+                          ioInterval=(modelobj%t+epochLength)-modelobj%t)
+    else
+      call modelobj%ForwardStep(tn=modelobj%t+epochLength,dt=dt, &
+                                ioInterval=(modelobj%t+epochLength)-modelobj%t)
+    endif
     call system_clock(c1clk)
     call controller%Adapt(modelobj,adapted)
     call system_clock(c2clk)
@@ -281,6 +311,11 @@ program LinearEuler2D_AMR_Ultrasound_PointSource
   ! ---- Wall-clock summary (fixed BENCH_ keys for machine parsing) ----
   tSim = real(nEpochs,real64)*real(epochLength,real64)
   write(output_unit,'(A)') "BENCH_case = ultrasound_pointsource"
+  if(useLTS) then
+    write(output_unit,'(A)') "BENCH_timeStepping = lts"
+  else
+    write(output_unit,'(A)') "BENCH_timeStepping = global"
+  endif
   write(output_unit,'(A,I0)') "BENCH_nEpochs = ",nEpochs
   write(output_unit,'(A,I0)') "BENCH_nSteps = ",nStepsTotal
   write(output_unit,'(A,I0)') "BENCH_nElemFinal = ",modelobj%mesh%nElem
@@ -315,6 +350,7 @@ program LinearEuler2D_AMR_Ultrasound_PointSource
     stop 1
   endif
 
+  call ltsSched%Free()
   call modelobj%Free()
   call controller%Free()
   call geometry%Free()

--- a/src/SELF_AMRController_2D.f90
+++ b/src/SELF_AMRController_2D.f90
@@ -713,6 +713,11 @@ contains
     !! level, so a time step dtBase that is stable on the base (level-0) mesh scales to
     !! dtBase / 2**MaxLevel on the current forest. Deterministic and exact for the quadtree
     !! (child elements are exact half-scale subdivisions); no geometry reduction is needed.
+    !!
+    !! This is the SINGLE-RATE time step: every element is advanced at the rate the finest
+    !! level demands. Callers using local time stepping (SELF_LocalTimeStepping_2D) should
+    !! NOT pass this to ForwardStepLTS - that routine takes dtBase itself and derives
+    !! dtBase / 2**ell per level internally, which is the whole point of the scheme.
     implicit none
     class(AMRController2D),intent(in) :: this
     real(prec),intent(in) :: dtBase

--- a/src/SELF_AdaptiveMesh_2D.f90
+++ b/src/SELF_AdaptiveMesh_2D.f90
@@ -79,6 +79,7 @@ contains
     ! Local
     integer :: nEl,nGeo,nBCs,li,s,node,nbr,ns,nf,e,ne,k
     integer :: m,nMortar,gid,gidA,gidB,t1,t2,c1,c2,es1,es2
+    integer,allocatable :: mlevel(:)
     integer :: eFirst,eLast,nLocal
     type(Lagrange) :: geomInterp
     integer,allocatable :: leafIdx(:)
@@ -109,6 +110,7 @@ contains
     allocate(si(1:5,1:4,1:nEl))
     si = 0
     allocate(minfo(1:8,1:4*nEl)) ! upper bound: at most one mortar per leaf face
+    allocate(mlevel(1:4*nEl))
     nMortar = 0
     gid = 0
 
@@ -180,6 +182,8 @@ contains
           minfo(6,m) = 10*ns+nf
           minfo(7,m) = gidA
           minfo(8,m) = gidB
+          ! Level of the BIG side; the two small elements are one level finer.
+          mlevel(m) = forest%level(node)
         endif
       enddo
     enddo
@@ -230,17 +234,28 @@ contains
       outMesh%elemMaterial(li-eFirst+1) = forest%rootMaterial(forest%rootElem(forest%leaf(li)))
     enddo
 
+    ! Refinement level of each leaf (quadtree depth), for the rank-local slice; maxElemLevel
+    ! is taken from the (rank-replicated) forest and so is identical on every rank. Because
+    ! a conforming side is only ever emitted between two leaves of the same level, every
+    ! level jump recorded here coincides with a mortar entry in mortarInfo.
+    outMesh%maxElemLevel = forest%MaxLevel()
+    do li = eFirst,eLast
+      outMesh%elemLevel(li-eFirst+1) = forest%level(forest%leaf(li))
+    enddo
+
     ! Mortar table.
     outMesh%nMortars = nMortar
     if(associated(outMesh%mortarInfo)) deallocate(outMesh%mortarInfo)
     if(nMortar > 0) then
       allocate(outMesh%mortarInfo(1:8,1:nMortar))
       outMesh%mortarInfo(1:8,1:nMortar) = minfo(1:8,1:nMortar)
+      allocate(outMesh%mortarLevel(1:nMortar))
+      outMesh%mortarLevel(1:nMortar) = mlevel(1:nMortar)
     else
       outMesh%mortarInfo => null()
     endif
 
-    deallocate(leafIdx,si,minfo,coords)
+    deallocate(leafIdx,si,minfo,mlevel,coords)
     call geomInterp%Free()
 
     call outMesh%UpdateDevice()

--- a/src/SELF_DGModel2D_t.f90
+++ b/src/SELF_DGModel2D_t.f90
@@ -59,7 +59,22 @@ module SELF_DGModel2D_t
     !! stages device-side instead, leaving this unallocated.
     real(prec),allocatable :: transferStage(:,:,:,:)
 
+    !! Active subsets for local time stepping (AMR Stage 7). While a refinement level is
+    !! being advanced, activeElem lists the rank-local elements of that level and
+    !! activeMortar lists the mortars it participates in (as the big side or as a small
+    !! side); every tendency and RK-update loop below is then restricted to those lists.
+    !!
+    !! Both are NULL in normal (single-rate) operation, which every subset-aware operator
+    !! reads as "the whole mesh" - so the default path is the original full traversal, with
+    !! identical loop order and arithmetic. The lists are owned by the LTS schedule, not by
+    !! the model; the model only points at them for the duration of a substep. See
+    !! SELF_LocalTimeStepping_2D and ResolveIndexList in SELF_Data.
+    integer,pointer,contiguous :: activeElem(:) => null()
+    integer,pointer,contiguous :: activeMortar(:) => null()
+
   contains
+
+    procedure :: ActiveElements => ActiveElements_DGModel2D_t
 
     procedure :: Init => Init_DGModel2D_t
     procedure :: SetMetadata => SetMetadata_DGModel2D_t
@@ -99,6 +114,19 @@ module SELF_DGModel2D_t
   endtype DGModel2D_t
 
 contains
+
+  subroutine ActiveElements_DGModel2D_t(this,eidx,ne)
+    !! Resolve the model's active element subset into the index list eidx(1:ne) that the
+    !! model's own loops traverse. With no subset set (the single-rate default) this returns
+    !! the identity list over 1:mesh%nElem, so the loops are the original ones.
+    implicit none
+    class(DGModel2D_t),intent(in) :: this
+    integer,pointer,contiguous,intent(out) :: eidx(:)
+    integer,intent(out) :: ne
+
+    call ResolveIndexList(this%solution%allElem,this%mesh%nElem,this%activeElem,eidx,ne)
+
+  endsubroutine ActiveElements_DGModel2D_t
 
   subroutine Init_DGModel2D_t(this,mesh,geometry)
     implicit none
@@ -385,7 +413,8 @@ contains
     real(prec),optional,intent(in) :: dt
     ! Local
     real(prec) :: dtLoc
-    integer :: i,j,iEl,iVar
+    integer :: i,j,ie,iEl,iVar,ne
+    integer,pointer,contiguous :: eidx(:)
 
     if(present(dt)) then
       dtLoc = dt
@@ -393,9 +422,12 @@ contains
       dtLoc = this%dt
     endif
 
-    do concurrent(i=1:this%solution%N+1,j=1:this%solution%N+1, &
-                  iel=1:this%mesh%nElem,ivar=1:this%nstepped)
+    call this%ActiveElements(eidx,ne)
 
+    do concurrent(i=1:this%solution%N+1,j=1:this%solution%N+1, &
+                  ie=1:ne,ivar=1:this%nstepped)
+
+      iEl = eidx(ie)
       this%solution%interior(i,j,iEl,iVar) = &
         this%solution%interior(i,j,iEl,iVar)+ &
         dtLoc*this%dSdt%interior(i,j,iEl,iVar)
@@ -409,11 +441,15 @@ contains
     class(DGModel2D_t),intent(inout) :: this
     integer,intent(in) :: m
     ! Local
-    integer :: i,j,iEl,iVar
+    integer :: i,j,ie,iEl,iVar,ne
+    integer,pointer,contiguous :: eidx(:)
+
+    call this%ActiveElements(eidx,ne)
 
     do concurrent(i=1:this%solution%N+1,j=1:this%solution%N+1, &
-                  iel=1:this%mesh%nElem,ivar=1:this%nstepped)
+                  ie=1:ne,ivar=1:this%nstepped)
 
+      iEl = eidx(ie)
       this%workSol%interior(i,j,iEl,iVar) = rk2_a(m)* &
                                             this%workSol%interior(i,j,iEl,iVar)+ &
                                             this%dSdt%interior(i,j,iEl,iVar)
@@ -431,11 +467,15 @@ contains
     class(DGModel2D_t),intent(inout) :: this
     integer,intent(in) :: m
     ! Local
-    integer :: i,j,iEl,iVar
+    integer :: i,j,ie,iEl,iVar,ne
+    integer,pointer,contiguous :: eidx(:)
+
+    call this%ActiveElements(eidx,ne)
 
     do concurrent(i=1:this%solution%N+1,j=1:this%solution%N+1, &
-                  iel=1:this%mesh%nElem,ivar=1:this%nstepped)
+                  ie=1:ne,ivar=1:this%nstepped)
 
+      iEl = eidx(ie)
       this%workSol%interior(i,j,iEl,iVar) = rk3_a(m)* &
                                             this%workSol%interior(i,j,iEl,iVar)+ &
                                             this%dSdt%interior(i,j,iEl,iVar)
@@ -453,11 +493,15 @@ contains
     class(DGModel2D_t),intent(inout) :: this
     integer,intent(in) :: m
     ! Local
-    integer :: i,j,iEl,iVar
+    integer :: i,j,ie,iEl,iVar,ne
+    integer,pointer,contiguous :: eidx(:)
+
+    call this%ActiveElements(eidx,ne)
 
     do concurrent(i=1:this%solution%N+1,j=1:this%solution%N+1, &
-                  iel=1:this%mesh%nElem,ivar=1:this%nstepped)
+                  ie=1:ne,ivar=1:this%nstepped)
 
+      iEl = eidx(ie)
       this%workSol%interior(i,j,iEl,iVar) = rk4_a(m)* &
                                             this%workSol%interior(i,j,iEl,iVar)+ &
                                             this%dSdt%interior(i,j,iEl,iVar)
@@ -474,21 +518,21 @@ contains
     implicit none
     class(DGModel2D_t),intent(inout) :: this
 
-    call this%solution%AverageSides()
+    call this%solution%AverageSides(this%activeElem)
 
     call this%solution%MappedDGGradient(this%solutionGradient%interior)
 
     ! interpolate the solutiongradient to the element boundaries
-    call this%solutionGradient%BoundaryInterp()
+    call this%solutionGradient%BoundaryInterp(this%activeElem)
 
     ! perform the side exchange to populate the
     ! solutionGradient % extBoundary attribute
-    call this%solutionGradient%SideExchange(this%mesh)
+    call this%solutionGradient%SideExchange(this%mesh,this%activeElem)
 
     ! populate the solutionGradient % extBoundary attribute on
     ! nonconforming (mortar) interfaces
     if(this%mesh%nMortars > 0) then
-      call this%solutionGradient%MortarExchange(this%mesh)
+      call this%solutionGradient%MortarExchange(this%mesh,this%activeMortar)
     endif
 
   endsubroutine CalculateSolutionGradient_DGModel2D_t
@@ -532,14 +576,18 @@ contains
     implicit none
     class(DGModel2D_t),intent(inout) :: this
     ! Local
-    integer :: iel
+    integer :: ie,iel,ne
+    integer,pointer,contiguous :: eidx(:)
     integer :: i
     integer :: j
     real(prec) :: s(1:this%nvar),dsdx(1:this%nvar,1:2)
 
-    do concurrent(i=1:this%solution%N+1,j=1:this%solution%N+1, &
-                  iel=1:this%mesh%nElem)
+    call this%ActiveElements(eidx,ne)
 
+    do concurrent(i=1:this%solution%N+1,j=1:this%solution%N+1, &
+                  ie=1:ne)
+
+      iel = eidx(ie)
       s = this%solution%interior(i,j,iel,1:this%nvar)
       dsdx = this%solutionGradient%interior(i,j,iel,1:this%nvar,1:2)
       this%flux%interior(i,j,iel,1:this%nvar,1:2) = this%flux2d(s,dsdx)
@@ -555,16 +603,20 @@ contains
     implicit none
     class(DGModel2D_t),intent(inout) :: this
     ! Local
-    integer :: iel
+    integer :: ie,iel,ne
+    integer,pointer,contiguous :: eidx(:)
     integer :: j
     integer :: i
     real(prec) :: sL(1:this%nvar),sR(1:this%nvar)
     real(prec) :: dsdx(1:this%nvar,1:2)
     real(prec) :: nhat(1:2),nmag
 
-    do concurrent(i=1:this%solution%N+1,j=1:4, &
-                  iel=1:this%mesh%nElem)
+    call this%ActiveElements(eidx,ne)
 
+    do concurrent(i=1:this%solution%N+1,j=1:4, &
+                  ie=1:ne)
+
+      iel = eidx(ie)
       ! Get the boundary normals on cell edges from the mesh geometry
       nhat = this%geometry%nHat%boundary(i,j,iEl,1,1:2)
       sL = this%solution%boundary(i,j,iel,1:this%nvar) ! interior solution
@@ -582,14 +634,18 @@ contains
     implicit none
     class(DGModel2D_t),intent(inout) :: this
     ! Local
-    integer :: iel
+    integer :: ie,iel,ne
+    integer,pointer,contiguous :: eidx(:)
     integer :: i
     integer :: j
     real(prec) :: s(1:this%nvar),dsdx(1:this%nvar,1:2)
 
-    do concurrent(i=1:this%solution%N+1,j=1:this%solution%N+1, &
-                  iel=1:this%mesh%nElem)
+    call this%ActiveElements(eidx,ne)
 
+    do concurrent(i=1:this%solution%N+1,j=1:this%solution%N+1, &
+                  ie=1:ne)
+
+      iel = eidx(ie)
       s = this%solution%interior(i,j,iel,1:this%nvar)
       dsdx = this%solutionGradient%interior(i,j,iel,1:this%nvar,1:2)
       this%source%interior(i,j,iel,1:this%nvar) = this%source2d(s,dsdx)
@@ -716,18 +772,27 @@ contains
   endsubroutine setgradientboundarycondition_DGModel2D_t
 
   subroutine CalculateTendency_DGModel2D_t(this)
+    !! Evaluate dSdt over the model's active element subset (the whole mesh unless local
+    !! time stepping has restricted it - see DGModel2D_t%activeElem).
+    !!
+    !! The subset is threaded into every stage. It is safe to restrict BoundaryInterp to
+    !! the active elements alone because a conforming side only ever joins elements of the
+    !! same refinement level, so an active level's neighbours across conforming sides are
+    !! themselves active; the only cross-level coupling is through the mortars listed in
+    !! activeMortar, whose off-level traces the caller supplies.
     implicit none
     class(DGModel2D_t),intent(inout) :: this
     ! Local
-    integer :: i,j,iEl,iVar
+    integer :: i,j,ie,iEl,iVar,ne
+    integer,pointer,contiguous :: eidx(:)
 
-    call this%solution%BoundaryInterp()
-    call this%solution%SideExchange(this%mesh)
+    call this%solution%BoundaryInterp(this%activeElem)
+    call this%solution%SideExchange(this%mesh,this%activeElem)
 
     ! populate the solution % extBoundary attribute on nonconforming
     ! (mortar) interfaces
     if(this%mesh%nMortars > 0) then
-      call this%solution%MortarExchange(this%mesh)
+      call this%solution%MortarExchange(this%mesh,this%activeMortar)
     endif
 
     call this%PreTendencyHook() ! User-supplied
@@ -736,7 +801,7 @@ contains
     if(this%gradient_enabled) then
       call this%CalculateSolutionGradient()
       call this%SetGradientBoundaryCondition() ! User-supplied
-      call this%solutionGradient%AverageSides()
+      call this%solutionGradient%AverageSides(this%activeElem)
     endif
 
     call this%SourceMethod() ! User supplied
@@ -745,16 +810,19 @@ contains
     ! On mortar interfaces, replace the big side's surface-flux integrand with the
     ! projection of the small sides' integrands so that the interface is conservative
     if(this%mesh%nMortars > 0) then
-      call this%flux%MortarFluxCollect(this%mesh)
+      call this%flux%MortarFluxCollect(this%mesh,this%activeMortar)
     endif
 
     call this%FluxMethod() ! User supplied
 
-    call this%flux%MappedDGDivergence(this%fluxDivergence%interior)
+    call this%flux%MappedDGDivergence(this%fluxDivergence%interior,this%activeElem)
+
+    call this%ActiveElements(eidx,ne)
 
     do concurrent(i=1:this%solution%N+1,j=1:this%solution%N+1, &
-                  iel=1:this%mesh%nElem,ivar=1:this%solution%nVar)
+                  ie=1:ne,ivar=1:this%solution%nVar)
 
+      iEl = eidx(ie)
       this%dSdt%interior(i,j,iEl,iVar) = &
         this%source%interior(i,j,iEl,iVar)- &
         this%fluxDivergence%interior(i,j,iEl,iVar)

--- a/src/SELF_Data.f90
+++ b/src/SELF_Data.f90
@@ -57,6 +57,23 @@ module SELF_Data
     type(Metadata),allocatable :: meta(:)
     type(EquationParser),allocatable :: eqn(:)
 
+    !! Identity element list (/1,2,...,nElem/), the default argument for the element-subset
+    !! form of the tensor-product operators. Operators that accept an optional elems(:)
+    !! argument loop over a resolved index list; when the caller passes nothing they loop
+    !! over this list instead, which reproduces the plain 1:nElem traversal exactly (same
+    !! trip count, same order, same arithmetic) and so is bitwise identical to the
+    !! subset-free code. Kept as a member rather than rebuilt per call so that operators
+    !! declaring intent(in) on the object can still use it and no allocation happens in a
+    !! hot path. Built by MapArrays (i.e. by both Init and Resize).
+    integer,pointer,contiguous :: allElem(:) => null()
+
+    !! Identity mortar list (/1,2,...,nMortars/), the same idea for the operators whose
+    !! subset is a list of 2:1 nonconforming interfaces rather than of elements. Unlike
+    !! allElem this cannot be built by MapArrays, because the mortar count belongs to the
+    !! mesh and not to the field; it is built on first use next to the mortar staging
+    !! buffer, and released here so that a pointer component does not outlive the object.
+    integer,pointer,contiguous :: allMortar(:) => null()
+
   contains
 
     ! Procedures for setting metadata for
@@ -74,6 +91,100 @@ module SELF_Data
   integer,parameter :: selfWeakBRForm = 3
 
 contains
+
+! -- Subset helpers -- !
+!
+! The subset-aware form of the tensor-product operators replaces a `do ... = 1, n` loop over
+! every element (or every mortar) with a loop over an explicit index list. Local time
+! stepping uses this to evaluate a tendency on one refinement level at a time; every
+! pre-existing caller passes no list at all and gets the full traversal, unchanged.
+
+  subroutine EnsureIndexList(allIdx,n)
+    !! Make allIdx the identity list (/1,...,n/), reallocating only when the length is wrong.
+    !! Called from each data type's MapArrays for the element list, and lazily for the mortar
+    !! list (whose length is a property of the mesh, not of the field), so that no allocation
+    !! happens in a hot path.
+    implicit none
+    integer,pointer,contiguous,intent(inout) :: allIdx(:)
+    integer,intent(in) :: n
+    ! Local
+    integer :: i
+
+    if(associated(allIdx)) then
+      if(size(allIdx) /= n) then
+        deallocate(allIdx)
+        allIdx => null()
+      endif
+    endif
+
+    if(.not. associated(allIdx)) then
+      allocate(allIdx(1:n))
+      do i = 1,n
+        allIdx(i) = i
+      enddo
+    endif
+
+  endsubroutine EnsureIndexList
+
+  subroutine ResolveIndexList(allIdx,n,subset,idx,ns)
+    !! Resolve the optional subset argument of a subset-aware operator into the index list
+    !! idx(1:ns) that its loops traverse.
+    !!
+    !! When subset is present and associated the operator touches only those entries. When it
+    !! is absent - or present but disassociated - the identity list is used, so `idx(i) == i`
+    !! and `ns == n`: the loop is the original 1:n loop, with the same trip count, order and
+    !! arithmetic, hence bitwise unchanged. Treating a null pointer as "no subset" lets a
+    !! caller thread an optional subset straight through without branching on it.
+    !!
+    !! Indices are RANK-LOCAL for elements and GLOBAL (replicated) for mortars, matching the
+    !! arrays they index. No bounds check is made; these are inner-loop paths.
+    !!
+    !! subset is a POINTER dummy rather than a TARGET dummy on purpose: associating idx with
+    !! the target of a pointer is well defined for as long as that target lives, whereas
+    !! associating it with a plain TARGET dummy would leave idx undefined the moment this
+    !! routine returns. Callers therefore hold their lists as pointers (see the local time
+    !! stepping schedule), and callers that want everything simply omit the argument.
+    implicit none
+    integer,pointer,contiguous,intent(in) :: allIdx(:)
+    integer,intent(in) :: n
+    integer,pointer,contiguous,intent(in),optional :: subset(:)
+    integer,pointer,contiguous,intent(out) :: idx(:)
+    integer,intent(out) :: ns
+
+    if(present(subset)) then
+      if(associated(subset)) then
+        idx => subset
+        ns = size(subset)
+        return
+      endif
+    endif
+
+    idx => allIdx
+    ns = n
+
+  endsubroutine ResolveIndexList
+
+  subroutine RejectSubset(subset,file,line)
+    !! Guard for backends that have no subset kernel. The GPU operators flatten the element
+    !! dimension into a single degree-of-freedom count, so restricting them needs an index
+    !! argument threaded through the kernels; until that exists, silently ignoring the subset
+    !! would produce a wrong answer, so it is an error. Passing no subset is always accepted,
+    !! which is every pre-existing call site.
+    implicit none
+    integer,pointer,contiguous,intent(in),optional :: subset(:)
+    character(*),intent(in) :: file
+    integer,intent(in) :: line
+
+    if(present(subset)) then
+      if(associated(subset)) then
+        print*,file,':',line, &
+          ' : Error : subset operators (local time stepping) are not implemented '// &
+          'for this backend. Build for CPU to use local time stepping.'
+        stop 1
+      endif
+    endif
+
+  endsubroutine RejectSubset
 
 ! -- DataObj -- !
 

--- a/src/SELF_LocalTimeStepping_2D.f90
+++ b/src/SELF_LocalTimeStepping_2D.f90
@@ -1,0 +1,799 @@
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+!
+! Maintainers : support@fluidnumerics.com
+! Official Repository : https://github.com/FluidNumerics/self/
+!
+! Copyright © 2024 Fluid Numerics LLC
+!
+! Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+!
+! 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+!    the documentation and/or other materials provided with the distribution.
+!
+! 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+!    this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+! HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+! LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+! THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+! THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+!
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+
+module SELF_LocalTimeStepping_2D
+!! Local time stepping (LTS) for the 2-D adaptive solver - AMR Stage 7.
+!!
+!! Under the level-based global time step, every element is advanced at the rate the FINEST
+!! level requires: `dt = dtBase / 2**maxLevel` (AMRController2D%RecommendedTimeStep). The
+!! coarse bulk, which is nearly all of the mesh in a typical wavefront-tracking run, is then
+!! over-resolved in time by a factor of `2**maxLevel`. LTS removes that: elements at
+!! refinement level ell are advanced at `dtBase / 2**ell`, so each element is stepped at the
+!! rate its own size demands.
+!!
+!! ## Why the level interfaces are the whole problem
+!!
+!! EmitMesh only ever emits a conforming side between two leaves of the SAME level; every
+!! level jump is a 2:1 mortar (SELF_AdaptiveMesh_2D). Therefore:
+!!
+!!    all coupling between different time-step sizes flows through mesh%mortarInfo.
+!!
+!! Within a level, SideExchange behaves exactly as it always has - the neighbours of a
+!! level-ell element across conforming sides are themselves at level ell, and are being
+!! advanced by the same substep. Only the mortars need new machinery.
+!!
+!! ## The scheme : Berger-Oliger recursion with conservative refluxing
+!!
+!! One macro step of size dt0 = dtBase is
+!!
+!!   StepLevel(0, dt0):  advance level 0 by dt0
+!!                       StepLevel(1, dt0/2) ; StepLevel(1, dt0/2)
+!!                       reflux the level-0/1 interfaces
+!!
+!! and StepLevel recurses to maxLevel. At the end of a macro step every level has reached
+!! t0 + dt0, so entropy diagnostics, file IO and AMR adaptation see a globally synchronized
+!! state and need no changes.
+!!
+!! Coupling in each direction:
+!!
+!!   coarse -> fine.  The coarse element has already finished its step when the fine
+!!     substeps run, so its stored edge trace is at the wrong time. Before each fine RK
+!!     stage the big side's trace is overwritten with a time interpolation of a short
+!!     history (`bigTrace`), and the ordinary MortarExchange then restricts it onto the
+!!     small sides exactly as before - including over MPI, since MortarExchange already
+!!     ships the big trace to the small sides' ranks. Quadratic interpolation through
+!!     t0-dtC, t0, t0+dtC is used once the history is deep enough (third order, matching
+!!     RK3); linear at the start of a run and after each adaptation epoch.
+!!
+!!   fine -> coarse.  During the coarse stages the fine traces are still at t0 - the
+!!     standard Berger-Oliger lag - so the coarse element temporarily sees a lagged
+!!     interface flux. Both what it used and what the fine level actually used are
+!!     accumulated into flux registers, and Reflux then replaces the former with the
+!!     latter. Refluxing is what makes the interface conservative; it also restores the
+!!     accuracy of the interface flux, so the lag does not degrade the coarse solution.
+!!
+!! ## Why the flux registers are exact
+!!
+!! For a Williamson 2N low-storage scheme (`S_m = a_m S_{m-1} + R_m`, `U_m = U_{m-1} +
+!! g_m dt S_m`) a full step telescopes into a plain weighted sum of the stage tendencies,
+!!
+!!     U^{n+1} = U^n + dt ( c_1 R_1 + c_2 R_2 + c_3 R_3 )
+!!     c_3 = g_3,  c_2 = g_2 + g_3 a_3,  c_1 = g_1 + g_2 a_2 + g_3 a_3 a_2
+!!
+!! (`rk3StageWeight` below; the weights sum to one, which is the consistency condition).
+!! The DG surface term enters R linearly through flux%boundaryNormal, so accumulating
+!! `c_m * dt * boundaryNormal` over the stages gives the exact time-integrated interface
+!! flux of the step, and adding the surface term of a register DIFFERENCE afterwards
+!! reproduces exactly the update that a different interface flux would have produced.
+!!
+!! One honest caveat: the coarse element's INTERMEDIATE stage values still saw the lagged
+!! flux. For a linear system - LinearEuler2D and LinearShallowWater2D, the models AMR
+!! targets - the correction is therefore exact. For a nonlinear system it is the standard
+!! AMR refluxing approximation: conservation is exact either way, the stage states are not.
+!!
+!! ## Scope and guards (this stage)
+!!
+!!   - RK3 only. The recursion and the registers are written around the 2N weights above.
+!!   - CPU only. The GPU operators flatten the element dimension into one degree-of-freedom
+!!     count and have no element-subset kernel; passing a subset to them is a hard error
+!!     (RejectSubset in SELF_Data), which is what stops a GPU build silently single-rating.
+!!   - Hyperbolic only (gradient_enabled = .false.). Parabolic terms across a level
+!!     interface need the gradient traces interpolated in time as well.
+!!
+!! See docs/Learning/AdaptiveMeshRefinement.md section 5.4 for how this fits the AMR staging.
+
+  use SELF_Constants
+  use SELF_Mesh_2D
+  use SELF_Model
+  use SELF_DGModel2D
+
+  implicit none
+
+  !! Register selectors for AccumulateRegister.
+  integer,parameter :: LTS_REG_COARSE = 1 !! what the interface's own (big) level used
+  integer,parameter :: LTS_REG_FINE = 2 !! what the level one finer used, projected
+
+  !! Per-level index lists. All three are GLOBAL mortar indices or RANK-LOCAL element
+  !! indices, matching what the subset-aware operators expect.
+  type :: LTSLevel2D
+    !! Rank-local elements at this level.
+    integer,pointer,contiguous :: elems(:) => null()
+    !! Mortars this level touches at all, as the big side or as a small side. This is the
+    !! subset handed to MortarExchange while the level is being advanced.
+    integer,pointer,contiguous :: mortars(:) => null()
+    !! Mortars where this level is the BIG side (mortarLevel == this level). These are the
+    !! interfaces this level must reflux after its children have caught up.
+    integer,pointer,contiguous :: mortarsBig(:) => null()
+    !! Mortars where this level is a SMALL side (mortarLevel == this level - 1). These are
+    !! the interfaces whose big-side trace must be interpolated in time for this level, and
+    !! whose flux this level contributes to the parent's register.
+    integer,pointer,contiguous :: mortarsSmall(:) => null()
+    !! Number of valid slots in the big-side trace history of this level's mortarsBig:
+    !! 0 before the first step, 1 after seeding, 2 (linear), 3 (quadratic).
+    integer :: historyDepth = 0
+    !! Start time of the step whose end value sits in history slot 3, i.e. slot 2 was
+    !! captured at windowStart and slot 3 at windowStart + this level's dt. A child level
+    !! interpolates its parent's trace against this window.
+    real(prec) :: windowStart = 0.0_prec
+  endtype LTSLevel2D
+
+  type :: LTSSchedule2D
+    logical :: built = .false.
+    integer :: maxLevel = 0
+    integer :: nMortars = 0
+    integer :: N = 0
+    integer :: nVar = 0
+    type(LTSLevel2D),allocatable :: level(:) ! 0:maxLevel
+
+    !! Flux registers, in the BIG side's trace space, indexed by global mortar id.
+    !! regCoarse is the time-integrated interface flux the big side actually used over its
+    !! own step; regFine is the time-integrated flux the two fine substeps used, already
+    !! projected onto the big side by MortarFluxCollect. Reflux applies the difference.
+    real(prec),allocatable :: regCoarse(:,:,:) ! (N+1, nVar, nMortars)
+    real(prec),allocatable :: regFine(:,:,:)
+    !! Big-side edge trace history for time interpolation, slots (t-dt, t, t+dt) in
+    !! 1,2,3 with 3 the most recent. Only the rank owning the big element fills its entry.
+    real(prec),allocatable :: bigTrace(:,:,:,:) ! (N+1, nVar, 3, nMortars)
+
+  contains
+    procedure,public :: Build => Build_LTSSchedule2D
+    procedure,public :: Free => Free_LTSSchedule2D
+    procedure,public :: Matches => Matches_LTSSchedule2D
+  endtype LTSSchedule2D
+
+contains
+
+  pure function rk3StageWeight(m) result(c)
+    !! Effective quadrature weight of stage m in a full Williamson 2N RK3 step:
+    !! U^{n+1} = U^n + dt * sum_m c_m R_m. Derived once from rk3_a and rk3_g rather than
+    !! hard-coded, so the registers cannot drift away from the integrator's coefficients.
+    implicit none
+    integer,intent(in) :: m
+    real(prec) :: c
+
+    select case(m)
+    case(1)
+      c = rk3_g(1)+rk3_g(2)*rk3_a(2)+rk3_g(3)*rk3_a(3)*rk3_a(2)
+    case(2)
+      c = rk3_g(2)+rk3_g(3)*rk3_a(3)
+    case default
+      c = rk3_g(3)
+    endselect
+
+  endfunction rk3StageWeight
+
+! ---------------------------------------------------------------------------------------- !
+!  Schedule construction
+! ---------------------------------------------------------------------------------------- !
+
+  subroutine Build_LTSSchedule2D(this,mesh,N,nVar)
+    !! Derive the per-level element and mortar lists from mesh%elemLevel and
+    !! mesh%mortarLevel, and size the registers and trace history.
+    !!
+    !! The element lists are rank-local; the mortar lists are global and identical on every
+    !! rank, because mortarInfo and mortarLevel are replicated. That is what lets every rank
+    !! walk the same recursion and post matching messages even for levels on which it owns
+    !! no elements.
+    implicit none
+    class(LTSSchedule2D),intent(inout) :: this
+    type(Mesh2D),intent(in) :: mesh
+    integer,intent(in) :: N
+    integer,intent(in) :: nVar
+    ! Local
+    integer :: L,e,m,n1,n2,n3,n4,lvl
+
+    call this%Free()
+
+    this%maxLevel = mesh%maxElemLevel
+    this%nMortars = mesh%nMortars
+    this%N = N
+    this%nVar = nVar
+
+    allocate(this%level(0:this%maxLevel))
+
+    do L = 0,this%maxLevel
+
+      ! Pass 1 : count. Pass 2 : fill. Element ids ascend, so each list is sorted, which
+      ! keeps the restricted loops in the same relative order as the unrestricted ones.
+      n1 = 0
+      do e = 1,mesh%nElem
+        if(mesh%elemLevel(e) == L) n1 = n1+1
+      enddo
+      allocate(this%level(L)%elems(1:n1))
+      n1 = 0
+      do e = 1,mesh%nElem
+        if(mesh%elemLevel(e) == L) then
+          n1 = n1+1
+          this%level(L)%elems(n1) = e
+        endif
+      enddo
+
+      n2 = 0
+      n3 = 0
+      n4 = 0
+      do m = 1,mesh%nMortars
+        lvl = mesh%mortarLevel(m)
+        if(lvl == L) then
+          n2 = n2+1
+          n3 = n3+1
+        elseif(lvl == L-1) then
+          n2 = n2+1
+          n4 = n4+1
+        endif
+      enddo
+      allocate(this%level(L)%mortars(1:n2))
+      allocate(this%level(L)%mortarsBig(1:n3))
+      allocate(this%level(L)%mortarsSmall(1:n4))
+      n2 = 0
+      n3 = 0
+      n4 = 0
+      do m = 1,mesh%nMortars
+        lvl = mesh%mortarLevel(m)
+        if(lvl == L) then
+          n2 = n2+1
+          this%level(L)%mortars(n2) = m
+          n3 = n3+1
+          this%level(L)%mortarsBig(n3) = m
+        elseif(lvl == L-1) then
+          n2 = n2+1
+          this%level(L)%mortars(n2) = m
+          n4 = n4+1
+          this%level(L)%mortarsSmall(n4) = m
+        endif
+      enddo
+
+      this%level(L)%historyDepth = 0
+
+    enddo
+
+    if(this%nMortars > 0) then
+      allocate(this%regCoarse(1:N+1,1:nVar,1:this%nMortars))
+      allocate(this%regFine(1:N+1,1:nVar,1:this%nMortars))
+      allocate(this%bigTrace(1:N+1,1:nVar,1:3,1:this%nMortars))
+      this%regCoarse = 0.0_prec
+      this%regFine = 0.0_prec
+      this%bigTrace = 0.0_prec
+    endif
+
+    this%built = .true.
+
+  endsubroutine Build_LTSSchedule2D
+
+  logical function Matches_LTSSchedule2D(this,mesh,N,nVar) result(ok)
+    !! Is this schedule still the one for the given mesh? Used to rebuild lazily after an
+    !! adaptation epoch has replaced the mesh under the model.
+    implicit none
+    class(LTSSchedule2D),intent(in) :: this
+    type(Mesh2D),intent(in) :: mesh
+    integer,intent(in) :: N
+    integer,intent(in) :: nVar
+
+    ok = this%built .and. &
+         this%maxLevel == mesh%maxElemLevel .and. &
+         this%nMortars == mesh%nMortars .and. &
+         this%N == N .and. &
+         this%nVar == nVar
+
+    if(ok) then
+      ! Element counts are the cheap discriminator between two meshes that happen to share
+      ! a level cap and mortar count.
+      ok = (size(this%level(0)%elems)+CountAbove(this,0)) == mesh%nElem
+    endif
+
+  endfunction Matches_LTSSchedule2D
+
+  integer function CountAbove(sched,L) result(n)
+    !! Total number of rank-local elements at levels above L.
+    implicit none
+    class(LTSSchedule2D),intent(in) :: sched
+    integer,intent(in) :: L
+    ! Local
+    integer :: k
+
+    n = 0
+    do k = L+1,sched%maxLevel
+      n = n+size(sched%level(k)%elems)
+    enddo
+
+  endfunction CountAbove
+
+  subroutine Free_LTSSchedule2D(this)
+    implicit none
+    class(LTSSchedule2D),intent(inout) :: this
+    ! Local
+    integer :: L
+
+    if(allocated(this%level)) then
+      do L = lbound(this%level,1),ubound(this%level,1)
+        if(associated(this%level(L)%elems)) deallocate(this%level(L)%elems)
+        if(associated(this%level(L)%mortars)) deallocate(this%level(L)%mortars)
+        if(associated(this%level(L)%mortarsBig)) deallocate(this%level(L)%mortarsBig)
+        if(associated(this%level(L)%mortarsSmall)) deallocate(this%level(L)%mortarsSmall)
+        this%level(L)%elems => null()
+        this%level(L)%mortars => null()
+        this%level(L)%mortarsBig => null()
+        this%level(L)%mortarsSmall => null()
+      enddo
+      deallocate(this%level)
+    endif
+
+    if(allocated(this%regCoarse)) deallocate(this%regCoarse)
+    if(allocated(this%regFine)) deallocate(this%regFine)
+    if(allocated(this%bigTrace)) deallocate(this%bigTrace)
+
+    this%built = .false.
+    this%maxLevel = 0
+    this%nMortars = 0
+    this%N = 0
+    this%nVar = 0
+
+  endsubroutine Free_LTSSchedule2D
+
+! ---------------------------------------------------------------------------------------- !
+!  The recursion
+! ---------------------------------------------------------------------------------------- !
+
+  subroutine ForwardStepLTS(model,sched,tn,dtBase,ioInterval)
+    !! Advance the model to tn with local time stepping, writing output every ioInterval.
+    !!
+    !! dtBase is the time step for the BASE (level-0) mesh - not the level-derived global dt
+    !! that AMRController2D%RecommendedTimeStep returns. Level ell is advanced at
+    !! dtBase / 2**ell, so the stability constraint each level sees is its own.
+    !!
+    !! This deliberately mirrors ForwardStep_Model (entropy, metrics, model and tecplot
+    !! output on the same cadence) rather than hooking into SetTimeIntegrator, so that local
+    !! time stepping is opt-in and the single-rate path is untouched.
+    implicit none
+    class(DGModel2D_t),intent(inout) :: model
+    type(LTSSchedule2D),intent(inout) :: sched
+    real(prec),intent(in) :: tn
+    real(prec),intent(in) :: dtBase
+    real(prec),intent(in) :: ioInterval
+    ! Local
+    integer :: i,nIO
+    real(prec) :: targetTime,tNext,tStep
+
+    call GuardLTS(model)
+
+    if(.not. sched%Matches(model%mesh,model%solution%interp%N,model%solution%nVar)) then
+      call sched%Build(model%mesh,model%solution%interp%N,model%solution%nVar)
+    endif
+
+    model%dt = dtBase
+    targetTime = tn
+    nIO = int((targetTime-model%t)/ioInterval)
+
+    do i = 1,nIO
+
+      tNext = model%t+ioInterval
+
+      do while(model%t < tNext)
+        call model%PreStepHook()
+        ! tStep is a COPY of model%t on purpose. StepLevel writes model%t as it walks the
+        ! RK stages, so passing model%t directly would alias its own t0 argument and the
+        ! stage times would shift under it.
+        tStep = model%t
+        call StepLevel(model,sched,0,min(dtBase,tNext-model%t),tStep)
+        call model%PostStepHook()
+      enddo
+
+      model%t = tNext
+
+      call model%CalculateEntropy()
+      call model%ReportEntropy()
+      call model%ReportMetrics()
+
+      call model%WriteModel()
+      if(model%tecplot_enabled) then
+        call model%WriteTecplot()
+      endif
+      call model%IncrementIOCounter()
+
+    enddo
+
+  endsubroutine ForwardStepLTS
+
+  subroutine GuardLTS(model)
+    !! Reject the configurations this stage does not implement, loudly and up front rather
+    !! than as a wrong answer. The CPU-only restriction is additionally enforced deeper down
+    !! by RejectSubset, which fires as soon as a GPU operator is handed a subset.
+    implicit none
+    class(DGModel2D_t),intent(in) :: model
+    ! Local
+    integer :: m
+
+    if(model%gradient_enabled) then
+      print*,__FILE__,':',__LINE__, &
+        ' : Error : local time stepping does not support gradient-enabled (parabolic) '// &
+        'models; the gradient traces across a level interface are not time-interpolated.'
+      stop 1
+    endif
+
+    if(model%mesh%nMortars > 0) then
+      if(.not. allocated(model%mesh%mortarLevel)) then
+        print*,__FILE__,':',__LINE__, &
+          ' : Error : local time stepping needs mesh%mortarLevel, which this mesh does '// &
+          'not carry. Emit the mesh from a quadtree forest (EmitMesh) or use one of the '// &
+          'built-in mortar meshes.'
+        stop 1
+      endif
+      do m = 1,model%mesh%nMortars
+        if(model%mesh%mortarLevel(m) < 0 .or. &
+           model%mesh%mortarLevel(m) > model%mesh%maxElemLevel-1) then
+          print*,__FILE__,':',__LINE__, &
+            ' : Error : mortar ',m,' has big-side level ',model%mesh%mortarLevel(m), &
+            ' which is not one level below the mesh level cap ',model%mesh%maxElemLevel, &
+            '. The forest must be 2:1 balanced.'
+          stop 1
+        endif
+      enddo
+    endif
+
+  endsubroutine GuardLTS
+
+  recursive subroutine StepLevel(model,sched,L,dt,t0)
+    !! Advance every element at refinement level L by dt, then recurse twice on level L+1 at
+    !! dt/2 and reflux the level-L/L+1 interfaces.
+    implicit none
+    class(DGModel2D_t),intent(inout) :: model
+    type(LTSSchedule2D),intent(inout) :: sched
+    integer,intent(in) :: L
+    real(prec),intent(in) :: dt
+    real(prec),intent(in) :: t0
+    ! Local
+    integer :: m
+    real(prec) :: dtSave,tBase
+
+    ! Copy t0 before touching model%t. A caller may legitimately hand us its own t0 dummy
+    ! (the recursive calls below do), which is ultimately anchored to model%t; reading t0
+    ! after model%t has been advanced would then read the advanced value.
+    tBase = t0
+    dtSave = model%dt
+
+    ! Registers for the interfaces this level owns are re-opened for this step: regCoarse
+    ! fills during the stages below, regFine during the level-(L+1) substeps that follow.
+    call ZeroRegisters(sched,L)
+
+    ! Seed the big-side trace history the first time this level is stepped, so that the
+    ! children have a t0 value to interpolate from.
+    if(sched%level(L)%historyDepth == 0 .and. size(sched%level(L)%mortarsBig) > 0) then
+      call model%solution%BoundaryInterp(sched%level(L)%elems)
+      call CaptureBigTrace(model,sched,L)
+      sched%level(L)%historyDepth = 1
+    endif
+    call ShiftBigTrace(sched,L)
+
+    ! ---- Advance level L with the low-storage RK3, stage times exactly as in
+    !      LowStorageRK3_timeIntegrator ----
+    model%dt = dt
+    model%t = tBase
+    model%activeElem => sched%level(L)%elems
+    model%activeMortar => sched%level(L)%mortars
+
+    do m = 1,3
+      ! The big sides of this level's mortarsSmall belong to level L-1, which has already
+      ! finished its step; give them their trace at the current stage time.
+      call WriteInterpolatedBigTrace(model,sched,L,model%t,dt)
+
+      call model%CalculateTendency()
+
+      ! flux%boundaryNormal now holds this stage's mortar surface integrand, already
+      ! projected from the small sides by MortarFluxCollect. Bank it in both directions:
+      ! as "what the big side used" for the interfaces this level owns, and as "what the
+      ! fine level used" for the interfaces its parent owns.
+      call AccumulateRegister(model,sched,L,LTS_REG_COARSE,rk3StageWeight(m)*dt)
+      call AccumulateRegister(model,sched,L,LTS_REG_FINE,rk3StageWeight(m)*dt)
+
+      call model%UpdateGRK3(m)
+      model%t = tBase+rk3_b(m)*dt
+    enddo
+
+    model%t = tBase+dt
+    model%activeElem => null()
+    model%activeMortar => null()
+    sched%level(L)%windowStart = tBase
+
+    ! Record the level's new big-side trace at t0+dt, completing the interpolation window
+    ! [t0, t0+dt] the children are about to step across.
+    call model%solution%BoundaryInterp(sched%level(L)%elems)
+    call CaptureBigTrace(model,sched,L)
+    sched%level(L)%historyDepth = min(sched%level(L)%historyDepth+1,3)
+
+    ! ---- Children, then reflux ----
+    if(L < sched%maxLevel) then
+      call StepLevel(model,sched,L+1,0.5_prec*dt,tBase)
+      call StepLevel(model,sched,L+1,0.5_prec*dt,tBase+0.5_prec*dt)
+      call Reflux(model,sched,L)
+      ! The reflux changed the big elements' interiors, so the trace captured above is
+      ! stale; refresh it before the children read it again.
+      call model%solution%BoundaryInterp(sched%level(L)%elems)
+      call CaptureBigTrace(model,sched,L)
+      model%t = tBase+dt
+    endif
+
+    model%dt = dtSave
+
+  endsubroutine StepLevel
+
+! ---------------------------------------------------------------------------------------- !
+!  Big-side trace history and time interpolation
+! ---------------------------------------------------------------------------------------- !
+
+  subroutine ShiftBigTrace(sched,L)
+    !! Age the history of this level's big-side traces by one step: (t-dt, t, t+dt) becomes
+    !! the window ending at the value about to be overwritten.
+    implicit none
+    type(LTSSchedule2D),intent(inout) :: sched
+    integer,intent(in) :: L
+    ! Local
+    integer :: k,m
+
+    do k = 1,size(sched%level(L)%mortarsBig)
+      m = sched%level(L)%mortarsBig(k)
+      sched%bigTrace(:,:,1,m) = sched%bigTrace(:,:,2,m)
+      sched%bigTrace(:,:,2,m) = sched%bigTrace(:,:,3,m)
+    enddo
+
+  endsubroutine ShiftBigTrace
+
+  subroutine CaptureBigTrace(model,sched,L)
+    !! Copy the current big-side edge trace of every mortar this level owns into the newest
+    !! history slot. Only the rank that owns the big element has the trace, and only that
+    !! rank needs it: MortarExchange is what ships it to the small sides' ranks.
+    implicit none
+    class(DGModel2D_t),intent(in) :: model
+    type(LTSSchedule2D),intent(inout) :: sched
+    integer,intent(in) :: L
+    ! Local
+    integer :: k,m,eB,sB,offset,rankId
+
+    rankId = model%mesh%decomp%rankId
+    offset = model%mesh%decomp%offsetElem(rankId+1)
+
+    do k = 1,size(sched%level(L)%mortarsBig)
+      m = sched%level(L)%mortarsBig(k)
+      eB = model%mesh%mortarInfo(1,m)
+      if(model%mesh%decomp%elemToRank(eB) /= rankId) cycle
+      sB = model%mesh%mortarInfo(2,m)
+      sched%bigTrace(1:sched%N+1,1:sched%nVar,3,m) = &
+        model%solution%boundary(1:sched%N+1,sB,eB-offset,1:sched%nVar)
+    enddo
+
+  endsubroutine CaptureBigTrace
+
+  subroutine WriteInterpolatedBigTrace(model,sched,L,t,dtChild)
+    !! For every mortar in which level L is a small side, overwrite the big element's stored
+    !! edge trace with the parent's trace interpolated to time t, so that the MortarExchange
+    !! inside CalculateTendency restricts a time-accurate value onto the small sides.
+    !!
+    !! This is safe to do to a live solution object: the big element belongs to level L-1,
+    !! which is not being advanced now, and its trace is recomputed by BoundaryInterp the
+    !! next time its own level steps.
+    !!
+    !! The interpolation is quadratic through the history slots (t0-dtP, t0, t0+dtP) once
+    !! three are valid - third order, matching RK3 - and linear on (t0, t0+dtP) before then,
+    !! which is the case on the first parent step of a run and just after an adaptation
+    !! epoch has reset the history.
+    implicit none
+    class(DGModel2D_t),intent(inout) :: model
+    type(LTSSchedule2D),intent(inout) :: sched
+    integer,intent(in) :: L
+    real(prec),intent(in) :: t
+    real(prec),intent(in) :: dtChild
+    ! Local
+    integer :: k,m,eB,sB,offset,rankId,i,ivar,depth
+    real(prec) :: dtParent,tParent0,s,w1,w2,w3
+
+    if(L == 0) return
+    if(size(sched%level(L)%mortarsSmall) == 0) return
+
+    depth = sched%level(L-1)%historyDepth
+    if(depth < 2) return ! nothing to interpolate between yet; leave the stored trace alone
+
+    rankId = model%mesh%decomp%rankId
+    offset = model%mesh%decomp%offsetElem(rankId+1)
+
+    ! The parent's step is twice this level's, and its history window ends at the parent's
+    ! current time; slot 2 sits one parent step back from slot 3.
+    dtParent = 2.0_prec*dtChild
+    tParent0 = sched%level(L-1)%windowStart
+    s = (t-tParent0)/dtParent
+
+    if(depth >= 3) then
+      ! Lagrange through s = -1, 0, 1 (history slots 1, 2, 3)
+      w1 = 0.5_prec*s*(s-1.0_prec)
+      w2 = 1.0_prec-s*s
+      w3 = 0.5_prec*s*(s+1.0_prec)
+    else
+      w1 = 0.0_prec
+      w2 = 1.0_prec-s
+      w3 = s
+    endif
+
+    do k = 1,size(sched%level(L)%mortarsSmall)
+      m = sched%level(L)%mortarsSmall(k)
+      eB = model%mesh%mortarInfo(1,m)
+      if(model%mesh%decomp%elemToRank(eB) /= rankId) cycle
+      sB = model%mesh%mortarInfo(2,m)
+      do ivar = 1,sched%nVar
+        do i = 1,sched%N+1
+          model%solution%boundary(i,sB,eB-offset,ivar) = &
+            w1*sched%bigTrace(i,ivar,1,m)+ &
+            w2*sched%bigTrace(i,ivar,2,m)+ &
+            w3*sched%bigTrace(i,ivar,3,m)
+        enddo
+      enddo
+    enddo
+
+  endsubroutine WriteInterpolatedBigTrace
+
+! ---------------------------------------------------------------------------------------- !
+!  Flux registers and refluxing
+! ---------------------------------------------------------------------------------------- !
+
+  subroutine ZeroRegisters(sched,L)
+    !! Re-open both registers for the interfaces level L owns.
+    implicit none
+    type(LTSSchedule2D),intent(inout) :: sched
+    integer,intent(in) :: L
+    ! Local
+    integer :: k,m
+
+    if(sched%nMortars == 0) return
+
+    do k = 1,size(sched%level(L)%mortarsBig)
+      m = sched%level(L)%mortarsBig(k)
+      sched%regCoarse(:,:,m) = 0.0_prec
+      sched%regFine(:,:,m) = 0.0_prec
+    enddo
+
+  endsubroutine ZeroRegisters
+
+  subroutine AccumulateRegister(model,sched,L,which,weight)
+    !! Add weight * flux%boundaryNormal(big side) to one of the registers, over the mortars
+    !! that level L owns (which = LTS_REG_COARSE) or in which it is a small side
+    !! (which = LTS_REG_FINE).
+    !!
+    !! By the time this is called, MortarFluxCollect has already replaced the big side's
+    !! integrand with the L2 projection of the two small sides' integrands, so a single read
+    !! serves both roles: for the level that owns the interface it is the flux that level
+    !! used; for the level below it, it is the exact projection of what the fine sides used.
+    implicit none
+    class(DGModel2D_t),intent(in) :: model
+    type(LTSSchedule2D),intent(inout) :: sched
+    integer,intent(in) :: L
+    integer,intent(in) :: which
+    real(prec),intent(in) :: weight
+    ! Local
+    integer :: k,m,eB,sB,offset,rankId,i,ivar,nm
+
+    if(sched%nMortars == 0) return
+
+    if(which == LTS_REG_COARSE) then
+      nm = size(sched%level(L)%mortarsBig)
+    else
+      nm = size(sched%level(L)%mortarsSmall)
+    endif
+    if(nm == 0) return
+
+    rankId = model%mesh%decomp%rankId
+    offset = model%mesh%decomp%offsetElem(rankId+1)
+
+    do k = 1,nm
+      if(which == LTS_REG_COARSE) then
+        m = sched%level(L)%mortarsBig(k)
+      else
+        m = sched%level(L)%mortarsSmall(k)
+      endif
+      eB = model%mesh%mortarInfo(1,m)
+      if(model%mesh%decomp%elemToRank(eB) /= rankId) cycle
+      sB = model%mesh%mortarInfo(2,m)
+      do ivar = 1,sched%nVar
+        do i = 1,sched%N+1
+          if(which == LTS_REG_COARSE) then
+            sched%regCoarse(i,ivar,m) = sched%regCoarse(i,ivar,m)+ &
+                                        weight*model%flux%boundaryNormal(i,sB,eB-offset,ivar)
+          else
+            sched%regFine(i,ivar,m) = sched%regFine(i,ivar,m)+ &
+                                      weight*model%flux%boundaryNormal(i,sB,eB-offset,ivar)
+          endif
+        enddo
+      enddo
+    enddo
+
+  endsubroutine AccumulateRegister
+
+  subroutine Reflux(model,sched,L)
+    !! Replace, on every interface level L owns, the time-integrated flux the big side used
+    !! with the one the fine level actually used.
+    !!
+    !! The DG surface term of MappedDGDivergence contributes, for a change Delta in the
+    !! boundaryNormal of side sB,
+    !!
+    !!    dF(i,j) += B_sB(i,j;Delta) / J(i,j)
+    !!
+    !! with B given per side by the bMatrix/qWeights combinations below, and dSdt = source -
+    !! dF. Over a full RK3 step the solution therefore picked up -B(regCoarse)/J from this
+    !! interface where it should have picked up -B(regFine)/J, so the correction is
+    !!
+    !!    U(i,j) += B(regCoarse - regFine)(i,j) / J(i,j)
+    !!
+    !! which is exactly conservative because regFine is, by construction, minus the sum of
+    !! the small sides' own time-integrated surface integrals (see MortarFluxCollect).
+    implicit none
+    class(DGModel2D_t),intent(inout) :: model
+    type(LTSSchedule2D),intent(in) :: sched
+    integer,intent(in) :: L
+    ! Local
+    integer :: k,m,eB,sB,offset,rankId,i,j,ivar,Np
+    real(prec) :: d,surf
+
+    rankId = model%mesh%decomp%rankId
+    offset = model%mesh%decomp%offsetElem(rankId+1)
+    Np = sched%N+1
+
+    do k = 1,size(sched%level(L)%mortarsBig)
+      m = sched%level(L)%mortarsBig(k)
+      eB = model%mesh%mortarInfo(1,m)
+      if(model%mesh%decomp%elemToRank(eB) /= rankId) cycle
+      sB = model%mesh%mortarInfo(2,m)
+
+      do ivar = 1,model%nstepped
+        do j = 1,Np
+          do i = 1,Np
+
+            select case(sB)
+            case(1) ! South : the trace runs along i
+              d = sched%regCoarse(i,ivar,m)-sched%regFine(i,ivar,m)
+              surf = model%solution%interp%bMatrix(j,1)*d/ &
+                     model%solution%interp%qWeights(j)
+            case(2) ! East : the trace runs along j
+              d = sched%regCoarse(j,ivar,m)-sched%regFine(j,ivar,m)
+              surf = model%solution%interp%bMatrix(i,2)*d/ &
+                     model%solution%interp%qWeights(i)
+            case(3) ! North : the trace runs along i
+              d = sched%regCoarse(i,ivar,m)-sched%regFine(i,ivar,m)
+              surf = model%solution%interp%bMatrix(j,2)*d/ &
+                     model%solution%interp%qWeights(j)
+            case default ! West : the trace runs along j
+              d = sched%regCoarse(j,ivar,m)-sched%regFine(j,ivar,m)
+              surf = model%solution%interp%bMatrix(i,1)*d/ &
+                     model%solution%interp%qWeights(i)
+            endselect
+
+            model%solution%interior(i,j,eB-offset,ivar) = &
+              model%solution%interior(i,j,eB-offset,ivar)+ &
+              surf/model%geometry%J%interior(i,j,eB-offset,1)
+
+          enddo
+        enddo
+      enddo
+
+    enddo
+
+  endsubroutine Reflux
+
+endmodule SELF_LocalTimeStepping_2D

--- a/src/SELF_MappedScalar_2D_t.f90
+++ b/src/SELF_MappedScalar_2D_t.f90
@@ -93,6 +93,8 @@ contains
 
     call Resize_Scalar2D_t(this,interp,nVar,nElem)
     if(allocated(this%mortarBuff)) deallocate(this%mortarBuff)
+    if(associated(this%allMortar)) deallocate(this%allMortar)
+    this%allMortar => null()
 
     ! The geometry binding refers to the PREVIOUS mesh's geometry, which the caller is
     ! about to destroy. It must be dropped here so the AssociateGeometry that follows a
@@ -158,20 +160,29 @@ contains
 
   endsubroutine SetInteriorFromEquation_MappedScalar2D_t
 
-  subroutine MPIExchangeAsync_MappedScalar2D_t(this,mesh)
+  subroutine MPIExchangeAsync_MappedScalar2D_t(this,mesh,elems)
+    !! Post the non-blocking sends/receives for the rank-shared conforming sides. elems
+    !! restricts this to a subset of rank-local elements; because a conforming side always
+    !! joins two elements of the same refinement level, restricting both ranks to the same
+    !! level keeps the send/receive pairing intact.
     implicit none
     class(MappedScalar2D_t),intent(inout) :: this
     type(Mesh2D),intent(inout) :: mesh
+    integer,pointer,contiguous,intent(in),optional :: elems(:)
     ! Local
-    integer :: e1,s1,e2,s2,ivar
+    integer :: ie,e1,s1,e2,s2,ivar,ne
+    integer,pointer,contiguous :: eidx(:)
     integer :: globalSideId,r2,tag
     integer :: iError
     integer :: msgCount
 
+    call ResolveIndexList(this%allElem,this%nElem,elems,eidx,ne)
+
     msgCount = 0
 
     do ivar = 1,this%nvar
-      do e1 = 1,this%nElem
+      do ie = 1,ne
+        e1 = eidx(ie)
         do s1 = 1,4
 
           e2 = mesh%sideInfo(3,s1,e1) ! Neighbor Element
@@ -211,19 +222,25 @@ contains
 
   endsubroutine MPIExchangeAsync_MappedScalar2D_t
 
-  subroutine ApplyFlip_MappedScalar2D_t(this,mesh)
-    ! Apply side flips to sides where MPI exchanges took place.
+  subroutine ApplyFlip_MappedScalar2D_t(this,mesh,elems)
+    ! Apply side flips to sides where MPI exchanges took place. elems must match the subset
+    ! passed to MPIExchangeAsync, so that exactly the sides that were received get flipped.
     implicit none
     class(MappedScalar2D_t),intent(inout) :: this
     type(Mesh2D),intent(in) :: mesh
+    integer,pointer,contiguous,intent(in),optional :: elems(:)
     ! Local
-    integer :: e1,s1,e2,s2
+    integer :: ie,e1,s1,e2,s2,ne
+    integer,pointer,contiguous :: eidx(:)
     integer :: i,i2
     integer :: r2,flip,ivar
     real(prec) :: extBuff(1:this%interp%N+1)
 
+    call ResolveIndexList(this%allElem,this%nElem,elems,eidx,ne)
+
     do ivar = 1,this%nvar
-      do e1 = 1,this%nElem
+      do ie = 1,ne
+        e1 = eidx(ie)
         do s1 = 1,4
 
           e2 = mesh%sideInfo(3,s1,e1) ! Neighbor Element (global id)
@@ -258,17 +275,28 @@ contains
 
   endsubroutine ApplyFlip_MappedScalar2D_t
 
-  subroutine SideExchange_MappedScalar2D_t(this,mesh)
+  subroutine SideExchange_MappedScalar2D_t(this,mesh,elems)
+    !! Copy each conforming side's neighbour trace into extBoundary.
+    !!
+    !! elems restricts the exchange to a subset of rank-local elements. Conforming sides
+    !! only ever join elements of equal refinement level (every level jump in the mesh is a
+    !! mortar instead), so a per-level subset is closed under this exchange: every side of
+    !! an element in the subset has its partner in the same level, hence in the matching
+    !! subset on the owning rank.
     implicit none
     class(MappedScalar2D_t),intent(inout) :: this
     type(Mesh2D),intent(inout) :: mesh
+    integer,pointer,contiguous,intent(in),optional :: elems(:)
     ! Local
-    integer :: e1,e2,s1,s2,e2Global
+    integer :: ie,e1,e2,s1,s2,e2Global,ne
+    integer,pointer,contiguous :: eidx(:)
     integer :: flip
     integer :: i1,i2,ivar
     integer :: r2
     integer :: rankId,offset,N
     integer,pointer :: elemtorank(:)
+
+    call ResolveIndexList(this%allElem,this%nElem,elems,eidx,ne)
 
     ! This mapping is needed to resolve a build error with
     ! amdflang that appears to be caused by referencing
@@ -280,11 +308,12 @@ contains
     N = this%interp%N
 
     if(mesh%decomp%mpiEnabled) then
-      call this%MPIExchangeAsync(mesh)
+      call this%MPIExchangeAsync(mesh,elems)
     endif
 
-    do concurrent(s1=1:4,e1=1:mesh%nElem,ivar=1:this%nvar)
+    do concurrent(s1=1:4,ie=1:ne,ivar=1:this%nvar)
 
+      e1 = eidx(ie)
       e2Global = mesh%sideInfo(3,s1,e1)
       e2 = e2Global-offset
       s2 = mesh%sideInfo(4,s1,e1)/10
@@ -316,33 +345,42 @@ contains
     if(mesh%decomp%mpiEnabled) then
       call mesh%decomp%FinalizeMPIExchangeAsync()
       ! Apply side flips for data exchanged with MPI
-      call this%ApplyFlip(mesh)
+      call this%ApplyFlip(mesh,elems)
     endif
 
   endsubroutine SideExchange_MappedScalar2D_t
 
-  subroutine MPIMortarExchangeAsync_MappedScalar2D_t(this,mesh)
+  subroutine MPIMortarExchangeAsync_MappedScalar2D_t(this,mesh,mortars)
     !! Posts the point-to-point messages required for mortar interfaces whose big and
     !! small elements reside on different ranks. The big-side rank sends its edge trace
     !! to each remote small-side rank and receives each remote small-side trace; tags
     !! are built from the sub-edge global side ids, following the conforming SideExchange
     !! tag convention.
+    !!
+    !! mortars restricts this to a subset of the (rank-replicated) mortar table. The table
+    !! and the subset are identical on every rank, so both ends of each message agree on
+    !! which mortars are being exchanged.
     implicit none
     class(MappedScalar2D_t),intent(inout) :: this
     type(Mesh2D),intent(inout) :: mesh
+    integer,pointer,contiguous,intent(in),optional :: mortars(:)
     ! Local
-    integer :: m,k,ivar
+    integer :: im,m,k,ivar,nm
+    integer,pointer,contiguous :: midx(:)
     integer :: eB,sB,rB,eS,sS,rS
     integer :: globalSideId,tag
     integer :: offset
     integer :: iError
     integer :: msgCount
 
+    call ResolveIndexList(this%allMortar,mesh%nMortars,mortars,midx,nm)
+
     msgCount = 0
     offset = mesh%decomp%offsetElem(mesh%decomp%rankId+1)
 
     do ivar = 1,this%nvar
-      do m = 1,mesh%nMortars
+      do im = 1,nm
+        m = midx(im)
 
         eB = mesh%mortarInfo(1,m)
         sB = mesh%mortarInfo(2,m)
@@ -402,7 +440,7 @@ contains
 
   endsubroutine MPIMortarExchangeAsync_MappedScalar2D_t
 
-  subroutine MortarExchange_MappedScalar2D_t(this,mesh)
+  subroutine MortarExchange_MappedScalar2D_t(this,mesh,mortars)
     !! Fills the extBoundary attribute on all sides that participate in a 2:1
     !! nonconforming (mortar) interface.
     !!
@@ -414,11 +452,19 @@ contains
     !! sides' orientations and the big side's orientation. Must be called after
     !! BoundaryInterp and may be called before, after, or without SideExchange (the
     !! side sets touched are disjoint from conforming sides).
+    !!
+    !! mortars restricts the exchange to a subset of the mortar table, leaving every other
+    !! mortar's extBoundary untouched. Local time stepping uses this to exchange only the
+    !! level interfaces that the level it is advancing actually touches; note that a mortar
+    !! joins two DIFFERENT levels, so a per-level mortar subset must list every mortar in
+    !! which the level appears as either the big or a small side.
     implicit none
     class(MappedScalar2D_t),intent(inout) :: this
     type(Mesh2D),intent(inout) :: mesh
+    integer,pointer,contiguous,intent(in),optional :: mortars(:)
     ! Local
-    integer :: m,k,ivar,i,ii
+    integer :: im,m,k,ivar,i,ii,nm
+    integer,pointer,contiguous :: midx(:)
     integer :: eB,sB,eS,sS,flip
     integer :: rankId,offset,N
     integer,pointer :: elemtorank(:)
@@ -436,14 +482,17 @@ contains
       allocate(this%mortarBuff(1:N+1,1:4,1:mesh%nMortars,1:this%nvar))
       this%mortarBuff = 0.0_prec
     endif
+    call EnsureIndexList(this%allMortar,mesh%nMortars)
+    call ResolveIndexList(this%allMortar,mesh%nMortars,mortars,midx,nm)
 
     if(mesh%decomp%mpiEnabled) then
-      call this%MPIMortarExchangeAsync(mesh)
+      call this%MPIMortarExchangeAsync(mesh,mortars)
     endif
 
     ! Stage rank-local traces in the big side's edge orientation
-    do concurrent(m=1:mesh%nMortars,ivar=1:this%nvar)
+    do concurrent(im=1:nm,ivar=1:this%nvar)
 
+      m = midx(im)
       eB = mesh%mortarInfo(1,m)
       if(elemtorank(eB) == rankId) then
         sB = mesh%mortarInfo(2,m)
@@ -477,7 +526,8 @@ contains
 
       ! Reorient small-side traces received over MPI into the big side's orientation
       do ivar = 1,this%nvar
-        do m = 1,mesh%nMortars
+        do im = 1,nm
+          m = midx(im)
           eB = mesh%mortarInfo(1,m)
           if(elemtorank(eB) == rankId) then
             do k = 1,2
@@ -501,8 +551,9 @@ contains
     ! Compute external states :
     !  small sides get the restricted big-side trace (exact),
     !  the big side gets the L2 projection of the small-side traces
-    do concurrent(m=1:mesh%nMortars,ivar=1:this%nvar)
+    do concurrent(im=1:nm,ivar=1:this%nvar)
 
+      m = midx(im)
       do k = 1,2
         eS = mesh%mortarInfo(2*k+1,m)
         if(elemtorank(eS) == rankId) then

--- a/src/SELF_MappedVector_2D_t.f90
+++ b/src/SELF_MappedVector_2D_t.f90
@@ -87,6 +87,8 @@ contains
 
     call Resize_Vector2D_t(this,interp,nVar,nElem)
     if(allocated(this%mortarBuff)) deallocate(this%mortarBuff)
+    if(associated(this%allMortar)) deallocate(this%allMortar)
+    this%allMortar => null()
 
     ! The geometry binding refers to the PREVIOUS mesh's geometry, which the caller is
     ! about to destroy. It must be dropped here so the AssociateGeometry that follows a
@@ -155,21 +157,29 @@ contains
 
   endsubroutine SetInteriorFromEquation_MappedVector2D_t
 
-  subroutine MPIExchangeAsync_MappedVector2D_t(this,mesh)
+  subroutine MPIExchangeAsync_MappedVector2D_t(this,mesh,elems)
+    !! Vector analogue of the scalar conforming-side message posting. elems restricts this
+    !! to a subset of rank-local elements; see SideExchange_MappedScalar2D_t for why a
+    !! per-refinement-level subset keeps the send/receive pairing intact.
     implicit none
     class(MappedVector2D_t),intent(inout) :: this
     type(Mesh2D),intent(inout) :: mesh
+    integer,pointer,contiguous,intent(in),optional :: elems(:)
     ! Local
-    integer :: e1,s1,e2,s2,ivar,idir
+    integer :: ie,e1,s1,e2,s2,ivar,idir,ne
+    integer,pointer,contiguous :: eidx(:)
     integer :: globalSideId,r2,tag
     integer :: iError
     integer :: msgCount
+
+    call ResolveIndexList(this%allElem,this%nElem,elems,eidx,ne)
 
     msgCount = 0
 
     do idir = 1,2
       do ivar = 1,this%nvar
-        do e1 = 1,this%nElem
+        do ie = 1,ne
+          e1 = eidx(ie)
           do s1 = 1,4
 
             e2 = mesh%sideInfo(3,s1,e1) ! Neighbor Element
@@ -210,20 +220,26 @@ contains
 
   endsubroutine MPIExchangeAsync_MappedVector2D_t
 
-  subroutine ApplyFlip_MappedVector2D_t(this,mesh)
-    ! Apply side flips to sides where MPI exchanges took place.
+  subroutine ApplyFlip_MappedVector2D_t(this,mesh,elems)
+    ! Apply side flips to sides where MPI exchanges took place. elems must match the subset
+    ! passed to MPIExchangeAsync, so that exactly the sides that were received get flipped.
     implicit none
     class(MappedVector2D_t),intent(inout) :: this
     type(Mesh2D),intent(in) :: mesh
+    integer,pointer,contiguous,intent(in),optional :: elems(:)
     ! Local
-    integer :: e1,s1,e2,s2
+    integer :: ie,e1,s1,e2,s2,ne
+    integer,pointer,contiguous :: eidx(:)
     integer :: i,i2
     integer :: r2,flip,ivar,idir
     real(prec) :: extBuff(1:this%interp%N+1)
 
+    call ResolveIndexList(this%allElem,this%nElem,elems,eidx,ne)
+
     do idir = 1,2
       do ivar = 1,this%nvar
-        do e1 = 1,this%nElem
+        do ie = 1,ne
+          e1 = eidx(ie)
           do s1 = 1,4
 
             e2 = mesh%sideInfo(3,s1,e1) ! Neighbor Element (global id)
@@ -259,17 +275,23 @@ contains
 
   endsubroutine ApplyFlip_MappedVector2D_t
 
-  subroutine SideExchange_MappedVector2D_t(this,mesh)
+  subroutine SideExchange_MappedVector2D_t(this,mesh,elems)
+    !! Vector analogue of the scalar conforming-side exchange. elems restricts the exchange
+    !! to a subset of rank-local elements; see SideExchange_MappedScalar2D_t.
     implicit none
     class(MappedVector2D_t),intent(inout) :: this
     type(Mesh2D),intent(inout) :: mesh
+    integer,pointer,contiguous,intent(in),optional :: elems(:)
     ! Local
-    integer :: e1,e2,s1,s2,e2Global
+    integer :: ie,e1,e2,s1,s2,e2Global,ne
+    integer,pointer,contiguous :: eidx(:)
     integer :: flip,bcid
     integer :: i1,i2,ivar,idir
     integer :: r2
     integer :: rankId,offset
     integer,pointer :: elemtorank(:)
+
+    call ResolveIndexList(this%allElem,this%nElem,elems,eidx,ne)
 
     ! This mapping is needed to resolve a build error with
     ! amdflang that appears to be caused by referencing
@@ -281,11 +303,12 @@ contains
     offset = mesh%decomp%offsetElem(rankId+1)
 
     if(mesh%decomp%mpiEnabled) then
-      call this%MPIExchangeAsync(mesh)
+      call this%MPIExchangeAsync(mesh,elems)
     endif
 
-    do concurrent(s1=1:4,e1=1:mesh%nElem,ivar=1:this%nvar,idir=1:2)
+    do concurrent(s1=1:4,ie=1:ne,ivar=1:this%nvar,idir=1:2)
 
+      e1 = eidx(ie)
       e2Global = mesh%sideInfo(3,s1,e1)
       e2 = e2Global-offset
       s2 = mesh%sideInfo(4,s1,e1)/10
@@ -323,31 +346,37 @@ contains
     if(mesh%decomp%mpiEnabled) then
       call mesh%decomp%FinalizeMPIExchangeAsync()
       ! Apply side flips for data exchanged with MPI
-      call this%ApplyFlip(mesh)
+      call this%ApplyFlip(mesh,elems)
     endif
 
   endsubroutine SideExchange_MappedVector2D_t
 
-  subroutine MPIMortarExchangeAsync_MappedVector2D_t(this,mesh)
+  subroutine MPIMortarExchangeAsync_MappedVector2D_t(this,mesh,mortars)
     !! Vector analogue of the scalar mortar exchange message posting; each physical
-    !! direction of each variable is exchanged as its own message.
+    !! direction of each variable is exchanged as its own message. mortars restricts this
+    !! to a subset of the (rank-replicated) mortar table.
     implicit none
     class(MappedVector2D_t),intent(inout) :: this
     type(Mesh2D),intent(inout) :: mesh
+    integer,pointer,contiguous,intent(in),optional :: mortars(:)
     ! Local
-    integer :: m,k,ivar,idir
+    integer :: im,m,k,ivar,idir,nm
+    integer,pointer,contiguous :: midx(:)
     integer :: eB,sB,rB,eS,sS,rS
     integer :: globalSideId,tag
     integer :: offset
     integer :: iError
     integer :: msgCount
 
+    call ResolveIndexList(this%allMortar,mesh%nMortars,mortars,midx,nm)
+
     msgCount = 0
     offset = mesh%decomp%offsetElem(mesh%decomp%rankId+1)
 
     do idir = 1,2
       do ivar = 1,this%nvar
-        do m = 1,mesh%nMortars
+        do im = 1,nm
+          m = midx(im)
 
           eB = mesh%mortarInfo(1,m)
           sB = mesh%mortarInfo(2,m)
@@ -408,15 +437,17 @@ contains
 
   endsubroutine MPIMortarExchangeAsync_MappedVector2D_t
 
-  subroutine MortarExchange_MappedVector2D_t(this,mesh)
+  subroutine MortarExchange_MappedVector2D_t(this,mesh,mortars)
     !! Fills the extBoundary attribute on all sides participating in a 2:1
     !! nonconforming (mortar) interface; vector analogue of the scalar MortarExchange
-    !! (see MappedScalar2D_t for the algorithm description).
+    !! (see MappedScalar2D_t for the algorithm description and for what mortars means).
     implicit none
     class(MappedVector2D_t),intent(inout) :: this
     type(Mesh2D),intent(inout) :: mesh
+    integer,pointer,contiguous,intent(in),optional :: mortars(:)
     ! Local
-    integer :: m,k,ivar,idir,i,ii
+    integer :: im,m,k,ivar,idir,i,ii,nm
+    integer,pointer,contiguous :: midx(:)
     integer :: eB,sB,eS,sS,flip
     integer :: rankId,offset,N
     integer,pointer :: elemtorank(:)
@@ -434,14 +465,17 @@ contains
       allocate(this%mortarBuff(1:N+1,1:4,1:mesh%nMortars,1:this%nvar,1:2))
       this%mortarBuff = 0.0_prec
     endif
+    call EnsureIndexList(this%allMortar,mesh%nMortars)
+    call ResolveIndexList(this%allMortar,mesh%nMortars,mortars,midx,nm)
 
     if(mesh%decomp%mpiEnabled) then
-      call this%MPIMortarExchangeAsync(mesh)
+      call this%MPIMortarExchangeAsync(mesh,mortars)
     endif
 
     ! Stage rank-local traces in the big side's edge orientation
-    do concurrent(m=1:mesh%nMortars,ivar=1:this%nvar,idir=1:2)
+    do concurrent(im=1:nm,ivar=1:this%nvar,idir=1:2)
 
+      m = midx(im)
       eB = mesh%mortarInfo(1,m)
       if(elemtorank(eB) == rankId) then
         sB = mesh%mortarInfo(2,m)
@@ -476,7 +510,8 @@ contains
       ! Reorient small-side traces received over MPI into the big side's orientation
       do idir = 1,2
         do ivar = 1,this%nvar
-          do m = 1,mesh%nMortars
+          do im = 1,nm
+            m = midx(im)
             eB = mesh%mortarInfo(1,m)
             if(elemtorank(eB) == rankId) then
               do k = 1,2
@@ -501,8 +536,9 @@ contains
     ! Compute external states :
     !  small sides get the restricted big-side trace (exact),
     !  the big side gets the L2 projection of the small-side traces
-    do concurrent(m=1:mesh%nMortars,ivar=1:this%nvar,idir=1:2)
+    do concurrent(im=1:nm,ivar=1:this%nvar,idir=1:2)
 
+      m = midx(im)
       do k = 1,2
         eS = mesh%mortarInfo(2*k+1,m)
         if(elemtorank(eS) == rankId) then
@@ -540,25 +576,31 @@ contains
 
   endsubroutine MortarExchange_MappedVector2D_t
 
-  subroutine MPIMortarFluxAsync_MappedVector2D_t(this,mesh)
+  subroutine MPIMortarFluxAsync_MappedVector2D_t(this,mesh,mortars)
     !! Posts the one-directional messages for MortarFluxCollect : each remote small
-    !! side sends its boundaryNormal trace to the big side's rank.
+    !! side sends its boundaryNormal trace to the big side's rank. mortars restricts this
+    !! to a subset of the (rank-replicated) mortar table.
     implicit none
     class(MappedVector2D_t),intent(inout) :: this
     type(Mesh2D),intent(inout) :: mesh
+    integer,pointer,contiguous,intent(in),optional :: mortars(:)
     ! Local
-    integer :: m,k,ivar
+    integer :: im,m,k,ivar,nm
+    integer,pointer,contiguous :: midx(:)
     integer :: eB,rB,eS,sS,rS
     integer :: globalSideId,tag
     integer :: offset
     integer :: iError
     integer :: msgCount
 
+    call ResolveIndexList(this%allMortar,mesh%nMortars,mortars,midx,nm)
+
     msgCount = 0
     offset = mesh%decomp%offsetElem(mesh%decomp%rankId+1)
 
     do ivar = 1,this%nvar
-      do m = 1,mesh%nMortars
+      do im = 1,nm
+        m = midx(im)
 
         eB = mesh%mortarInfo(1,m)
         rB = mesh%decomp%elemToRank(eB)
@@ -601,7 +643,7 @@ contains
 
   endsubroutine MPIMortarFluxAsync_MappedVector2D_t
 
-  subroutine MortarFluxCollect_MappedVector2D_t(this,mesh)
+  subroutine MortarFluxCollect_MappedVector2D_t(this,mesh,mortars)
     !! Replaces the big-side boundaryNormal trace on each mortar interface with the L2
     !! projection of the two small sides' boundaryNormal traces.
     !!
@@ -614,11 +656,18 @@ contains
     !! discrete surface integrals to roundoff, so the mortar interface is discretely
     !! conservative. Must be called after the model's BoundaryFlux and before the flux
     !! divergence is computed.
+    !!
+    !! mortars restricts the projection to a subset of the mortar table. Under local time
+    !! stepping this is what lets the coarse side pick up the fine sides' flux at its own
+    !! stage times, and what lets the fine substeps write their projected flux into the big
+    !! side's boundaryNormal so it can be accumulated into a flux register.
     implicit none
     class(MappedVector2D_t),intent(inout) :: this
     type(Mesh2D),intent(inout) :: mesh
+    integer,pointer,contiguous,intent(in),optional :: mortars(:)
     ! Local
-    integer :: m,k,ivar,i,ii
+    integer :: im,m,k,ivar,i,ii,nm
+    integer,pointer,contiguous :: midx(:)
     integer :: eB,sB,eS,sS,flip
     integer :: rankId,offset,N
     integer,pointer :: elemtorank(:)
@@ -636,14 +685,17 @@ contains
       allocate(this%mortarBuff(1:N+1,1:4,1:mesh%nMortars,1:this%nvar,1:2))
       this%mortarBuff = 0.0_prec
     endif
+    call EnsureIndexList(this%allMortar,mesh%nMortars)
+    call ResolveIndexList(this%allMortar,mesh%nMortars,mortars,midx,nm)
 
     if(mesh%decomp%mpiEnabled) then
-      call this%MPIMortarFluxAsync(mesh)
+      call this%MPIMortarFluxAsync(mesh,mortars)
     endif
 
     ! Stage rank-local small-side integrands in the big side's edge orientation
-    do concurrent(m=1:mesh%nMortars,ivar=1:this%nvar)
+    do concurrent(im=1:nm,ivar=1:this%nvar)
 
+      m = midx(im)
       do k = 1,2
         eS = mesh%mortarInfo(2*k+1,m)
         if(elemtorank(eS) == rankId) then
@@ -668,7 +720,8 @@ contains
 
       ! Reorient small-side integrands received over MPI into the big side's orientation
       do ivar = 1,this%nvar
-        do m = 1,mesh%nMortars
+        do im = 1,nm
+          m = midx(im)
           eB = mesh%mortarInfo(1,m)
           if(elemtorank(eB) == rankId) then
             do k = 1,2
@@ -693,8 +746,9 @@ contains
     ! two converts the solution-space projection (mortarP carries the 1/2 sub-edge
     ! Jacobian) into the integrand-space projection; the sign accounts for the opposing
     ! outward normals.
-    do concurrent(m=1:mesh%nMortars,ivar=1:this%nvar)
+    do concurrent(im=1:nm,ivar=1:this%nvar)
 
+      m = midx(im)
       eB = mesh%mortarInfo(1,m)
       if(elemtorank(eB) == rankId) then
         sB = mesh%mortarInfo(2,m)
@@ -755,21 +809,30 @@ contains
 
   endsubroutine MappedDivergence_MappedVector2D_t
 
-  subroutine MappedDGDivergence_MappedVector2D_t(this,df)
+  subroutine MappedDGDivergence_MappedVector2D_t(this,df,elems)
     !! Computes the divergence of a 2-D vector using the weak form
     !! On input, the  attribute of the vector
     !! is assigned and the  attribute is set to the physical
     !! directions of the vector. This method will project the vector
     !! onto the contravariant basis vectors.
+    !!
+    !! elems restricts the divergence to a subset of rank-local elements, leaving df
+    !! untouched elsewhere; the operator is element-local, so a subset result is identical
+    !! to the corresponding slice of the full-mesh result. Omitting it covers 1:nElem.
     implicit none
     class(MappedVector2D_t),intent(in) :: this
     real(prec) :: df(1:this%N+1,1:this%N+1,1:this%nelem,1:this%nvar)
+    integer,pointer,contiguous,intent(in),optional :: elems(:)
     ! Local
-    integer :: iEl,iVar,i,j,ii
+    integer :: ie,iEl,iVar,i,j,ii,ne
+    integer,pointer,contiguous :: eidx(:)
     real(prec) :: dfLoc,Fx,Fy,Fc
 
-    do concurrent(i=1:this%N+1,j=1:this%N+1,iel=1:this%nElem,ivar=1:this%nVar)
+    call ResolveIndexList(this%allElem,this%nElem,elems,eidx,ne)
 
+    do concurrent(i=1:this%N+1,j=1:this%N+1,ie=1:ne,ivar=1:this%nVar)
+
+      iel = eidx(ie)
       dfLoc = 0.0_prec
       do ii = 1,this%N+1
         ! Convert from physical to computational space
@@ -786,8 +849,9 @@ contains
 
     enddo
 
-    do concurrent(i=1:this%N+1,j=1:this%N+1,iel=1:this%nElem,ivar=1:this%nVar)
+    do concurrent(i=1:this%N+1,j=1:this%N+1,ie=1:ne,ivar=1:this%nVar)
 
+      iel = eidx(ie)
       dfLoc = 0.0_prec
       do ii = 1,this%N+1
         ! Convert from physical to computational space

--- a/src/SELF_MeshRefinement_2D.f90
+++ b/src/SELF_MeshRefinement_2D.f90
@@ -147,6 +147,15 @@ contains
       enddo
     enddo
 
+    ! Refinement levels: every child sits one level below its parent. The refined mesh is
+    ! conforming, so all levels are raised together and no mortar (level jump) is created.
+    meshOut%maxElemLevel = meshIn%maxElemLevel+1
+    do p = 1,nElem
+      do c = 1,4
+        meshOut%elemLevel(4*(p-1)+c) = meshIn%elemLevel(p)+1
+      enddo
+    enddo
+
     deallocate(baseCorner,refSideInfo,refCorner,childCoords)
     call geomInterp%Free()
 

--- a/src/SELF_Mesh_2D_t.f90
+++ b/src/SELF_Mesh_2D_t.f90
@@ -128,6 +128,28 @@ module SELF_Mesh_2D_t
     ! side's edge coordinate, flip = 1 when reversed (same convention as sideInfo(4)).
     integer :: nMortars = 0
     integer,pointer,dimension(:,:) :: mortarInfo => null()
+    ! Refinement level of each mortar's BIG side, replicated on every rank like mortarInfo
+    ! itself. The two small sides are then at mortarLevel+1, since the forest is 2:1
+    ! balanced. This is kept here rather than derived from elemLevel because mortarInfo
+    ! carries GLOBAL element ids while elemLevel is the rank-local slice, so a rank cannot
+    ! look up the level of a mortar whose big element it does not own.
+    integer,allocatable :: mortarLevel(:)
+    ! Refinement level of each rank-local element, and the global maximum over all ranks.
+    !
+    ! elemLevel(iEl) is the quadtree depth of the leaf that produced element iEl: 0 on the
+    ! base mesh, incremented by one per 2:1 subdivision, so the element scale is
+    ! h_root / 2**elemLevel. Meshes that carry no refinement (structured, HOPr, HOHQMesh)
+    ! leave it at 0 and maxElemLevel = 0, which is the conforming single-rate case.
+    !
+    ! Levels exist so that local time stepping can subcycle level ell at dt_base/2**ell.
+    ! Because EmitMesh only ever emits a conforming side between two leaves of the SAME
+    ! level, every level jump in the mesh is a 2:1 mortar face; elemLevel and mortarInfo
+    ! together therefore describe the whole inter-level coupling.
+    !
+    ! maxElemLevel is GLOBAL (identical on every rank), whereas elemLevel is the rank-local
+    ! slice, indexed like every other element-sized array.
+    integer :: maxElemLevel = 0
+    integer,allocatable :: elemLevel(:)
     ! Material tracking: every element has an integer material id
     ! indexing into materialNames. Single-material readers (HOPr,
     ! structured, ISM, ISM-v2) leave nMaterials = 1 with the name
@@ -196,6 +218,12 @@ contains
     this%elemMaterial = 1
     this%materialNames(1) = "default"
 
+    ! Default refinement level: a conforming, unrefined mesh. EmitMesh overwrites this
+    ! with the per-leaf quadtree depth.
+    this%maxElemLevel = 0
+    allocate(this%elemLevel(1:nElem))
+    this%elemLevel = 0
+
     ! Create lookup tables to assist with connectivity generation
     this%CGNSCornerMap(1:2,1) = (/1,1/)
     this%CGNSCornerMap(1:2,2) = (/nGeo+1,1/)
@@ -233,8 +261,11 @@ contains
     if(allocated(this%elemMaterial)) deallocate(this%elemMaterial)
     if(allocated(this%materialNames)) deallocate(this%materialNames)
     this%nMaterials = 0
+    if(allocated(this%elemLevel)) deallocate(this%elemLevel)
+    this%maxElemLevel = 0
     if(associated(this%mortarInfo)) deallocate(this%mortarInfo)
     this%mortarInfo => null()
+    if(allocated(this%mortarLevel)) deallocate(this%mortarLevel)
     this%nMortars = 0
     call this%decomp%Free()
 
@@ -542,6 +573,8 @@ contains
     real(prec) :: nodeCoords(1:2,1:2,1:2,1:nGlobalElem)
     integer :: globalNodeIDs(1:2,1:2,1:nGlobalElem)
     integer :: sideInfo(1:5,1:4,1:nGlobalElem)
+    ! Big element 1 is level 0; small elements 2 and 3 are its level-1 refinement
+    integer,parameter :: elemLevel(1:nGlobalElem) = [0,1,1]
     integer :: e1,e2
     integer :: nLocalElems
     integer :: nGeo,nBCs
@@ -638,9 +671,17 @@ contains
     this%globalNodeIDs(1:2,1:2,1:nLocalElems) = globalNodeIDs(1:2,1:2,e1:e2)
     this%sideInfo(1:5,1:4,1:nLocalElems) = sideInfo(1:5,1:4,e1:e2)
 
+    ! Refinement levels: the big element is level 0, the two small elements are its 2:1
+    ! refined neighbors at level 1. This mirrors what EmitMesh derives from a quadtree and
+    ! lets the hand-built mesh exercise level-aware machinery (e.g. local time stepping).
+    this%maxElemLevel = 1
+    this%elemLevel(1:nLocalElems) = elemLevel(e1:e2)
+
     ! The mortar table is replicated on all ranks; element ids are global
     this%nMortars = 1
     allocate(this%mortarInfo(1:8,1:1))
+    allocate(this%mortarLevel(1:1))
+    this%mortarLevel(1) = 0 ! big element 1 is level 0; its small sides are level 1
     this%mortarInfo(1:8,1) = [1,2, & ! big element, big local side (east)
                               2,10*4, & ! sub-edge 1 : element 2, west side, flip 0
                               3,10*4, & ! sub-edge 2 : element 3, west side, flip 0
@@ -691,6 +732,8 @@ contains
     real(prec) :: nodeCoords(1:2,1:2,1:2,1:nGlobalElem)
     integer :: globalNodeIDs(1:2,1:2,1:nGlobalElem)
     integer :: sideInfo(1:5,1:4,1:nGlobalElem)
+    ! Big elements 1 and 2 are level 0; small elements 3-6 are their level-1 refinement
+    integer,parameter :: elemLevel(1:nGlobalElem) = [0,0,1,1,1,1]
     integer :: e1,e2
     integer :: nLocalElems
     integer :: nGeo,nBCs
@@ -847,9 +890,16 @@ contains
     this%globalNodeIDs(1:2,1:2,1:nLocalElems) = globalNodeIDs(1:2,1:2,e1:e2)
     this%sideInfo(1:5,1:4,1:nLocalElems) = sideInfo(1:5,1:4,e1:e2)
 
+    ! Refinement levels: the two big elements are level 0, the four small elements are
+    ! their 2:1 refined neighbors at level 1 (see SimpleMortarMesh for the rationale).
+    this%maxElemLevel = 1
+    this%elemLevel(1:nLocalElems) = elemLevel(e1:e2)
+
     ! The mortar table is replicated on all ranks; element ids are global
     this%nMortars = 2
     allocate(this%mortarInfo(1:8,1:2))
+    allocate(this%mortarLevel(1:2))
+    this%mortarLevel(1:2) = 0 ! big elements 1 and 2 are level 0
     this%mortarInfo(1:8,1) = [1,2, & ! big element 1, east side
                               3,10*4, & ! sub-edge 1 : element 3, west side, flip 0
                               4,10*4, & ! sub-edge 2 : element 4, west side, flip 0

--- a/src/SELF_Scalar_2D_t.f90
+++ b/src/SELF_Scalar_2D_t.f90
@@ -132,6 +132,8 @@ contains
     this%boundarynormal(1:Np,1:4,1:nElem,1:2*nVar) => &
       this%pool_boundarynormal(1:Np*4*nElem*2*nVar)
 
+    call EnsureIndexList(this%allElem,nElem)
+
   endsubroutine MapArrays_Scalar2D_t
 
   subroutine Resize_Scalar2D_t(this,interp,nVar,nElem)
@@ -193,6 +195,10 @@ contains
     if(associated(this%pool_extBoundary)) deallocate(this%pool_extBoundary)
     if(associated(this%pool_avgBoundary)) deallocate(this%pool_avgBoundary)
     if(associated(this%pool_boundarynormal)) deallocate(this%pool_boundarynormal)
+    if(associated(this%allElem)) deallocate(this%allElem)
+    this%allElem => null()
+    if(associated(this%allMortar)) deallocate(this%allMortar)
+    this%allMortar => null()
     deallocate(this%meta)
     deallocate(this%eqn)
 
@@ -210,14 +216,25 @@ contains
     if(.false.) this%N = this%N ! CPU stub; suppress unused-dummy-argument warning
   endsubroutine UpdateDevice_Scalar2D_t
 
-  subroutine BoundaryInterp_Scalar2D_t(this)
+  subroutine BoundaryInterp_Scalar2D_t(this,elems)
+    !! Interpolate the element interior onto the four element edges.
+    !!
+    !! elems, when present, restricts the operation to those rank-local elements and leaves
+    !! every other element's boundary trace untouched; local time stepping uses it to
+    !! interpolate only the refinement level it is about to advance. Omitting it traverses
+    !! 1:nElem exactly as before (see ResolveIndexList in SELF_Data).
     implicit none
     class(Scalar2D_t),intent(inout) :: this
+    integer,pointer,contiguous,intent(in),optional :: elems(:)
     ! Local
-    integer :: i,ii,iel,ivar
+    integer :: i,ii,ie,iel,ivar,ne
+    integer,pointer,contiguous :: eidx(:)
     real(prec) :: fbs,fbe,fbn,fbw
 
-    do concurrent(i=1:this%N+1,iel=1:this%nelem,ivar=1:this%nvar)
+    call ResolveIndexList(this%allElem,this%nElem,elems,eidx,ne)
+
+    do concurrent(i=1:this%N+1,ie=1:ne,ivar=1:this%nvar)
+      iel = eidx(ie)
       fbs = 0.0_prec
       fbe = 0.0_prec
       fbn = 0.0_prec
@@ -238,16 +255,25 @@ contains
 
   endsubroutine BoundaryInterp_Scalar2D_t
 
-  subroutine AverageSides_Scalar2D_t(this)
+  subroutine AverageSides_Scalar2D_t(this,elems)
+    !! Average the interior and exterior edge traces. elems restricts the operation to a
+    !! subset of rank-local elements; omitting it covers 1:nElem as before.
     implicit none
     class(Scalar2D_t),intent(inout) :: this
+    integer,pointer,contiguous,intent(in),optional :: elems(:)
     ! Local
+    integer :: ie
     integer :: iel
     integer :: iside
     integer :: ivar
     integer :: i
+    integer :: ne
+    integer,pointer,contiguous :: eidx(:)
 
-    do concurrent(i=1:this%interp%N+1,iside=1:4,iel=1:this%nElem,ivar=1:this%nVar)
+    call ResolveIndexList(this%allElem,this%nElem,elems,eidx,ne)
+
+    do concurrent(i=1:this%interp%N+1,iside=1:4,ie=1:ne,ivar=1:this%nVar)
+      iel = eidx(ie)
       this%avgBoundary(i,iside,iel,ivar) = 0.5_prec*( &
                                            this%boundary(i,iside,iel,ivar)+ &
                                            this%extBoundary(i,iside,iel,ivar))

--- a/src/SELF_Vector_2D_t.f90
+++ b/src/SELF_Vector_2D_t.f90
@@ -149,6 +149,10 @@ contains
     if(associated(this%pool_boundaryNormal)) deallocate(this%pool_boundaryNormal)
     if(associated(this%pool_extBoundary)) deallocate(this%pool_extBoundary)
     if(associated(this%pool_avgBoundary)) deallocate(this%pool_avgBoundary)
+    if(associated(this%allElem)) deallocate(this%allElem)
+    this%allElem => null()
+    if(associated(this%allMortar)) deallocate(this%allMortar)
+    this%allMortar => null()
 
     deallocate(this%meta)
     deallocate(this%eqn)
@@ -182,6 +186,8 @@ contains
     this%extBoundary(1:Np,1:4,1:nElem,1:nVar,1:2) => this%pool_extBoundary(1:nBnd)
     this%avgBoundary(1:Np,1:4,1:nElem,1:nVar,1:2) => this%pool_avgBoundary(1:nBnd)
     this%boundaryNormal(1:Np,1:4,1:nElem,1:nVar) => this%pool_boundaryNormal(1:nNrm)
+
+    call EnsureIndexList(this%allElem,nElem)
 
   endsubroutine MapArrays_Vector2D_t
 
@@ -271,18 +277,27 @@ contains
 
   endsubroutine GridInterp_Vector2D_t
 
-  subroutine AverageSides_Vector2D_t(this)
+  subroutine AverageSides_Vector2D_t(this,elems)
+    !! Average the interior and exterior edge traces. elems restricts the operation to a
+    !! subset of rank-local elements; omitting it covers 1:nElem as before.
     implicit none
     class(Vector2D_t),intent(inout) :: this
+    integer,pointer,contiguous,intent(in),optional :: elems(:)
     ! Local
+    integer :: ie
     integer :: iel
     integer :: iside
     integer :: ivar
     integer :: i
     integer :: idir
+    integer :: ne
+    integer,pointer,contiguous :: eidx(:)
 
-    do concurrent(i=1:this%interp%N+1,iside=1:4,iel=1:this%nElem, &
+    call ResolveIndexList(this%allElem,this%nElem,elems,eidx,ne)
+
+    do concurrent(i=1:this%interp%N+1,iside=1:4,ie=1:ne, &
                   ivar=1:this%nVar,idir=1:2)
+      iel = eidx(ie)
       this%avgboundary(i,iside,iel,ivar,idir) = 0.5_prec*( &
                                                 this%boundary(i,iside,iel,ivar,idir)+ &
                                                 this%extBoundary(i,iside,iel,ivar,idir))
@@ -290,16 +305,23 @@ contains
 
   endsubroutine AverageSides_Vector2D_t
 
-  subroutine BoundaryInterp_Vector2D_t(this)
+  subroutine BoundaryInterp_Vector2D_t(this,elems)
+    !! Interpolate the element interior onto the four element edges. elems restricts the
+    !! operation to a subset of rank-local elements; omitting it covers 1:nElem as before.
     implicit none
     class(Vector2D_t),intent(inout) :: this
+    integer,pointer,contiguous,intent(in),optional :: elems(:)
 ! Local
-    integer :: i,ii,idir,iel,ivar
+    integer :: i,ii,idir,ie,iel,ivar,ne
+    integer,pointer,contiguous :: eidx(:)
     real(prec) :: fbs,fbe,fbn,fbw
 
-    do concurrent(i=1:this%N+1,iel=1:this%nelem, &
+    call ResolveIndexList(this%allElem,this%nElem,elems,eidx,ne)
+
+    do concurrent(i=1:this%N+1,ie=1:ne, &
                   ivar=1:this%nvar,idir=1:2)
 
+      iel = eidx(ie)
       fbs = 0.0_prec
       fbe = 0.0_prec
       fbn = 0.0_prec

--- a/src/gpu/SELF_MappedScalar_2D.f90
+++ b/src/gpu/SELF_MappedScalar_2D.f90
@@ -388,22 +388,26 @@ contains
 
   endsubroutine SideExchangeFinish_MappedScalar2D
 
-  subroutine SideExchange_MappedScalar2D(this,mesh)
+  subroutine SideExchange_MappedScalar2D(this,mesh,elems)
     implicit none
     class(MappedScalar2D),intent(inout) :: this
     type(Mesh2D),intent(inout) :: mesh
+    integer,pointer,contiguous,intent(in),optional :: elems(:)
+
+    call RejectSubset(elems,__FILE__,__LINE__)
 
     call this%SideExchangeStart(mesh)
     call this%SideExchangeFinish(mesh)
 
   endsubroutine SideExchange_MappedScalar2D
 
-  subroutine MPIMortarExchangeAsync_MappedScalar2D(this,mesh)
+  subroutine MPIMortarExchangeAsync_MappedScalar2D(this,mesh,mortars)
     !! GPU-resident analogue of the base-class mortar message posting; messages are
     !! posted on device memory (GPU-aware MPI), following MPIExchangeAsync.
     implicit none
     class(MappedScalar2D),intent(inout) :: this
     type(Mesh2D),intent(inout) :: mesh
+    integer,pointer,contiguous,intent(in),optional :: mortars(:)
     ! Local
     integer :: m,k,ivar
     integer :: eB,sB,rB,eS,sS,rS
@@ -413,6 +417,8 @@ contains
     integer :: msgCount
     real(prec),pointer :: boundary(:,:,:,:)
     real(prec),pointer :: mortarBuff(:,:,:,:)
+
+    call RejectSubset(mortars,__FILE__,__LINE__)
 
     msgCount = 0
     offset = mesh%decomp%offsetElem(mesh%decomp%rankId+1)
@@ -481,16 +487,19 @@ contains
 
   endsubroutine MPIMortarExchangeAsync_MappedScalar2D
 
-  subroutine MortarExchange_MappedScalar2D(this,mesh)
+  subroutine MortarExchange_MappedScalar2D(this,mesh,mortars)
     !! GPU implementation of the mortar exchange (see the base class for the
     !! algorithm) : traces are staged, reoriented, restricted, and projected in
     !! device memory with the SELF_Mortar kernels.
     implicit none
     class(MappedScalar2D),intent(inout) :: this
     type(Mesh2D),intent(inout) :: mesh
+    integer,pointer,contiguous,intent(in),optional :: mortars(:)
     ! Local
     integer :: offset
     integer(c_size_t) :: buffSize
+
+    call RejectSubset(mortars,__FILE__,__LINE__)
 
     offset = mesh%decomp%offsetElem(mesh%decomp%rankId+1)
 

--- a/src/gpu/SELF_MappedVector_2D.f90
+++ b/src/gpu/SELF_MappedVector_2D.f90
@@ -154,7 +154,7 @@ contains
 
   endsubroutine SetInteriorFromEquation_MappedVector2D
 
-  subroutine MPIExchangeAsync_MappedVector2D(this,mesh)
+  subroutine MPIExchangeAsync_MappedVector2D(this,mesh,elems)
   !! Post the aggregated halo exchange: one MPI_Irecv/MPI_Isend pair per
   !! neighboring rank, carrying every (side,variable,component) boundary
   !! trace shared with that rank in a single packed device buffer. The
@@ -165,6 +165,7 @@ contains
     implicit none
     class(MappedVector2D),intent(inout) :: this
     type(Mesh2D),intent(inout) :: mesh
+    integer,pointer,contiguous,intent(in),optional :: elems(:)
     ! Local
     integer :: n,npts,cnt,disp
     integer :: iError
@@ -172,6 +173,8 @@ contains
     integer(c_size_t) :: worksize
     real(prec),pointer :: sendbuf(:)
     real(prec),pointer :: recvbuf(:)
+
+    call RejectSubset(elems,__FILE__,__LINE__)
 
     npts = (this%interp%N+1)*2*this%nvar
 
@@ -215,12 +218,15 @@ contains
 
   endsubroutine MPIExchangeAsync_MappedVector2D
 
-  subroutine SideExchange_MappedVector2D(this,mesh)
+  subroutine SideExchange_MappedVector2D(this,mesh,elems)
     implicit none
     class(MappedVector2D),intent(inout) :: this
     type(Mesh2D),intent(inout) :: mesh
+    integer,pointer,contiguous,intent(in),optional :: elems(:)
     ! Local
     integer :: offset
+
+    call RejectSubset(elems,__FILE__,__LINE__)
 
     offset = mesh%decomp%offsetElem(mesh%decomp%rankid+1)
 
@@ -251,12 +257,13 @@ contains
 
   endsubroutine SideExchange_MappedVector2D
 
-  subroutine MPIMortarExchangeAsync_MappedVector2D(this,mesh)
+  subroutine MPIMortarExchangeAsync_MappedVector2D(this,mesh,mortars)
     !! GPU-resident mortar message posting for vector data; messages are posted on
     !! device memory (GPU-aware MPI), one per variable and physical direction.
     implicit none
     class(MappedVector2D),intent(inout) :: this
     type(Mesh2D),intent(inout) :: mesh
+    integer,pointer,contiguous,intent(in),optional :: mortars(:)
     ! Local
     integer :: m,k,ivar,idir
     integer :: eB,sB,rB,eS,sS,rS
@@ -266,6 +273,8 @@ contains
     integer :: msgCount
     real(prec),pointer :: boundary(:,:,:,:,:)
     real(prec),pointer :: mortarBuff(:,:,:,:,:)
+
+    call RejectSubset(mortars,__FILE__,__LINE__)
 
     msgCount = 0
     offset = mesh%decomp%offsetElem(mesh%decomp%rankId+1)
@@ -336,15 +345,18 @@ contains
 
   endsubroutine MPIMortarExchangeAsync_MappedVector2D
 
-  subroutine MortarExchange_MappedVector2D(this,mesh)
+  subroutine MortarExchange_MappedVector2D(this,mesh,mortars)
     !! GPU implementation of the vector mortar exchange; the kernels treat the
     !! (variable, direction) pairs as 2*nvar independent trace lines.
     implicit none
     class(MappedVector2D),intent(inout) :: this
     type(Mesh2D),intent(inout) :: mesh
+    integer,pointer,contiguous,intent(in),optional :: mortars(:)
     ! Local
     integer :: offset
     integer(c_size_t) :: buffSize
+
+    call RejectSubset(mortars,__FILE__,__LINE__)
 
     offset = mesh%decomp%offsetElem(mesh%decomp%rankId+1)
 
@@ -377,12 +389,13 @@ contains
 
   endsubroutine MortarExchange_MappedVector2D
 
-  subroutine MPIMortarFluxAsync_MappedVector2D(this,mesh)
+  subroutine MPIMortarFluxAsync_MappedVector2D(this,mesh,mortars)
     !! One-directional messages for MortarFluxCollect on device memory : each remote
     !! small side sends its boundaryNormal trace to the big side's rank.
     implicit none
     class(MappedVector2D),intent(inout) :: this
     type(Mesh2D),intent(inout) :: mesh
+    integer,pointer,contiguous,intent(in),optional :: mortars(:)
     ! Local
     integer :: m,k,ivar
     integer :: eB,rB,eS,sS,rS
@@ -392,6 +405,8 @@ contains
     integer :: msgCount
     real(prec),pointer :: boundaryNormal(:,:,:,:)
     real(prec),pointer :: mortarBuff(:,:,:,:)
+
+    call RejectSubset(mortars,__FILE__,__LINE__)
 
     msgCount = 0
     offset = mesh%decomp%offsetElem(mesh%decomp%rankId+1)
@@ -444,16 +459,19 @@ contains
 
   endsubroutine MPIMortarFluxAsync_MappedVector2D
 
-  subroutine MortarFluxCollect_MappedVector2D(this,mesh)
+  subroutine MortarFluxCollect_MappedVector2D(this,mesh,mortars)
     !! GPU implementation of MortarFluxCollect (see the base class for the algorithm
     !! and conservation statement). Stages the small sides' boundaryNormal traces in
     !! the mortar buffer, then overwrites the big side's integrand on device.
     implicit none
     class(MappedVector2D),intent(inout) :: this
     type(Mesh2D),intent(inout) :: mesh
+    integer,pointer,contiguous,intent(in),optional :: mortars(:)
     ! Local
     integer :: offset
     integer(c_size_t) :: buffSize
+
+    call RejectSubset(mortars,__FILE__,__LINE__)
 
     offset = mesh%decomp%offsetElem(mesh%decomp%rankId+1)
 
@@ -503,10 +521,13 @@ contains
 
   endsubroutine MappedDivergence_MappedVector2D
 
-  subroutine MappedDGDivergence_MappedVector2D(this,df)
+  subroutine MappedDGDivergence_MappedVector2D(this,df,elems)
     implicit none
     class(MappedVector2D),intent(inout) :: this
     type(c_ptr),intent(out) :: df
+    integer,pointer,contiguous,intent(in),optional :: elems(:)
+
+    call RejectSubset(elems,__FILE__,__LINE__)
 
     ! Contravariant projection
     call ContravariantProjection_2D_gpu(this%interior_gpu, &

--- a/src/gpu/SELF_Mesh_2D.f90
+++ b/src/gpu/SELF_Mesh_2D.f90
@@ -82,6 +82,13 @@ contains
     this%elemMaterial = 1
     this%materialNames(1) = "default"
 
+    ! Default refinement level: a conforming, unrefined mesh. EmitMesh and the built-in
+    ! mortar meshes overwrite this with the per-element quadtree depth. This mirrors
+    ! Init_Mesh2D_t, which this routine deliberately duplicates rather than extends.
+    this%maxElemLevel = 0
+    allocate(this%elemLevel(1:nElem))
+    this%elemLevel = 0
+
     ! Create lookup tables to assist with connectivity generation
     this%CGNSCornerMap(1:2,1) = (/1,1/)
     this%CGNSCornerMap(1:2,2) = (/nGeo+1,1/)
@@ -121,8 +128,11 @@ contains
     if(allocated(this%elemMaterial)) deallocate(this%elemMaterial)
     if(allocated(this%materialNames)) deallocate(this%materialNames)
     this%nMaterials = 0
+    if(allocated(this%elemLevel)) deallocate(this%elemLevel)
+    this%maxElemLevel = 0
     if(associated(this%mortarInfo)) deallocate(this%mortarInfo)
     this%mortarInfo => null()
+    if(allocated(this%mortarLevel)) deallocate(this%mortarLevel)
     this%nMortars = 0
     call this%decomp%Free()
 

--- a/src/gpu/SELF_Scalar_2D.f90
+++ b/src/gpu/SELF_Scalar_2D.f90
@@ -181,18 +181,24 @@ contains
 
   endsubroutine UpdateDevice_Scalar2D
 
-  subroutine BoundaryInterp_Scalar2D(this)
+  subroutine BoundaryInterp_Scalar2D(this,elems)
     implicit none
     class(Scalar2D),intent(inout) :: this
+    integer,pointer,contiguous,intent(in),optional :: elems(:)
+
+    call RejectSubset(elems,__FILE__,__LINE__)
 
     call BoundaryInterp_2D_gpu(this%interp%bMatrix_gpu,this%interior_gpu,this%boundary_gpu, &
                                this%interp%N,this%nvar,this%nelem)
 
   endsubroutine BoundaryInterp_Scalar2D
 
-  subroutine AverageSides_Scalar2D(this)
+  subroutine AverageSides_Scalar2D(this,elems)
     implicit none
     class(Scalar2D),intent(inout) :: this
+    integer,pointer,contiguous,intent(in),optional :: elems(:)
+
+    call RejectSubset(elems,__FILE__,__LINE__)
 
     call Average_gpu(this%avgBoundary_gpu,this%boundary_gpu,this%extBoundary_gpu,size(this%boundary))
 

--- a/src/gpu/SELF_Vector_2D.f90
+++ b/src/gpu/SELF_Vector_2D.f90
@@ -209,17 +209,23 @@ contains
 
   endsubroutine GridInterp_Vector2D
 
-  subroutine AverageSides_Vector2D(this)
+  subroutine AverageSides_Vector2D(this,elems)
     implicit none
     class(Vector2D),intent(inout) :: this
+    integer,pointer,contiguous,intent(in),optional :: elems(:)
+
+    call RejectSubset(elems,__FILE__,__LINE__)
 
     call Average_gpu(this%avgBoundary_gpu,this%boundary_gpu,this%extBoundary_gpu,size(this%boundary))
 
   endsubroutine AverageSides_Vector2D
 
-  subroutine BoundaryInterp_Vector2D(this)
+  subroutine BoundaryInterp_Vector2D(this,elems)
     implicit none
     class(Vector2D),intent(inout) :: this
+    integer,pointer,contiguous,intent(in),optional :: elems(:)
+
+    call RejectSubset(elems,__FILE__,__LINE__)
 
     call BoundaryInterp_2D_gpu(this%interp%bMatrix_gpu,this%interior_gpu,this%boundary_gpu, &
                                this%interp%N,2*this%nvar,this%nelem)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -259,6 +259,7 @@ set_tests_properties(
 if(NOT SELF_ENABLE_GPU AND NOT SELF_ENABLE_APU)
     add_fortran_tests( "subset_operators_2d.f90"
                        "lts_2d_conservation.f90" )
+    add_mpi_fortran_tests( "lts_2d_conservation_mpi.f90" )
 endif()
 
 add_mpi_fortran_tests( "mappedvectordgdivergence_2d_linear_mpi.f90"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -250,6 +250,16 @@ set_tests_properties(
     mesh3d_read_guard_badconnectivity
     PROPERTIES WILL_FAIL TRUE)
 
+# Local time stepping (AMR Stage 7) is CPU-only for now: the GPU operators flatten the
+# element dimension into a single degree-of-freedom count and have no element-subset
+# kernel, so handing them a subset is a hard error (RejectSubset in SELF_Data) rather
+# than a silent wrong answer. These tests drive that path deliberately, so they are only
+# meaningful - and only registered - on a CPU build. Fold them back into the lists above
+# once the subset kernels exist.
+if(NOT SELF_ENABLE_GPU AND NOT SELF_ENABLE_APU)
+    add_fortran_tests( "subset_operators_2d.f90" )
+endif()
+
 add_mpi_fortran_tests( "mappedvectordgdivergence_2d_linear_mpi.f90"
                        "mappedvectordgdivergence_2d_linear_sideexchange_mpi.f90"
                        "mappedvectordgdivergence_2d_linear_structuredmesh_mpi.f90"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -257,7 +257,8 @@ set_tests_properties(
 # meaningful - and only registered - on a CPU build. Fold them back into the lists above
 # once the subset kernels exist.
 if(NOT SELF_ENABLE_GPU AND NOT SELF_ENABLE_APU)
-    add_fortran_tests( "subset_operators_2d.f90" )
+    add_fortran_tests( "subset_operators_2d.f90"
+                       "lts_2d_conservation.f90" )
 endif()
 
 add_mpi_fortran_tests( "mappedvectordgdivergence_2d_linear_mpi.f90"

--- a/test/lts_2d_conservation.f90
+++ b/test/lts_2d_conservation.f90
@@ -1,0 +1,415 @@
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+!
+! Maintainers : support@fluidnumerics.com
+! Official Repository : https://github.com/FluidNumerics/self/
+!
+! Copyright © 2024 Fluid Numerics LLC
+!
+! Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+!
+! 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+!    the documentation and/or other materials provided with the distribution.
+!
+! 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+!    this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+! HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+! LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+! THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+! THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+!
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+
+program LTS_2D_Conservation
+!! Local time stepping (AMR Stage 7) on a 2:1 nonconforming mesh: does subcycling the fine
+!! level stay conservative, and does the flux-register reflux stay quiet when it should?
+!!
+!! Assertions:
+!!
+!!  (a) The RK3 stage weights returned by rk3StageWeight really do reproduce a full
+!!      low-storage RK3 step. Everything about the flux registers rests on the telescoping
+!!      identity U^{n+1} = U^n + dt * sum_m c_m R_m, so it is checked directly against the
+!!      integrator's own rk3_a/rk3_b/rk3_g on a scalar linear ODE, to round-off.
+!!
+!!  (b) On a conforming (single-level) mesh, ForwardStepLTS reproduces the ordinary RK3
+!!      ForwardStep BITWISE. With one level there is no recursion, no mortar and no reflux,
+!!      so the two paths must be the same arithmetic in the same order - this is the check
+!!      that the LTS driver itself introduces no drift.
+!!
+!!  (c) On the three-element SimpleMortarMesh (big element at level 0, two small elements at
+!!      level 1, so the fine level really does subcycle) with reflecting boundaries, the
+!!      domain integral of the acoustic pressure is conserved across many macro steps. The
+!!      mortar projection makes each interface conservative in space; refluxing is what
+!!      makes it conservative in time when the two sides step at different rates.
+!!
+!!  (d) The same conservation statement holds on a THREE-level mesh emitted from a real
+!!      quadtree forest, where the recursion nests twice (level 2 takes four substeps per
+!!      macro step) and level 1 is simultaneously a small side of one interface and the big
+!!      side of another - the configuration in which the register bookkeeping and the
+!!      parent-window interpolation are easiest to get backwards.
+!!
+!!  (e) The solution stays finite and NaN-free.
+!!
+!! (c) is the assertion that actually exercises the flux registers: without refluxing, the
+!! coarse side would keep the lagged interface flux it used during its own stages and the
+!! integral would drift at the level of the lag.
+
+  use self_data
+  use self_lineareuler2d
+  use self_mesh_2d
+  use SELF_Model
+  use SELF_QuadTreeMesh_2D
+  use SELF_AdaptiveMesh_2D
+  use SELF_LocalTimeStepping_2D
+
+  implicit none
+
+  integer,parameter :: controlDegree = 5
+  integer,parameter :: targetDegree = 10
+  real(prec),parameter :: dx = 0.1_prec
+  real(prec),parameter :: c0 = 1.0_prec
+  real(prec),parameter :: rho0 = 1.0_prec
+  real(prec),parameter :: amp = 1.0e-4_prec
+  real(prec),parameter :: Lr = 0.05_prec
+  !! Stable on the level-0 (2*dx) element; level 1 subcycles at dtBase/2.
+  real(prec),parameter :: dtBase = 5.0e-4_prec
+  real(prec),parameter :: endtime = 0.05_prec
+  real(prec),parameter :: iointerval = 0.05_prec
+
+  type(Mesh2D),target :: keepalive
+  integer :: keepaliveBCs(1:4)
+
+  call CheckStageWeights()
+
+  keepaliveBCs(1:4) = [SELF_BC_NONORMALFLOW,SELF_BC_NONORMALFLOW, &
+                       SELF_BC_NONORMALFLOW,SELF_BC_NONORMALFLOW]
+  ! SELF releases MPI with the last live mesh; keep one alive across both cases.
+  call keepalive%StructuredMesh(2,2,1,1,dx,dx,keepaliveBCs)
+
+  call CheckConformingEquivalence()
+  call CheckMortarConservation()
+  call CheckThreeLevelConservation()
+
+  call keepalive%Free()
+
+  print*,"LTS 2D: stage weights, conforming equivalence, and two- and three-level ", &
+    "mortar conservation all pass"
+
+contains
+
+  subroutine CheckStageWeights()
+    !! Integrate y' = lambda*y over one step, once with the integrator's own 2N recursion and
+    !! once with the telescoped weights, and require the two to agree to round-off.
+    implicit none
+    ! Local
+    integer :: m
+    real(prec) :: lam,dt,y2N,yWeighted,g,r,tol
+
+    lam = -0.7_prec
+    dt = 0.31_prec
+
+    ! Williamson 2N : g is the low-storage register, r the stage tendency
+    y2N = 1.0_prec
+    g = 0.0_prec
+    do m = 1,3
+      r = lam*y2N
+      g = rk3_a(m)*g+r
+      y2N = y2N+rk3_g(m)*dt*g
+    enddo
+
+    ! Telescoped form, re-running the same stage states so that the tendencies match
+    yWeighted = 1.0_prec
+    block
+      real(prec) :: ys,gs,rr(1:3)
+      ys = 1.0_prec
+      gs = 0.0_prec
+      do m = 1,3
+        rr(m) = lam*ys
+        gs = rk3_a(m)*gs+rr(m)
+        ys = ys+rk3_g(m)*dt*gs
+      enddo
+      do m = 1,3
+        yWeighted = yWeighted+dt*rk3StageWeight(m)*rr(m)
+      enddo
+    endblock
+
+    tol = 8.0_prec*epsilon(1.0_prec)
+    if(abs(y2N-yWeighted) > tol) then
+      print*,"Error: rk3StageWeight does not reproduce a full low-storage RK3 step."
+      print*,"  2N form, weighted form, difference :",y2N,yWeighted,y2N-yWeighted
+      stop 1
+    endif
+
+    ! Consistency : the weights of any single step must sum to one.
+    if(abs(rk3StageWeight(1)+rk3StageWeight(2)+rk3StageWeight(3)-1.0_prec) > tol) then
+      print*,"Error: rk3 stage weights do not sum to one :", &
+        rk3StageWeight(1),rk3StageWeight(2),rk3StageWeight(3)
+      stop 1
+    endif
+
+  endsubroutine CheckStageWeights
+
+  subroutine CheckConformingEquivalence()
+    !! One refinement level everywhere : ForwardStepLTS must be the ordinary RK3 step,
+    !! bitwise. Any difference here is the LTS driver perturbing the single-rate path.
+    implicit none
+    ! Local
+    type(LinearEuler2D) :: mLTS,mRef
+    type(Lagrange),target :: interp
+    type(Mesh2D),target :: meshLTS,meshRef
+    type(SEMQuad),target :: geomLTS,geomRef
+    type(LTSSchedule2D) :: sched
+    integer :: bcids(1:4)
+    integer :: Np,nEl,nVar
+
+    bcids(1:4) = [SELF_BC_NONORMALFLOW,SELF_BC_NONORMALFLOW, &
+                  SELF_BC_NONORMALFLOW,SELF_BC_NONORMALFLOW]
+
+    call interp%Init(N=controlDegree,controlNodeType=GAUSS, &
+                     M=targetDegree,targetNodeType=UNIFORM)
+
+    call meshLTS%StructuredMesh(4,4,1,1,dx,dx,bcids)
+    call geomLTS%Init(interp,meshLTS%nElem)
+    call geomLTS%GenerateFromMesh(meshLTS)
+    call mLTS%Init(meshLTS,geomLTS)
+    mLTS%prescribed_bcs_enabled = .false.
+    mLTS%tecplot_enabled = .false.
+    mLTS%rho0 = rho0
+    call mLTS%SphericalSoundWave(amp,Lr,2.0_prec*dx,2.0_prec*dx,c0)
+
+    call meshRef%StructuredMesh(4,4,1,1,dx,dx,bcids)
+    call geomRef%Init(interp,meshRef%nElem)
+    call geomRef%GenerateFromMesh(meshRef)
+    call mRef%Init(meshRef,geomRef)
+    mRef%prescribed_bcs_enabled = .false.
+    mRef%tecplot_enabled = .false.
+    mRef%rho0 = rho0
+    call mRef%SphericalSoundWave(amp,Lr,2.0_prec*dx,2.0_prec*dx,c0)
+
+    call ForwardStepLTS(mLTS,sched,tn=endtime,dtBase=dtBase,ioInterval=iointerval)
+
+    call mRef%SetTimeIntegrator('rk3')
+    call mRef%ForwardStep(tn=endtime,dt=dtBase,ioInterval=iointerval)
+
+    Np = controlDegree+1
+    nEl = meshLTS%nElem
+    nVar = mLTS%solution%nVar
+
+    if(any(mLTS%solution%interior(1:Np,1:Np,1:nEl,1:nVar) /= &
+           mRef%solution%interior(1:Np,1:Np,1:nEl,1:nVar))) then
+      print*,"Error: on a single-level mesh, ForwardStepLTS did not reproduce ForwardStep."
+      print*,"  max |difference| : ", &
+        maxval(abs(mLTS%solution%interior(1:Np,1:Np,1:nEl,1:nVar)- &
+                   mRef%solution%interior(1:Np,1:Np,1:nEl,1:nVar)))
+      stop 1
+    endif
+
+    call sched%Free()
+    call mLTS%Free()
+    call mRef%Free()
+    call geomLTS%Free()
+    call geomRef%Free()
+    call meshLTS%Free()
+    call meshRef%Free()
+    call interp%Free()
+
+  endsubroutine CheckConformingEquivalence
+
+  subroutine CheckMortarConservation()
+    !! Two levels across a 2:1 mortar, reflecting boundaries : the domain integral of the
+    !! pressure must not drift while the fine level subcycles.
+    implicit none
+    ! Local
+    type(LinearEuler2D) :: modelobj
+    type(Lagrange),target :: interp
+    type(Mesh2D),target :: mesh
+    type(SEMQuad),target :: geometry
+    type(LTSSchedule2D) :: sched
+    integer :: bcids(1:4)
+    real(prec) :: m0,mf,e0,ef,scale,defect
+
+    ! No-normal-flow on every side, so the acoustic mass has nowhere to leave and any drift
+    ! in its integral is a defect of the scheme rather than of the physics.
+    bcids(1:4) = [SELF_BC_NONORMALFLOW,SELF_BC_NONORMALFLOW, &
+                  SELF_BC_NONORMALFLOW,SELF_BC_NONORMALFLOW]
+
+    call mesh%SimpleMortarMesh(dx,bcids)
+
+    if(mesh%maxElemLevel /= 1) then
+      print*,"Error: SimpleMortarMesh should report a level cap of 1, got ",mesh%maxElemLevel
+      stop 1
+    endif
+
+    call interp%Init(N=controlDegree,controlNodeType=GAUSS, &
+                     M=targetDegree,targetNodeType=UNIFORM)
+    call geometry%Init(interp,mesh%nElem)
+    call geometry%GenerateFromMesh(mesh)
+
+    call modelobj%Init(mesh,geometry)
+    modelobj%prescribed_bcs_enabled = .false.
+    modelobj%tecplot_enabled = .false.
+    modelobj%rho0 = rho0
+
+    ! Pulse centred on the mortar, so the interface carries a real signal throughout.
+    call modelobj%SphericalSoundWave(amp,Lr,2.0_prec*dx,dx,c0)
+
+    m0 = PressureIntegral(modelobj,geometry)
+    call modelobj%CalculateEntropy()
+    e0 = modelobj%entropy
+
+    call ForwardStepLTS(modelobj,sched,tn=endtime,dtBase=dtBase,ioInterval=iointerval)
+
+    mf = PressureIntegral(modelobj,geometry)
+    call modelobj%CalculateEntropy()
+    ef = modelobj%entropy
+
+    if(ef /= ef) then
+      print*,"Error: entropy is NaN after local time stepping across the mortar."
+      stop 1
+    endif
+    if(ef > e0) then
+      print*,"Error: entropy grew under local time stepping :",e0,ef
+      stop 1
+    endif
+
+    ! Scale the defect by the pulse amplitude times the domain measure, so the tolerance is
+    ! a relative one rather than a magic absolute number.
+    scale = amp*c0*c0*(6.0_prec*dx*dx)
+    defect = abs(mf-m0)/scale
+    print*,"LTS mortar conservation : integral before, after, relative defect :",m0,mf,defect
+    if(defect > 1.0e-10_prec) then
+      print*,"Error: the pressure integral drifted across the level interface. Refluxing ", &
+        "should hold this at round-off."
+      stop 1
+    endif
+
+    call sched%Free()
+    call modelobj%Free()
+    call geometry%Free()
+    call mesh%Free()
+    call interp%Free()
+
+  endsubroutine CheckMortarConservation
+
+  subroutine CheckThreeLevelConservation()
+    !! Three refinement levels emitted from a real quadtree forest, so the recursion nests
+    !! twice (level 2 subcycles four times per macro step) and level 1 acts as both a big
+    !! side and a small side at once - the configuration where the register bookkeeping and
+    !! the parent-window interpolation could most easily be wired up back to front.
+    !!
+    !! The same conservation statement as the two-level case must still hold at round-off.
+    implicit none
+    ! Local
+    type(LinearEuler2D) :: modelobj
+    type(Lagrange),target :: interp
+    type(Mesh2D),target :: baseMesh,mesh
+    type(SEMQuad),target :: geometry
+    type(QuadTreeMesh2D) :: forest
+    type(LTSSchedule2D) :: sched
+    integer :: bcids(1:4)
+    integer,allocatable :: flag(:)
+    real(prec) :: m0,mf,e0,ef,scale,defect
+
+    bcids(1:4) = [SELF_BC_NONORMALFLOW,SELF_BC_NONORMALFLOW, &
+                  SELF_BC_NONORMALFLOW,SELF_BC_NONORMALFLOW]
+
+    ! 4x4 base mesh; refine one corner twice so the forest carries levels 0, 1 and 2.
+    call baseMesh%StructuredMesh(4,4,1,1,dx,dx,bcids)
+    call forest%Init(baseMesh)
+    allocate(flag(1:forest%nLeaves)); flag = QUADTREE_KEEP; flag(1) = QUADTREE_REFINE
+    call forest%AdaptFromFlags(flag); deallocate(flag)
+    allocate(flag(1:forest%nLeaves)); flag = QUADTREE_KEEP; flag(1) = QUADTREE_REFINE
+    call forest%AdaptFromFlags(flag); deallocate(flag)
+    call forest%Balance2to1()
+    call EmitMesh(forest,baseMesh,mesh)
+
+    if(mesh%maxElemLevel /= 2) then
+      print*,"Error: the emitted forest should span three levels, got a cap of ", &
+        mesh%maxElemLevel
+      stop 1
+    endif
+    if(mesh%nMortars <= 0) then
+      print*,"Error: a 2:1-balanced three-level forest must emit mortars."
+      stop 1
+    endif
+
+    call interp%Init(N=controlDegree,controlNodeType=GAUSS, &
+                     M=targetDegree,targetNodeType=UNIFORM)
+    call geometry%Init(interp,mesh%nElem)
+    call geometry%GenerateFromMesh(mesh)
+
+    call modelobj%Init(mesh,geometry)
+    modelobj%prescribed_bcs_enabled = .false.
+    modelobj%tecplot_enabled = .false.
+    modelobj%rho0 = rho0
+
+    ! Centre the pulse on the refined corner so the signal actually crosses both level jumps.
+    call modelobj%SphericalSoundWave(amp,Lr,dx,dx,c0)
+
+    m0 = PressureIntegral(modelobj,geometry)
+    call modelobj%CalculateEntropy()
+    e0 = modelobj%entropy
+
+    call ForwardStepLTS(modelobj,sched,tn=endtime,dtBase=dtBase,ioInterval=iointerval)
+
+    mf = PressureIntegral(modelobj,geometry)
+    call modelobj%CalculateEntropy()
+    ef = modelobj%entropy
+
+    if(ef /= ef) then
+      print*,"Error: entropy is NaN after three-level local time stepping."
+      stop 1
+    endif
+    if(ef > e0) then
+      print*,"Error: entropy grew under three-level local time stepping :",e0,ef
+      stop 1
+    endif
+
+    scale = amp*c0*c0*(16.0_prec*dx*dx)
+    defect = abs(mf-m0)/scale
+    print*,"LTS three-level conservation : integral before, after, relative defect :", &
+      m0,mf,defect
+    if(defect > 1.0e-10_prec) then
+      print*,"Error: the pressure integral drifted across the three-level interfaces."
+      stop 1
+    endif
+
+    call sched%Free()
+    call modelobj%Free()
+    call geometry%Free()
+    call mesh%Free()
+    call forest%Free()
+    call baseMesh%Free()
+    call interp%Free()
+
+  endsubroutine CheckThreeLevelConservation
+
+  real(prec) function PressureIntegral(modelobj,geometry) result(total)
+    !! Jacobian-and-quadrature-weighted integral of the pressure (variable 3) over the whole
+    !! rank-local domain. With reflecting boundaries this is a conserved quantity of the
+    !! linearized acoustics, so it is the sharpest available probe of interface conservation.
+    implicit none
+    type(LinearEuler2D),intent(in) :: modelobj
+    type(SEMQuad),intent(in) :: geometry
+    ! Local
+    integer :: iel,i,j
+
+    total = 0.0_prec
+    do iel = 1,geometry%nelem
+      do j = 1,modelobj%solution%interp%N+1
+        do i = 1,modelobj%solution%interp%N+1
+          total = total+modelobj%solution%interior(i,j,iel,3)* &
+                  abs(geometry%J%interior(i,j,iel,1))* &
+                  modelobj%solution%interp%qWeights(i)* &
+                  modelobj%solution%interp%qWeights(j)
+        enddo
+      enddo
+    enddo
+
+  endfunction PressureIntegral
+
+endprogram LTS_2D_Conservation

--- a/test/lts_2d_conservation_mpi.f90
+++ b/test/lts_2d_conservation_mpi.f90
@@ -1,0 +1,174 @@
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+!
+! Maintainers : support@fluidnumerics.com
+! Official Repository : https://github.com/FluidNumerics/self/
+!
+! Copyright © 2024 Fluid Numerics LLC
+!
+! Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+!
+! 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+!    the documentation and/or other materials provided with the distribution.
+!
+! 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+!    this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+! HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+! LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+! THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+! THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+!
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+
+program LTS_2D_Conservation_MPI
+!! Multi-rank local time stepping (AMR Stage 7) across 2:1 level interfaces.
+!!
+!! This is the check that the LTS recursion is collective in the right way. Element lists
+!! are rank-local, but the mortar table, mortarLevel and hence the per-level mortar lists
+!! are replicated, so every rank walks the SAME recursion and reaches every MortarExchange
+!! and MortarFluxCollect at the same point - including ranks that own no element at the
+!! level currently being advanced, which must still participate so that the sends posted by
+!! the other side of a split interface are matched. If that were wrong the run would either
+!! deadlock or mismatch messages, and if the per-rank register bookkeeping were wrong the
+!! conservation check below would drift.
+!!
+!! DoubleMortarMesh is used precisely because its two-rank decomposition is adversarial by
+!! construction (see its docstring): mortar 1 splits the big side from its small sides across
+!! the rank boundary, while mortar 2 puts BOTH small elements on a rank remote from the big
+!! element's, so the big-side trace is received independently per sub-edge. One of its small
+!! sides also carries flip = 1, so the trace reorientation is exercised at the same time.
+!! Three-level nesting of the recursion is covered serially by lts_2d_conservation.
+!!
+!! Assertions:
+!!  (a) the run completes on >= 2 ranks (no deadlock, no message mismatch);
+!!  (b) the GLOBAL domain integral of pressure is conserved to round-off - the rank-local
+!!      integrals are summed with an allreduce, so this is a statement about the whole
+!!      domain including the interfaces that straddle a rank boundary;
+!!  (c) entropy stays finite and non-increasing, and the solution is NaN-free.
+
+  use self_data
+  use self_lineareuler2d
+  use self_mesh_2d
+  use SELF_Model
+  use SELF_LocalTimeStepping_2D
+  use mpi
+
+  implicit none
+
+  integer,parameter :: controlDegree = 5
+  integer,parameter :: targetDegree = 10
+  real(prec),parameter :: dx = 0.1_prec
+  real(prec),parameter :: c0 = 1.0_prec
+  real(prec),parameter :: rho0 = 1.0_prec
+  real(prec),parameter :: amp = 1.0e-4_prec
+  real(prec),parameter :: Lr = 0.05_prec
+  real(prec),parameter :: dtBase = 5.0e-4_prec
+  real(prec),parameter :: endtime = 0.01_prec
+  real(prec),parameter :: iointerval = 0.01_prec
+
+  type(LinearEuler2D) :: modelobj
+  type(Lagrange),target :: interp
+  type(Mesh2D),target :: mesh
+  type(SEMQuad),target :: geometry
+  type(LTSSchedule2D) :: sched
+  integer :: bcids(1:4)
+  real(prec) :: m0,mf,e0,ef,scale,defect
+
+  bcids(1:4) = [SELF_BC_NONORMALFLOW,SELF_BC_NONORMALFLOW, &
+                SELF_BC_NONORMALFLOW,SELF_BC_NONORMALFLOW]
+
+  ! Six elements, two 2:1 mortars; big elements at level 0, small elements at level 1.
+  call mesh%DoubleMortarMesh(dx,bcids)
+
+  if(mesh%maxElemLevel /= 1 .or. mesh%nMortars /= 2) then
+    print*,"Error: expected a two-level mesh with two mortars, got level cap ", &
+      mesh%maxElemLevel," and ",mesh%nMortars," mortars."
+    stop 1
+  endif
+
+  call interp%Init(N=controlDegree,controlNodeType=GAUSS, &
+                   M=targetDegree,targetNodeType=UNIFORM)
+  call geometry%Init(interp,mesh%nElem)
+  call geometry%GenerateFromMesh(mesh)
+
+  call modelobj%Init(mesh,geometry)
+  modelobj%prescribed_bcs_enabled = .false.
+  modelobj%tecplot_enabled = .false.
+  modelobj%rho0 = rho0
+
+  ! Centred on the first mortar so the interface carries a real signal from step one.
+  call modelobj%SphericalSoundWave(amp,Lr,2.0_prec*dx,dx,c0)
+
+  m0 = GlobalPressureIntegral()
+  call modelobj%CalculateEntropy()
+  e0 = modelobj%entropy
+
+  call ForwardStepLTS(modelobj,sched,tn=endtime,dtBase=dtBase,ioInterval=iointerval)
+
+  mf = GlobalPressureIntegral()
+  call modelobj%CalculateEntropy()
+  ef = modelobj%entropy
+
+  if(ef /= ef) then
+    print*,"Error: entropy is NaN after multi-rank local time stepping."
+    stop 1
+  endif
+  if(ef > e0) then
+    print*,"Error: entropy grew under multi-rank local time stepping :",e0,ef
+    stop 1
+  endif
+
+  scale = amp*c0*c0*(12.0_prec*dx*dx)
+  defect = abs(mf-m0)/scale
+  if(mesh%decomp%rankId == 0) then
+    print*,"LTS MPI conservation : integral before, after, relative defect :",m0,mf,defect
+  endif
+  if(defect > 1.0e-10_prec) then
+    print*,"Error: the global pressure integral drifted under multi-rank local time ", &
+      "stepping across the level interfaces."
+    stop 1
+  endif
+
+  call sched%Free()
+  call modelobj%Free()
+  call geometry%Free()
+  call mesh%Free()
+  call interp%Free()
+
+contains
+
+  real(prec) function GlobalPressureIntegral() result(total)
+    !! Jacobian-and-quadrature-weighted integral of the pressure over the WHOLE domain:
+    !! summed locally, then reduced, so a defect hiding on one side of a rank boundary
+    !! cannot cancel against the other side's.
+    implicit none
+    ! Local
+    integer :: iel,i,j,iError
+    real(prec) :: localSum
+
+    localSum = 0.0_prec
+    do iel = 1,geometry%nelem
+      do j = 1,modelobj%solution%interp%N+1
+        do i = 1,modelobj%solution%interp%N+1
+          localSum = localSum+modelobj%solution%interior(i,j,iel,3)* &
+                     abs(geometry%J%interior(i,j,iel,1))* &
+                     modelobj%solution%interp%qWeights(i)* &
+                     modelobj%solution%interp%qWeights(j)
+        enddo
+      enddo
+    enddo
+
+    if(mesh%decomp%mpiEnabled) then
+      call mpi_allreduce(localSum,total,1,mesh%decomp%mpiPrec,MPI_SUM, &
+                         mesh%decomp%mpiComm,iError)
+    else
+      total = localSum
+    endif
+
+  endfunction GlobalPressureIntegral
+
+endprogram LTS_2D_Conservation_MPI

--- a/test/subset_operators_2d.f90
+++ b/test/subset_operators_2d.f90
@@ -1,0 +1,231 @@
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+!
+! Maintainers : support@fluidnumerics.com
+! Official Repository : https://github.com/FluidNumerics/self/
+!
+! Copyright © 2024 Fluid Numerics LLC
+!
+! Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+!
+! 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+!    the documentation and/or other materials provided with the distribution.
+!
+! 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+!    this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+! HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+! LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+! THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+! THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+!
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+
+program Subset_Operators_2D
+!! Bitwise regression test for the element/mortar subsetting added for local time stepping
+!! (AMR Stage 7).
+!!
+!! Every tensor-product operator in the 2-D pipeline now traverses an index list instead of
+!! 1:nElem, defaulting to the identity list when no subset is supplied. That default must be
+!! indistinguishable from the original code, and a genuine subset must produce, on the
+!! elements it covers, exactly what the full evaluation produced there. Both are checked here
+!! to the LAST BIT: the whole point of routing the loops through an index list is that the
+!! arithmetic and its ordering are untouched, so anything short of bitwise equality means the
+!! restriction changed the discretization.
+!!
+!! Two meshes are exercised:
+!!
+!!   (a) a conforming structured mesh - covers BoundaryInterp, SideExchange, BoundaryFlux,
+!!       FluxMethod, SourceMethod, MappedDGDivergence and the dSdt loop;
+!!   (b) the three-element SimpleMortarMesh - additionally covers MortarExchange and
+!!       MortarFluxCollect, whose subset is a list of mortars rather than elements.
+!!
+!! The subsets used are the odd- and even-numbered elements. Their union is the whole mesh,
+!! and neither is closed under "is a neighbour of", so the test also pins down the claim that
+!! restricting BoundaryInterp to the active elements is safe: the neighbour traces a subset
+!! evaluation reads were written by an earlier call and must still be the right ones.
+
+  use self_data
+  use self_lineareuler2d
+  use self_mesh_2d
+
+  implicit none
+
+  integer,parameter :: controlDegree = 4
+  integer,parameter :: targetDegree = 7
+  real(prec),parameter :: dx = 0.1_prec
+  real(prec),parameter :: c0 = 1.0_prec
+  real(prec),parameter :: rho0 = 1.0_prec
+  real(prec),parameter :: amp = 1.0e-4_prec
+  real(prec),parameter :: Lr = 0.2_prec
+
+  ! SELF owns the MPI lifecycle and releases it when the last live mesh is freed, so a
+  ! keepalive mesh spans both cases; without it, freeing the first case's mesh would
+  ! finalize MPI and the second case could not start (see domaindecomposition_two_meshes).
+  type(Mesh2D),target :: keepalive
+  integer :: keepaliveBCs(1:4)
+
+  keepaliveBCs(1:4) = [SELF_BC_RADIATION,SELF_BC_RADIATION, &
+                       SELF_BC_RADIATION,SELF_BC_RADIATION]
+  call keepalive%StructuredMesh(2,2,1,1,dx,dx,keepaliveBCs)
+
+  if(.not. RunCase("structured")) stop 1
+  if(.not. RunCase("mortar")) stop 1
+
+  call keepalive%Free()
+
+  print*,"subset operators: full and subset tendencies agree bitwise on both meshes"
+
+contains
+
+  logical function RunCase(meshKind) result(ok)
+    !! Build a model on the named mesh, evaluate the tendency over the whole mesh, then
+    !! re-evaluate it over the odd and then the even elements, and require the restricted
+    !! results to reproduce the full one bitwise on the elements each covers.
+    implicit none
+    character(*),intent(in) :: meshKind
+    ! Local
+    type(LinearEuler2D) :: modelobj
+    type(Lagrange),target :: interp
+    type(Mesh2D),target :: mesh
+    type(SEMQuad),target :: geometry
+    integer :: bcids(1:4)
+    integer :: nEl,nVar,Np,i,nOdd,nEven
+    ! Subset lists are pointers because the subset-aware operators take pointer dummies;
+    ! see ResolveIndexList in SELF_Data for why that is the safe association.
+    integer,pointer,contiguous :: oddElem(:),evenElem(:),allMortar(:)
+    real(prec),allocatable :: dSdtFull(:,:,:,:)
+
+    ok = .false.
+
+    bcids(1:4) = [SELF_BC_RADIATION,SELF_BC_RADIATION, &
+                  SELF_BC_RADIATION,SELF_BC_RADIATION]
+
+    if(meshKind == "mortar") then
+      call mesh%SimpleMortarMesh(dx,bcids)
+    else
+      call mesh%StructuredMesh(5,4,2,2,dx,dx,bcids)
+    endif
+
+    call interp%Init(N=controlDegree,controlNodeType=GAUSS, &
+                     M=targetDegree,targetNodeType=UNIFORM)
+    call geometry%Init(interp,mesh%nElem)
+    call geometry%GenerateFromMesh(mesh)
+
+    call modelobj%Init(mesh,geometry)
+    modelobj%prescribed_bcs_enabled = .false.
+    modelobj%tecplot_enabled = .false.
+    modelobj%rho0 = rho0
+
+    ! An off-centre pulse, so the tendency is non-trivial on essentially every element.
+    call modelobj%SphericalSoundWave(amp,Lr,2.0_prec*dx,1.5_prec*dx,c0)
+
+    nEl = mesh%nElem
+    nVar = modelobj%solution%nVar
+    Np = controlDegree+1
+
+    ! ---- Reference : the full-mesh tendency, with no subset set ----
+    call modelobj%CalculateTendency()
+    allocate(dSdtFull(1:Np,1:Np,1:nEl,1:nVar))
+    dSdtFull = modelobj%dSdt%interior(1:Np,1:Np,1:nEl,1:nVar)
+
+    if(all(dSdtFull == 0.0_prec)) then
+      print*,"Error: reference tendency is identically zero on the ",meshKind," mesh; ", &
+        "the test would pass vacuously."
+      return
+    endif
+
+    ! ---- Build the odd/even element subsets ----
+    nOdd = (nEl+1)/2
+    nEven = nEl-nOdd
+    allocate(oddElem(1:nOdd),evenElem(1:max(nEven,1)))
+    nOdd = 0
+    nEven = 0
+    do i = 1,nEl
+      if(mod(i,2) == 1) then
+        nOdd = nOdd+1
+        oddElem(nOdd) = i
+      else
+        nEven = nEven+1
+        evenElem(nEven) = i
+      endif
+    enddo
+
+    ! Every mortar is active in both passes: a mortar couples two elements that the odd/even
+    ! split may place on opposite sides, so restricting the mortar list here would drop a
+    ! coupling that the reference evaluation included.
+    allocate(allMortar(1:max(mesh%nMortars,1)))
+    do i = 1,mesh%nMortars
+      allMortar(i) = i
+    enddo
+
+    ! ---- Restricted evaluations ----
+    ! Poison dSdt first, so that an operator which silently skips an element it should have
+    ! written is caught rather than reading a stale correct value.
+    modelobj%dSdt%interior = -huge(1.0_prec)
+
+    if(mesh%nMortars > 0) modelobj%activeMortar => allMortar
+
+    modelobj%activeElem => oddElem
+    call modelobj%CalculateTendency()
+    if(.not. Matches(modelobj,dSdtFull,oddElem(1:nOdd),Np,nVar,meshKind,"odd")) return
+
+    modelobj%activeElem => evenElem(1:nEven)
+    call modelobj%CalculateTendency()
+    if(.not. Matches(modelobj,dSdtFull,evenElem(1:nEven),Np,nVar,meshKind,"even")) return
+
+    ! ---- Back to the unrestricted path : it must still reproduce the reference exactly ----
+    modelobj%activeElem => null()
+    modelobj%activeMortar => null()
+    modelobj%dSdt%interior = -huge(1.0_prec)
+    call modelobj%CalculateTendency()
+    if(any(modelobj%dSdt%interior(1:Np,1:Np,1:nEl,1:nVar) /= dSdtFull)) then
+      print*,"Error: repeating the unrestricted tendency on the ",meshKind, &
+        " mesh did not reproduce the reference bitwise."
+      return
+    endif
+
+    deallocate(dSdtFull,oddElem,evenElem,allMortar)
+    call modelobj%Free()
+    call geometry%Free()
+    call mesh%Free()
+    call interp%Free()
+
+    ok = .true.
+
+  endfunction RunCase
+
+  logical function Matches(modelobj,dSdtFull,elems,Np,nVar,meshKind,label) result(ok)
+    !! Require the restricted tendency to equal the reference bitwise on every element of
+    !! elems. Elements outside elems are deliberately not checked: the restricted evaluation
+    !! is expected to leave them alone (here, still poisoned).
+    implicit none
+    type(LinearEuler2D),intent(in) :: modelobj
+    real(prec),intent(in) :: dSdtFull(:,:,:,:)
+    integer,intent(in) :: elems(:)
+    integer,intent(in) :: Np,nVar
+    character(*),intent(in) :: meshKind,label
+    ! Local
+    integer :: k,iel
+
+    ok = .true.
+    do k = 1,size(elems)
+      iel = elems(k)
+      if(any(modelobj%dSdt%interior(1:Np,1:Np,iel,1:nVar) /= &
+             dSdtFull(1:Np,1:Np,iel,1:nVar))) then
+        print*,"Error: ",label," subset tendency differs from the full tendency on the ", &
+          meshKind," mesh, element ",iel
+        print*,"  max |difference| : ", &
+          maxval(abs(modelobj%dSdt%interior(1:Np,1:Np,iel,1:nVar)- &
+                     dSdtFull(1:Np,1:Np,iel,1:nVar)))
+        ok = .false.
+        return
+      endif
+    enddo
+
+  endfunction Matches
+
+endprogram Subset_Operators_2D


### PR DESCRIPTION
Elements at refinement level `ell` are advanced at `dtBase / 2**ell` instead of every element paying the finest level's rate. Closes the "Stage 7 (design first)" gap in `docs/Learning/AdaptiveMeshRefinement.md` §5.4.

## Why the level interfaces are the whole problem

`EmitMesh` only ever emits a **conforming** side between two leaves of the *same* level, so every level jump is a 2:1 mortar. Therefore **all** coupling between different time-step sizes flows through `mortarInfo`, and `SideExchange` stays purely intra-level — within a level, a level-`ell` element's neighbours across conforming sides are themselves level `ell`, being advanced by the same substep.

## The scheme

Berger–Oliger recursion: advance level `ell` once by `dt`, recurse twice on level `ell+1` at `dt/2`, then reflux. Every level is synchronized at the end of a macro step, so entropy, IO and AMR adaptation are untouched.

- **Coarse → fine** — the coarse element has finished its step when the fine substeps run, so its stored trace is at the wrong time. The big side's trace is overwritten with a time interpolation of a short history and the ordinary `MortarExchange` restricts it onto the small sides, reusing the existing MPI path verbatim. Quadratic (3rd order, matching RK3) once the history is deep enough, linear before.
- **Fine → coarse** — coarse stages see the fine traces at `t0`, the standard Berger–Oliger lag. **Flux registers** then correct it exactly: a Williamson 2N step telescopes into `U^{n+1} = U^n + dt Σ_m c_m R_m`, and the DG surface term enters `R` linearly through `flux%boundaryNormal`, so the time-integrated interface flux can be accumulated exactly and the surface term of a register *difference* reproduces exactly the update a different interface flux would have produced.

Caveat stated in the module docblock: the coarse element's *intermediate stage* values still saw the lagged flux. For a linear system — `LinearEuler2D`, `LinearShallowWater2D`, the models AMR targets — the correction is exact in full. For a nonlinear one it is the standard AMR refluxing approximation: conservation is exact either way, the stage states are not.

## Enabling change

The tensor-product operators gain an **optional** element/mortar subset argument. Loops walk an index list instead of `1:n`; with no subset they walk a cached identity list, so trip count, order and arithmetic are unchanged and the default path is **bitwise identical**. No public interface and no abstract interface in `SELF_Model` changes.

## Scope, each a hard error rather than a silent fallback

RK3 only; **CPU only** (the GPU operators flatten the element dimension and have no subset kernel); hyperbolic only (`gradient_enabled = .false.`). GPU support is the planned follow-on.

## Verification

| Check | Result |
|---|---|
| RK3 stage weights reproduce a full 2N step | exact to round-off |
| `ForwardStepLTS` ≡ `ForwardStep`, single-level mesh | **bitwise identical**, 100 steps |
| Element/mortar subsetting ≡ full evaluation | **bitwise identical** |
| Two-level conservation | 7.1e-17 |
| Three-level conservation (quadtree forest, recursion nests twice) | 3.4e-16 |
| 2-rank MPI conservation (`DoubleMortarMesh`) | 1.8e-17 |
| Full regression suite (gfortran 11.5, debug) | **197/197**, plus 3 new tests |
| All five commits build standalone | verified |

Ultrasound example, 1 epoch at `maxLevel=1`, same 580-element mesh: 158.1 s → 123.9 s of time integration, final acoustic energies agreeing to ~12 significant figures. That is the least favourable case — the ceiling at one level is 2× and much of that mesh is refined; the saving on the coarse bulk scales with `2**maxLevel`.

A bug worth noting, caught by the bitwise-equivalence test: `t0` was passed as `model%t` and then `model%t` was written inside the step — an aliasing violation that drifted the step count. One step was bitwise-correct; 100 steps were not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)