### PR TITLE
AMR indicator: gate the smoothness ratio on a relative energy floor (#162)

### DIFF
--- a/docs/Learning/AdaptiveMeshRefinement.md
+++ b/docs/Learning/AdaptiveMeshRefinement.md
@@ -135,6 +135,29 @@ quiescent. It sits below \(\varepsilon\) in `real32`, so in a single-precision b
 term dominates and the gate is inactive unless a caller raises it — the safe direction, since a
 `real32` field cannot represent −120 dB structure anyway.
 
+#### The energy hysteresis band
+
+As described so far the gate is a **single hard cut**, which reintroduces on the energy axis exactly
+the thrashing the two \(\sigma\) thresholds exist to prevent: an element whose energy drifts across
+that one value flips `COARSEN` ↔ `REFINE` on successive epochs, churning the mesh without the
+solution changing meaningfully. `significantEnergyFloor` opens a band instead:
+
+| gate energy \(g_e\) | flag |
+| --- | --- |
+| \(\le\) quiescent floor | `COARSEN`, whatever the spectrum says |
+| between the floors | `KEEP` — hold the mesh |
+| \(>\) significant floor | the spectrum decides, as before |
+
+The middle zone reads *too weak to be worth spending levels on, too strong to declare resolved*,
+and is stable under a small change in amplitude. Inside the band \(\sigma_e\) still reports the
+**true** spectrum — the band holds the flag, it does not falsify the diagnostic — so for those
+elements `flag` is deliberately not what thresholding \(\sigma_e\) would give.
+
+It defaults to the quiescent floor, collapsing the band to the single cut, so behaviour is
+unchanged unless a caller opts in. `test/refinement_indicator_2d_energy_hysteresis.f90` covers the
+three zones and asserts that an in-band energy drifting by a factor of ten either way does not move
+the flag, while the same drift across a degenerate band does.
+
 **Raising the floor is not free.** The gate cannot distinguish residue from the low-amplitude
 *flank* of a feature that is genuinely under-resolved, so an aggressive floor buys element count at
 the cost of refinement **depth**. Measured on the ultrasound point-source benchmark
@@ -202,6 +225,8 @@ call amr%Init(interp, nElem, refineThreshold=-3.0_prec, coarsenThreshold=-8.0_pr
 
 ! Amplitude gate (all optional; these are the defaults unless set).
 call amr%SetRelativeEnergyFloor(1.0e-12_prec) ! 0 disables the gate
+call amr%SetRelativeEnergyFloor(1.0e-12_prec, &  ! ... or open a hysteresis band
+                                significantEnergyFloor=1.0e-10_prec)
 call amr%SetEnergyScale(pRef**2)              ! pin the scale; ClearEnergyScale undoes it
 call amr%SetEnergyWeights(w)                  ! per-variable gate weights, e.g. from the entropy
 

--- a/docs/Learning/AdaptiveMeshRefinement.md
+++ b/docs/Learning/AdaptiveMeshRefinement.md
@@ -158,6 +158,18 @@ unchanged unless a caller opts in. `test/refinement_indicator_2d_energy_hysteres
 three zones and asserts that an in-band energy drifting by a factor of ten either way does not move
 the flag, while the same drift across a degenerate band does.
 
+**Keep the band narrow.** Its upper edge is functionally *"do not spend levels below this energy"* —
+the same knob as the floor, with the same cost in refinement depth. On the ultrasound benchmark's
+initial adaptation, with a quiescent floor of \(10^{-12}\):
+
+| significant floor | 1e-12 | 3e-12 | 1e-11 | 3e-11 | 1e-10 |
+| --- | --- | --- | --- | --- | --- |
+| elements / max level | 328 / 2 | 328 / 2 | **268 / 1** | 268 / 1 | 268 / 1 |
+
+A band up to ~3× the floor leaves depth untouched; at 10× it collapses a level, exactly as raising
+the floor to \(10^{-10}\) does. The band is a thrash damper, not a savings knob — widen it only as
+far as is needed to stop flags oscillating.
+
 **Raising the floor is not free.** The gate cannot distinguish residue from the low-amplitude
 *flank* of a feature that is genuinely under-resolved, so an aggressive floor buys element count at
 the cost of refinement **depth**. Measured on the ultrasound point-source benchmark

--- a/docs/Learning/AdaptiveMeshRefinement.md
+++ b/docs/Learning/AdaptiveMeshRefinement.md
@@ -130,13 +130,28 @@ so a quiescent element is reported perfectly resolved (\(\sigma_e = \log_{10}\va
 `COARSEN`) whatever its modal shape.
 
 Because energy is amplitude squared, `relativeEnergyFloor` is \(10^{dB/10}\) in amplitude terms.
-The default is \(10^{-8}\) — amplitudes below \(10^{-4}\) (−80 dB) of the field scale count as
-quiescent — and it is precision-aware (`max(1e-8, epsilon)`), because in `real32`
-\(\varepsilon = 1.2\times10^{-7}\) would otherwise mask the relative term for any field scale of
-order one. **The right value is problem-dependent**: it must sit below the dynamic range you care
-about and above the residue you want released. A 2-D cylindrical pulse, for instance, leaves a
-genuine algebraically-decaying tail behind its front (Huygens' principle fails in even dimensions),
-which is a physical feature rather than residue and is only released by a much larger floor.
+The default is \(10^{-12}\): amplitudes below \(10^{-6}\) (−120 dB) of the field scale count as
+quiescent. It sits below \(\varepsilon\) in `real32`, so in a single-precision build the absolute
+term dominates and the gate is inactive unless a caller raises it — the safe direction, since a
+`real32` field cannot represent −120 dB structure anyway.
+
+**Raising the floor is not free.** The gate cannot distinguish residue from the low-amplitude
+*flank* of a feature that is genuinely under-resolved, so an aggressive floor buys element count at
+the cost of refinement **depth**. Measured on the ultrasound point-source benchmark
+(`examples/linear_euler2d_amr_ultrasound_pointsource`, 30 epochs, `maxLevel = 2`):
+
+| `relativeEnergyFloor` | initial adaptation | mean elements | final |
+| --- | --- | --- | --- |
+| 0 (no gate) | 328, level 2 | 1482 | 1732 |
+| **1e-12 (default)** | **328, level 2** | **1057 (1.40x fewer)** | **1528** |
+| 1e-8 | 268, level **1** | 2210 | 3304 |
+
+At `1e-8` the gate also suppresses the source pulse's skirt, so the forest never reaches the level
+cap; `RecommendedTimeStep` is tied to the max level, so `dt` doubles, and the resulting
+time-integration error drives enough later refinement to roughly *double* the final mesh. Measure
+before raising this. A related trap: a 2-D cylindrical pulse leaves a genuine algebraically-decaying
+tail behind its front (Huygens' principle fails in even dimensions), which is physics rather than
+residue and should not be gated away.
 
 `energyScale` defaults to the largest \(g_e\) over the elements, reduced with `MPI_MAX` when the
 indicator is given a communicator, so the gate follows a decaying front. Two consequences worth
@@ -186,7 +201,7 @@ type(RefinementIndicator2D) :: amr
 call amr%Init(interp, nElem, refineThreshold=-3.0_prec, coarsenThreshold=-8.0_prec)
 
 ! Amplitude gate (all optional; these are the defaults unless set).
-call amr%SetRelativeEnergyFloor(1.0e-8_prec)  ! 0 disables the gate
+call amr%SetRelativeEnergyFloor(1.0e-12_prec) ! 0 disables the gate
 call amr%SetEnergyScale(pRef**2)              ! pin the scale; ClearEnergyScale undoes it
 call amr%SetEnergyWeights(w)                  ! per-variable gate weights, e.g. from the entropy
 

--- a/docs/Learning/AdaptiveMeshRefinement.md
+++ b/docs/Learning/AdaptiveMeshRefinement.md
@@ -96,6 +96,62 @@ term is the robustification introduced by **Hennemann, Rueda-Ramírez, Hindenlan
 (2021)** — the shock indicator used in Trixi.jl — which guards against the odd/even parity
 dropouts a single-mode measure suffers for symmetric data. It is only active for \(N\ge 2\).
 
+### 2.1.1 The amplitude gate (relative energy floor)
+
+\(S_e\) is a **ratio**, so it is scale-free by construction: it reports how an element's energy is
+distributed across modes and says nothing about how much energy the element carries. Grid-scale
+residue at \(10^{-5}\) of the field's amplitude has exactly the same \(S_e\approx 1\) as a
+full-amplitude discontinuity.
+
+Guarding the ratio with an *absolute* floor at machine epsilon does not fix this, because
+\(E_{\text{tot}}\) carries the **square** of the field amplitude while \(\varepsilon\) is a fixed
+\(2.2\times10^{-16}\): a wake at \(10^{-5}\) of the peak sits some ten orders of magnitude above the
+floor and is still judged on shape alone. Such elements never reach
+\(\sigma_{\text{coarsen}}\), so the mesh behind a passing front is never released and the refined
+region grows to the whole area the wave has swept (issue #162).
+
+Each element therefore also carries a **gate energy**
+
+$$
+g_e = \sum_v w_v\,E_{\text{tot},e,v},
+$$
+
+a weighted sum of the per-variable modal energies. Since \(E_{\text{tot},e,v}\) is the exact \(L^2\)
+energy of variable \(v\) on the reference element, \(g_e\) is a convex quadratic functional of the
+state — a **discrete entropy integral** over the element when \(w\) is taken from the diagonal of an
+entropy Hessian. It is compared against a field-wide energy scale,
+
+$$
+g_e \;\le\; \max\!\left(\varepsilon,\; \texttt{relativeEnergyFloor}\cdot \texttt{energyScale}\right)
+\quad\Longrightarrow\quad S_e := 0 ,
+$$
+
+so a quiescent element is reported perfectly resolved (\(\sigma_e = \log_{10}\varepsilon\), hence
+`COARSEN`) whatever its modal shape.
+
+Because energy is amplitude squared, `relativeEnergyFloor` is \(10^{dB/10}\) in amplitude terms.
+The default is \(10^{-8}\) — amplitudes below \(10^{-4}\) (−80 dB) of the field scale count as
+quiescent — and it is precision-aware (`max(1e-8, epsilon)`), because in `real32`
+\(\varepsilon = 1.2\times10^{-7}\) would otherwise mask the relative term for any field scale of
+order one. **The right value is problem-dependent**: it must sit below the dynamic range you care
+about and above the residue you want released. A 2-D cylindrical pulse, for instance, leaves a
+genuine algebraically-decaying tail behind its front (Huygens' principle fails in even dimensions),
+which is a physical feature rather than residue and is only released by a much larger floor.
+
+`energyScale` defaults to the largest \(g_e\) over the elements, reduced with `MPI_MAX` when the
+indicator is given a communicator, so the gate follows a decaying front. Two consequences worth
+knowing:
+
+- the automatic scale makes the flags depend on a floating-point reduction, which can differ at
+  round-off between rank counts — `SetEnergyScale` pins it and is the deterministic escape hatch;
+- once a wave has left the domain entirely the scale collapses onto the residue's own peak and the
+  gate stops discriminating; the absolute \(\varepsilon\) floor is what bounds that case.
+
+Note that raising \(\sigma_{\text{coarsen}}\) is **not** a substitute. In a low-amplitude wake
+\(\sigma_e\) is near \(0\), so any threshold high enough to coarsen the wake is also high enough to
+stop the front from refining; the two decisions cannot be separated by thresholds alone, which is
+what motivates an amplitude-based gate.
+
 ### 2.2 Refine / keep / coarsen semantics
 
 With user-supplied thresholds \(\sigma_{\text{refine}} > \sigma_{\text{coarsen}}\), each element
@@ -129,14 +185,30 @@ type(RefinementIndicator2D) :: amr
 ! interp : the model interpolant (Lagrange); nElem : rank-local element count
 call amr%Init(interp, nElem, refineThreshold=-3.0_prec, coarsenThreshold=-8.0_prec)
 
+! Amplitude gate (all optional; these are the defaults unless set).
+call amr%SetRelativeEnergyFloor(1.0e-8_prec)  ! 0 disables the gate
+call amr%SetEnergyScale(pRef**2)              ! pin the scale; ClearEnergyScale undoes it
+call amr%SetEnergyWeights(w)                  ! per-variable gate weights, e.g. from the entropy
+
 ! solution : the model's MappedScalar2D (or any Scalar2D); ivar selects the driving
 ! variable, or SELF_AMR_ALLVARS (=0) reduces over all variables (most conservative).
+! comm : optional, makes the automatic energy scale global (MPI_MAX).
+! gate : optional, a caller-computed per-element gate energy replacing the weighted sum.
 call amr%Estimate(solution, ivar=1)
 
 ! amr%indicator(1:nElem)  -- per-element sigma_e (host)
 ! amr%flag(1:nElem)       -- per-element SELF_AMR_REFINE / KEEP / COARSEN (host)
+! amr%gate(1:nElem)       -- per-element gate energy actually used (host, diagnostic)
 n = amr%CountFlagged(SELF_AMR_REFINE)
 ```
+
+The estimate runs in two phases: an element-local, parallel (device) pass that forms the spectra,
+the raw \(S_e\) and \(g_e\); then a host pass that reduces for the energy scale, applies the gate,
+takes the \(\log_{10}\) and sets the flags. The second phase is host-side because the scale needs a
+reduction that no element-local pass can supply, and it is shared by both backends, so CPU and GPU
+produce identical flags. `AMRController2D` forwards `relativeEnergyFloor` and `energyWeights` from
+its own `Init` and re-applies them after each epoch's indicator resize; it also supplies the
+communicator so the scale is global.
 
 The GPU device kernel uses per-thread scratch bounded to \(N \le 15\); higher degrees fail
 loudly at `Init` with a pointer to the bound (`AMR2D_MAXNP` in `SELF_Refinement.cpp`).

--- a/examples/linear_euler2d_amr_ultrasound_pointsource.f90
+++ b/examples/linear_euler2d_amr_ultrasound_pointsource.f90
@@ -74,6 +74,10 @@ program LinearEuler2D_AMR_Ultrasound_PointSource
 !!   SELF_AMR_ULTRASOUND_LR        source half-width in m, overriding the maxLevel-derived
 !!                                 value; f0 ~ c0/(4*Lr).
 !!   SELF_AMR_ULTRASOUND_EPOCHLEN  adaptation cadence in s, overriding stepsPerEpoch * dt.
+!!   SELF_AMR_ULTRASOUND_RELFLOOR  relative energy floor of the indicator's amplitude gate
+!!                                 (default SELF_AMR_DEFAULT_RELFLOOR); 0 disables the gate.
+!!   SELF_AMR_ULTRASOUND_SIGNIFFLOOR  upper edge of the gate's hysteresis band (default: the
+!!                                 floor itself, i.e. a single hard cut).
 !!
 !! The run prints a CONFIG_* block (resolved resolution, f0, points per wavelength) and a
 !! BENCH_* block (wall-clock split between time integration and adaptation) so a sweep over
@@ -123,7 +127,7 @@ program LinearEuler2D_AMR_Ultrasound_PointSource
   logical :: adapted
   real(prec) :: e0,ef,dt
   real(prec) :: Lr,LrRamp,epochLength,hFinest,lambda,f0,ppw
-  real(prec) :: relativeEnergyFloor
+  real(prec) :: relativeEnergyFloor,significantEnergyFloor
   character(32) :: envstr
   ! Wall-clock instrumentation of the epoch loop. system_clock with an integer(int64) count
   ! is a monotonic wall clock; ForwardStep's own TIMER macro (src/SELF_Macros.h) expands to
@@ -187,6 +191,15 @@ program LinearEuler2D_AMR_Ultrasound_PointSource
     read(envstr,*) relativeEnergyFloor
   endif
 
+  ! Upper edge of the amplitude gate's hysteresis band (see SELF_RefinementIndicator_2D).
+  ! Defaults to the floor itself, i.e. a single hard cut; overridable so the band's effect on
+  ! element count can be swept the same way the floor's was.
+  significantEnergyFloor = relativeEnergyFloor
+  call get_environment_variable("SELF_AMR_ULTRASOUND_SIGNIFFLOOR",envstr,status=envstat)
+  if(envstat == 0) then
+    read(envstr,*) significantEnergyFloor
+  endif
+
   ! Resolution actually being requested, reported so a sweep over maxLevel is interpretable.
   hFinest = Lx/real(nElemX,prec)/2.0_prec**maxLevel
   lambda = 4.0_prec*Lr ! dominant wavelength of the wavelet
@@ -200,6 +213,7 @@ program LinearEuler2D_AMR_Ultrasound_PointSource
   write(output_unit,'(A,ES16.7E3)') "CONFIG_pointsPerWavelength = ",ppw
   write(output_unit,'(A,ES16.7E3)') "CONFIG_epochLength_s = ",epochLength
   write(output_unit,'(A,ES16.7E3)') "CONFIG_relativeEnergyFloor = ",relativeEnergyFloor
+  write(output_unit,'(A,ES16.7E3)') "CONFIG_significantEnergyFloor = ",significantEnergyFloor
 
   bcids(1:4) = [SELF_BC_RADIATION, & ! south
                 SELF_BC_RADIATION, & ! east
@@ -222,7 +236,8 @@ program LinearEuler2D_AMR_Ultrasound_PointSource
 
   call controller%Init(modelobj,refineThreshold=-3.0_prec,coarsenThreshold=-8.0_prec, &
                        ivar=3,maxLevel=maxLevel,nHalo=2, &
-                       relativeEnergyFloor=relativeEnergyFloor)
+                       relativeEnergyFloor=relativeEnergyFloor, &
+                       significantEnergyFloor=significantEnergyFloor)
 
   ! ---- Initial condition + static refinement to the pulse ----
   ! After each mesh change the pulse is re-evaluated analytically on the new mesh so the

--- a/examples/linear_euler2d_amr_ultrasound_pointsource.f90
+++ b/examples/linear_euler2d_amr_ultrasound_pointsource.f90
@@ -123,6 +123,7 @@ program LinearEuler2D_AMR_Ultrasound_PointSource
   logical :: adapted
   real(prec) :: e0,ef,dt
   real(prec) :: Lr,LrRamp,epochLength,hFinest,lambda,f0,ppw
+  real(prec) :: relativeEnergyFloor
   character(32) :: envstr
   ! Wall-clock instrumentation of the epoch loop. system_clock with an integer(int64) count
   ! is a monotonic wall clock; ForwardStep's own TIMER macro (src/SELF_Macros.h) expands to
@@ -174,6 +175,18 @@ program LinearEuler2D_AMR_Ultrasound_PointSource
     read(envstr,*) epochLength
   endif
 
+  ! Amplitude gate of the refinement indicator (see SELF_RefinementIndicator_2D): elements below
+  ! this fraction of the field's peak ENERGY are treated as quiescent and released. Overridable
+  ! because the useful value is problem-dependent - it has to sit below the dynamic range of
+  ! interest and above the residue left behind the front - and because sweeping it is how the
+  ! saving from coarsening behind the wave is measured. 0 restores the pre-gate behaviour, in
+  ! which the wake is never released and the refined region grows to the whole swept area.
+  relativeEnergyFloor = SELF_AMR_DEFAULT_RELFLOOR
+  call get_environment_variable("SELF_AMR_ULTRASOUND_RELFLOOR",envstr,status=envstat)
+  if(envstat == 0) then
+    read(envstr,*) relativeEnergyFloor
+  endif
+
   ! Resolution actually being requested, reported so a sweep over maxLevel is interpretable.
   hFinest = Lx/real(nElemX,prec)/2.0_prec**maxLevel
   lambda = 4.0_prec*Lr ! dominant wavelength of the wavelet
@@ -186,6 +199,7 @@ program LinearEuler2D_AMR_Ultrasound_PointSource
   write(output_unit,'(A,ES16.7E3)') "CONFIG_f0_Hz = ",f0
   write(output_unit,'(A,ES16.7E3)') "CONFIG_pointsPerWavelength = ",ppw
   write(output_unit,'(A,ES16.7E3)') "CONFIG_epochLength_s = ",epochLength
+  write(output_unit,'(A,ES16.7E3)') "CONFIG_relativeEnergyFloor = ",relativeEnergyFloor
 
   bcids(1:4) = [SELF_BC_RADIATION, & ! south
                 SELF_BC_RADIATION, & ! east
@@ -207,7 +221,8 @@ program LinearEuler2D_AMR_Ultrasound_PointSource
   call modelobj%SetTimeIntegrator(integrator)
 
   call controller%Init(modelobj,refineThreshold=-3.0_prec,coarsenThreshold=-8.0_prec, &
-                       ivar=3,maxLevel=maxLevel,nHalo=2)
+                       ivar=3,maxLevel=maxLevel,nHalo=2, &
+                       relativeEnergyFloor=relativeEnergyFloor)
 
   ! ---- Initial condition + static refinement to the pulse ----
   ! After each mesh change the pulse is re-evaluated analytically on the new mesh so the

--- a/src/SELF_AMRController_2D.f90
+++ b/src/SELF_AMRController_2D.f90
@@ -127,12 +127,18 @@ module SELF_AMRController_2D
     integer :: nHalo = 1 !! refine-flag halo-expansion passes
     real(prec) :: refineThreshold = 0.0_prec
     real(prec) :: coarsenThreshold = 0.0_prec
+    ! Amplitude-gate settings forwarded to the indicator. They are held here because the indicator
+    ! is Freed and re-Init-ed (intent(out)) at the end of every adapting epoch, which resets its
+    ! own copies; the controller re-applies these afterwards.
+    real(prec) :: relativeEnergyFloor = SELF_AMR_DEFAULT_RELFLOOR
+    real(prec),allocatable :: energyWeights(:)
 
   contains
     procedure,public :: Init => Init_AMRController2D
     procedure,public :: Free => Free_AMRController2D
     procedure,public :: Adapt => Adapt_AMRController2D
     procedure,public :: RecommendedTimeStep => RecommendedTimeStep_AMRController2D
+    procedure,private :: ApplyIndicatorSettings => ApplyIndicatorSettings_AMRController2D
     procedure,private :: NextGeomBuffer => NextGeomBuffer_AMRController2D
     procedure,private :: BuildGeometry => BuildGeometry_AMRController2D
 
@@ -141,7 +147,7 @@ module SELF_AMRController_2D
 contains
 
   subroutine Init_AMRController2D(this,model,refineThreshold,coarsenThreshold,ivar, &
-                                  maxLevel,nHalo)
+                                  maxLevel,nHalo,relativeEnergyFloor,energyWeights)
     !! Attach the controller to an initialized model. The model's current mesh becomes the
     !! forest's base mesh (level 0); its geometry interpolant drives the indicator and the
     !! solution transfer. Thresholds are the sigma = log10 modal-energy-ratio cut-offs of the
@@ -149,6 +155,14 @@ contains
     !! SELF_RefinementIndicator_2D). ivar is the driving solution variable (or
     !! SELF_AMR_ALLVARS). maxLevel >= 0 caps the refinement depth; nHalo >= 0 sets the
     !! refine-flag halo width in elements.
+    !!
+    !! relativeEnergyFloor tunes the indicator's amplitude gate: an element whose energy is below
+    !! this fraction of the field's peak element energy is treated as quiescent (hence resolved)
+    !! regardless of its modal shape, which is what allows the mesh to be released behind a
+    !! passing front. It is an energy fraction, so the square of the corresponding amplitude
+    !! fraction; 0 disables the gate. energyWeights optionally weights the per-variable energies
+    !! that form the gate, e.g. from the model's entropy function - see
+    !! RefinementIndicator2D%SetEnergyWeights. Both default to the indicator's own defaults.
     implicit none
     class(AMRController2D),intent(out) :: this
     class(DGModel2D_t),intent(in) :: model
@@ -157,6 +171,8 @@ contains
     integer,intent(in) :: ivar
     integer,intent(in) :: maxLevel
     integer,intent(in) :: nHalo
+    real(prec),intent(in),optional :: relativeEnergyFloor
+    real(prec),intent(in),optional :: energyWeights(:)
 
     if(.not. associated(model%mesh)) then
       print*,__FILE__,':',__LINE__, &
@@ -179,6 +195,11 @@ contains
     this%nHalo = nHalo
     this%refineThreshold = refineThreshold
     this%coarsenThreshold = coarsenThreshold
+    if(present(relativeEnergyFloor)) this%relativeEnergyFloor = relativeEnergyFloor
+    if(present(energyWeights)) then
+      allocate(this%energyWeights(1:size(energyWeights)))
+      this%energyWeights = energyWeights
+    endif
 
     ! Rank-replicated forest: on one rank, straight from the mesh; on several, from the
     ! allgathered global base tables (every rank builds the identical forest).
@@ -188,8 +209,23 @@ contains
       call this%forest%Init(model%mesh)
     endif
     call this%indicator%Init(this%interp,model%mesh%nElem,refineThreshold,coarsenThreshold)
+    call this%ApplyIndicatorSettings()
 
   endsubroutine Init_AMRController2D
+
+  subroutine ApplyIndicatorSettings_AMRController2D(this)
+    !! Push the controller-owned amplitude-gate settings onto the indicator. Called after every
+    !! indicator Init, because Init is intent(out) and therefore resets them to the indicator's
+    !! defaults. The setters carry the validation.
+    implicit none
+    class(AMRController2D),intent(inout) :: this
+
+    call this%indicator%SetRelativeEnergyFloor(this%relativeEnergyFloor)
+    if(allocated(this%energyWeights)) then
+      call this%indicator%SetEnergyWeights(this%energyWeights)
+    endif
+
+  endsubroutine ApplyIndicatorSettings_AMRController2D
 
   subroutine InitForestFromDecomposedMesh(forest,mesh)
     !! Build a rank-replicated forest over a decomposed base mesh: allgather the global
@@ -522,6 +558,7 @@ contains
     this%nGeomGenerated = 0
     this%interp => null()
     this%ownsActive = .false.
+    if(allocated(this%energyWeights)) deallocate(this%energyWeights)
 
   endsubroutine Free_AMRController2D
 
@@ -567,7 +604,16 @@ contains
     ! The indicator is rank-local; the (replicated) forest needs the global per-leaf flags, so
     ! on nRanks > 1 they are allgathered by the active decomposition's element ranges. From
     ! here on every rank applies identical mutations to its identical forest copy.
-    call this%indicator%Estimate(model%solution,this%ivar)
+    ! The indicator's amplitude gate normalizes each element's energy by the peak element energy,
+    ! so on several ranks that peak must be global: otherwise the gate - and hence the flags and
+    ! the adapted mesh - would depend on the decomposition. That is one extra small collective per
+    ! epoch, alongside the flag allgather below, and none inside the time-stepping loop.
+    if(model%mesh%decomp%mpiEnabled) then
+      call this%indicator%Estimate(model%solution,this%ivar, &
+                                   comm=model%mesh%decomp%mpiComm)
+    else
+      call this%indicator%Estimate(model%solution,this%ivar)
+    endif
     nOld = this%forest%nLeaves
     allocate(flag(1:nOld))
     if(model%mesh%decomp%nRanks > 1) then
@@ -703,6 +749,10 @@ contains
     call this%indicator%Free()
     call this%indicator%Init(this%interp,newMesh%nElem, &
                              this%refineThreshold,this%coarsenThreshold)
+    ! Only controller-owned indicator settings survive an epoch. A driver that called
+    ! indicator%SetEnergyScale (or SetEnergyWeights) directly must re-apply it after any epoch
+    ! that reported adapted = .true.
+    call this%ApplyIndicatorSettings()
 
     adapted = .true.
 

--- a/src/SELF_AMRController_2D.f90
+++ b/src/SELF_AMRController_2D.f90
@@ -131,6 +131,7 @@ module SELF_AMRController_2D
     ! is Freed and re-Init-ed (intent(out)) at the end of every adapting epoch, which resets its
     ! own copies; the controller re-applies these afterwards.
     real(prec) :: relativeEnergyFloor = SELF_AMR_DEFAULT_RELFLOOR
+    real(prec) :: significantEnergyFloor = SELF_AMR_DEFAULT_RELFLOOR
     real(prec),allocatable :: energyWeights(:)
 
   contains
@@ -147,7 +148,8 @@ module SELF_AMRController_2D
 contains
 
   subroutine Init_AMRController2D(this,model,refineThreshold,coarsenThreshold,ivar, &
-                                  maxLevel,nHalo,relativeEnergyFloor,energyWeights)
+                                  maxLevel,nHalo,relativeEnergyFloor,energyWeights, &
+                                  significantEnergyFloor)
     !! Attach the controller to an initialized model. The model's current mesh becomes the
     !! forest's base mesh (level 0); its geometry interpolant drives the indicator and the
     !! solution transfer. Thresholds are the sigma = log10 modal-energy-ratio cut-offs of the
@@ -162,7 +164,9 @@ contains
     !! passing front. It is an energy fraction, so the square of the corresponding amplitude
     !! fraction; 0 disables the gate. energyWeights optionally weights the per-variable energies
     !! that form the gate, e.g. from the model's entropy function - see
-    !! RefinementIndicator2D%SetEnergyWeights. Both default to the indicator's own defaults.
+    !! RefinementIndicator2D%SetEnergyWeights. significantEnergyFloor opens a hysteresis band on
+    !! the energy axis: elements between the two floors hold their mesh (SELF_AMR_KEEP) instead of
+    !! flipping across a single hard cut. All three default to the indicator's own defaults.
     implicit none
     class(AMRController2D),intent(out) :: this
     class(DGModel2D_t),intent(in) :: model
@@ -173,6 +177,7 @@ contains
     integer,intent(in) :: nHalo
     real(prec),intent(in),optional :: relativeEnergyFloor
     real(prec),intent(in),optional :: energyWeights(:)
+    real(prec),intent(in),optional :: significantEnergyFloor
 
     if(.not. associated(model%mesh)) then
       print*,__FILE__,':',__LINE__, &
@@ -195,7 +200,11 @@ contains
     this%nHalo = nHalo
     this%refineThreshold = refineThreshold
     this%coarsenThreshold = coarsenThreshold
-    if(present(relativeEnergyFloor)) this%relativeEnergyFloor = relativeEnergyFloor
+    if(present(relativeEnergyFloor)) then
+      this%relativeEnergyFloor = relativeEnergyFloor
+      this%significantEnergyFloor = relativeEnergyFloor
+    endif
+    if(present(significantEnergyFloor)) this%significantEnergyFloor = significantEnergyFloor
     if(present(energyWeights)) then
       allocate(this%energyWeights(1:size(energyWeights)))
       this%energyWeights = energyWeights
@@ -220,7 +229,8 @@ contains
     implicit none
     class(AMRController2D),intent(inout) :: this
 
-    call this%indicator%SetRelativeEnergyFloor(this%relativeEnergyFloor)
+    call this%indicator%SetRelativeEnergyFloor(this%relativeEnergyFloor, &
+                                               significantEnergyFloor=this%significantEnergyFloor)
     if(allocated(this%energyWeights)) then
       call this%indicator%SetEnergyWeights(this%energyWeights)
     endif

--- a/src/SELF_RefinementIndicator_2D_t.f90
+++ b/src/SELF_RefinementIndicator_2D_t.f90
@@ -368,6 +368,18 @@ contains
     !!
     !! Must satisfy quiescent floor <= significant floor < 1. It defaults to the quiescent floor,
     !! which collapses the band to the single cut and reproduces the ungapped behaviour exactly.
+    !!
+    !! KEEP THE BAND NARROW. Its upper edge is functionally "do not spend levels below this
+    !! energy", which is the same knob as the floor itself and carries the same cost in refinement
+    !! depth. Measured on the ultrasound benchmark's initial adaptation (see
+    !! SELF_AMR_DEFAULT_RELFLOOR), with a quiescent floor of 1e-12:
+    !!
+    !!   significant floor   1e-12   3e-12   1e-11   3e-11   1e-10
+    !!   elements / level    328/2   328/2   268/1   268/1   268/1
+    !!
+    !! A band up to ~3x the floor leaves refinement depth untouched; at 10x it collapses a level,
+    !! exactly as raising the floor to 1e-10 does. The band is a thrash damper, not a savings knob:
+    !! widen it only as far as is needed to stop flags oscillating.
     implicit none
     class(RefinementIndicator2D_t),intent(inout) :: this
     real(prec),intent(in) :: relativeEnergyFloor

--- a/src/SELF_RefinementIndicator_2D_t.f90
+++ b/src/SELF_RefinementIndicator_2D_t.f90
@@ -66,6 +66,44 @@ module SELF_RefinementIndicator_2D_t
 !! the base-10 logarithm sigma_e = log10(S_e); a near-machine-zero floor keeps it finite for a
 !! perfectly resolved (or identically zero) field.
 !!
+!! ## Amplitude gate (relative energy floor)
+!!
+!! S_e is a ratio and therefore scale-free: it says nothing about how much energy an element
+!! carries, only how that energy is distributed across modes. An element holding a negligible
+!! share of the field's energy - low-amplitude grid-scale residue in the wake of a passing wave,
+!! say - still shows a flat modal spectrum and so reads as under-resolved forever. Guarding the
+!! ratio with an absolute floor at machine epsilon does not help: E_tot carries the SQUARE of the
+!! field amplitude, so a wake at 1e-5 of the peak amplitude sits ~1e10 above epsilon and still
+!! takes the ratio branch. Such elements are never flagged for coarsening and the mesh behind a
+!! front is never released.
+!!
+!! The fix is a second, RELATIVE floor. A per-element gate energy
+!!
+!!   g_e = sum_v w_v E_tot,e,v
+!!
+!! is formed from the modal energies of the driving variables with non-negative weights w_v. Since
+!! E_tot,e,v is the exact L2 energy of variable v on the reference element, g_e with w taken from
+!! a quadratic entropy function is the discrete entropy integral over the element: a convex
+!! function of the state, and therefore an amplitude measure that is meaningful across variables of
+!! very different magnitude. Comparing it against a field-wide energy scale,
+!!
+!!   effective floor = max( epsilon, relativeEnergyFloor * energyScale )
+!!   g_e <= effective floor   ->   S_e := 0   (element is quiescent, hence resolved)
+!!
+!! gives an amplitude gate that is independent of the modal shape. Because energy goes as
+!! amplitude squared, relativeEnergyFloor is 10**(dB/10) in amplitude terms: the default 1e-8
+!! treats amplitudes below 1e-4 (-80 dB) of the field scale as quiescent.
+!!
+!! energyScale defaults to the largest gate energy over the elements (globally reduced when
+!! Estimate is given an MPI communicator), which makes the gate track a decaying front. It can be
+!! pinned with SetEnergyScale for callers that need the flag decision to be independent of a
+!! floating-point reduction, and the gate itself can be supplied outright through the optional
+!! gate argument to Estimate (for example an exactly integrated nodal entropy).
+!!
+!! Note that raising coarsenThreshold is NOT a substitute: in a low-amplitude wake sigma_e is near
+!! 0, so any threshold high enough to coarsen the wake also stops a genuine front from refining.
+!! The two decisions cannot be separated by thresholds alone.
+!!
 !! ## Trigger semantics
 !!
 !! With user-supplied thresholds sigma_refine > sigma_coarsen the per-element flag is
@@ -95,6 +133,7 @@ module SELF_RefinementIndicator_2D_t
   use SELF_Lagrange
   use SELF_Scalar_2D
   use iso_c_binding
+  use mpi
 
   implicit none
 
@@ -107,6 +146,13 @@ module SELF_RefinementIndicator_2D_t
   ! driving-variable index to Estimate.
   integer,parameter :: SELF_AMR_ALLVARS = 0
 
+  ! Default relative energy floor of the amplitude gate (see the module header). 1e-8 in energy
+  ! is 1e-4 (-80 dB) in amplitude relative to the field scale. Precision-aware for the same
+  ! reason as locateTolerance in SELF_Constants: the gate is max(epsilon, floor*scale), so in
+  ! real32 (epsilon = 1.2e-7) a fixed 1e-8 would be masked by the absolute term for any field
+  ! scale of order one and the relative gate would never engage. real64 keeps 1e-8.
+  real(prec),parameter :: SELF_AMR_DEFAULT_RELFLOOR = max(1.0e-8_prec,epsilon(1.0_prec))
+
   type :: RefinementIndicator2D_t
     integer :: N = 0
       !! Polynomial degree of the interpolant the indicator is built for.
@@ -116,6 +162,31 @@ module SELF_RefinementIndicator_2D_t
       !! Elements with sigma_e above this value are flagged SELF_AMR_REFINE.
     real(prec) :: coarsenThreshold = 0.0_prec
       !! Elements with sigma_e below this value are flagged SELF_AMR_COARSEN.
+    real(prec) :: relativeEnergyFloor = SELF_AMR_DEFAULT_RELFLOOR
+      !! Elements whose gate energy is at or below relativeEnergyFloor*energyScale are treated as
+      !! quiescent (hence perfectly resolved) regardless of their modal shape. Energy goes as
+      !! amplitude squared, so this is 10**(dB/10) in amplitude terms: 1e-8 gates amplitudes
+      !! below 1e-4 (-80 dB) of the field scale. Set to 0 to recover the pure absolute
+      !! (machine-epsilon) floor.
+    real(prec) :: energyScale = 0.0_prec
+      !! Squared field scale the relative floor is measured against, in the units of the gate
+      !! energy. Meaningful only when energyScaleIsSet is true; otherwise the scale is recomputed
+      !! from the current field on every Estimate.
+    logical :: energyScaleIsSet = .false.
+      !! Whether energyScale was pinned by SetEnergyScale (true) or is computed automatically as
+      !! the largest gate energy over the elements (false, the default).
+    logical :: energyWeightsSet = .false.
+      !! Whether energyWeight was supplied by SetEnergyWeights (true) or is regenerated from the
+      !! driving-variable index on every Estimate (false, the default).
+    integer :: nVarWeights = 0
+      !! Allocated length of energyWeight (the solution variable count it was resolved for).
+    real(prec),pointer,contiguous,dimension(:) :: energyWeight => null()
+      !! Non-negative weights w_v of the gate energy g_e = sum_v w_v E_tot,e,v, indexed by
+      !! solution variable. Resolved lazily, because the variable count is a property of the
+      !! solution field and is not known at Init.
+    real(prec),pointer,contiguous,dimension(:) :: gate => null()
+      !! Per-element gate energy g_e from the most recent Estimate. Retained as a diagnostic: it
+      !! is the quantity the amplitude gate actually compared against the effective floor.
     real(prec),pointer,contiguous,dimension(:,:) :: Pmodal => null()
       !! Nodal-to-modal transform. Pmodal(ii,p) is the (p,ii) entry of the inverse Legendre
       !! Vandermonde in the L2-normalized basis, so the 1-D modal coefficients are
@@ -130,6 +201,10 @@ module SELF_RefinementIndicator_2D_t
     procedure,public :: Init => Init_RefinementIndicator2D_t
     procedure,public :: Free => Free_RefinementIndicator2D_t
     procedure,public :: SetThresholds => SetThresholds_RefinementIndicator2D_t
+    procedure,public :: SetRelativeEnergyFloor => SetRelativeEnergyFloor_RefinementIndicator2D_t
+    procedure,public :: SetEnergyScale => SetEnergyScale_RefinementIndicator2D_t
+    procedure,public :: ClearEnergyScale => ClearEnergyScale_RefinementIndicator2D_t
+    procedure,public :: SetEnergyWeights => SetEnergyWeights_RefinementIndicator2D_t
     procedure,public :: UpdateHost => UpdateHost_RefinementIndicator2D_t
     procedure,public :: UpdateDevice => UpdateDevice_RefinementIndicator2D_t
     procedure,public :: Estimate => Estimate_RefinementIndicator2D_t
@@ -142,6 +217,10 @@ contains
   subroutine Init_RefinementIndicator2D_t(this,interp,nElem,refineThreshold,coarsenThreshold)
     !! Allocate the indicator for an interpolant of degree interp%N and nElem elements and
     !! precompute the nodal->modal transform matrix from the interpolant control points.
+    !!
+    !! The amplitude gate is left at its defaults here (relativeEnergyFloor =
+    !! SELF_AMR_DEFAULT_RELFLOOR, automatic energy scale, unit weights); a caller that has tuned
+    !! those must re-apply them after any re-Init, since intent(out) resets them.
     implicit none
     class(RefinementIndicator2D_t),intent(out) :: this
     type(Lagrange),intent(in),target :: interp
@@ -169,11 +248,13 @@ contains
     allocate(this%Pmodal(1:interp%N+1,1:interp%N+1))
     allocate(this%indicator(1:nElem))
     allocate(this%flag(1:nElem))
+    allocate(this%gate(1:nElem))
 
     call BuildModalTransform(interp%controlPoints,interp%N,this%Pmodal)
 
     this%indicator = 0.0_prec
     this%flag = SELF_AMR_KEEP
+    this%gate = 0.0_prec
 
   endsubroutine Init_RefinementIndicator2D_t
 
@@ -186,9 +267,17 @@ contains
     if(associated(this%Pmodal)) deallocate(this%Pmodal)
     if(associated(this%indicator)) deallocate(this%indicator)
     if(associated(this%flag)) deallocate(this%flag)
+    if(associated(this%gate)) deallocate(this%gate)
+    if(associated(this%energyWeight)) deallocate(this%energyWeight)
     this%Pmodal => null()
     this%indicator => null()
     this%flag => null()
+    this%gate => null()
+    this%energyWeight => null()
+    this%nVarWeights = 0
+    this%energyWeightsSet = .false.
+    this%energyScaleIsSet = .false.
+    this%energyScale = 0.0_prec
 
   endsubroutine Free_RefinementIndicator2D_t
 
@@ -209,30 +298,248 @@ contains
 
   endsubroutine SetThresholds_RefinementIndicator2D_t
 
-  subroutine UpdateHost_RefinementIndicator2D_t(this)
+  subroutine SetRelativeEnergyFloor_RefinementIndicator2D_t(this,relativeEnergyFloor)
+    !! Set the relative energy floor of the amplitude gate. An element whose gate energy g
+    !! satisfies
+    !!
+    !!   g <= max( epsilon(1.0_prec), relativeEnergyFloor*energyScale )
+    !!
+    !! carries no resolvable signal at the scale of the field and is reported perfectly resolved
+    !! (sigma_e = log10(epsilon) -> SELF_AMR_COARSEN) whatever the shape of its modal spectrum.
+    !!
+    !! Dimensionless, and an ENERGY fraction, so it is the square of the corresponding amplitude
+    !! fraction: 1e-8 gates amplitudes below 1e-4 (-80 dB) of the field scale, 1e-6 gates
+    !! amplitudes below 1e-3 (-60 dB). Must lie in [0,1); 0 disables the relative floor and
+    !! restores the pure absolute (machine-epsilon) guard.
     implicit none
     class(RefinementIndicator2D_t),intent(inout) :: this
-    if(.false.) this%N = this%N ! CPU stub; suppress unused-dummy-argument warning
-  endsubroutine UpdateHost_RefinementIndicator2D_t
+    real(prec),intent(in) :: relativeEnergyFloor
 
-  subroutine UpdateDevice_RefinementIndicator2D_t(this)
-    implicit none
-    class(RefinementIndicator2D_t),intent(inout) :: this
-    if(.false.) this%N = this%N ! CPU stub; suppress unused-dummy-argument warning
-  endsubroutine UpdateDevice_RefinementIndicator2D_t
+    if(relativeEnergyFloor < 0.0_prec .or. relativeEnergyFloor >= 1.0_prec) then
+      print*,__FILE__,':',__LINE__, &
+        ' : Error : relativeEnergyFloor must satisfy 0 <= floor < 1.'
+      stop 1
+    endif
+    this%relativeEnergyFloor = relativeEnergyFloor
 
-  subroutine Estimate_RefinementIndicator2D_t(this,solution,ivar)
-    !! Compute the per-element modal-energy indicator sigma_e and refine/keep/coarsen flag from
-    !! the nodal solution field. ivar selects the driving variable in [1,solution%nVar]; passing
-    !! SELF_AMR_ALLVARS (=0) reduces the indicator over all variables by taking, per element, the
-    !! largest (least smooth) smoothness ratio S_e before the log10.
+  endsubroutine SetRelativeEnergyFloor_RefinementIndicator2D_t
+
+  subroutine SetEnergyScale_RefinementIndicator2D_t(this,energyScale)
+    !! Pin the energy scale that normalizes the relative floor, in the units of the gate energy
+    !! (squared field amplitude times the reference-element area). Two reasons to use this rather
+    !! than the automatic maximum over elements:
+    !!
+    !!   - determinism: the automatic scale is a floating-point reduction, and under MPI it is a
+    !!     collective whose result can differ at round-off between rank counts, which propagates
+    !!     into the flags;
+    !!   - a poor automatic normalizer: a strong steady background would otherwise set the floor
+    !!     for a weak transient that is the feature of interest.
+    !!
+    !! Must be >= 0; 0 makes the gate collapse onto the absolute floor.
     implicit none
     class(RefinementIndicator2D_t),intent(inout) :: this
-    class(Scalar2D),intent(in) :: solution
+    real(prec),intent(in) :: energyScale
+
+    if(energyScale < 0.0_prec) then
+      print*,__FILE__,':',__LINE__, &
+        ' : Error : energyScale must be non-negative.'
+      stop 1
+    endif
+    this%energyScale = energyScale
+    this%energyScaleIsSet = .true.
+
+  endsubroutine SetEnergyScale_RefinementIndicator2D_t
+
+  subroutine ClearEnergyScale_RefinementIndicator2D_t(this)
+    !! Return to the automatic energy scale (the largest gate energy over the elements).
+    implicit none
+    class(RefinementIndicator2D_t),intent(inout) :: this
+
+    this%energyScale = 0.0_prec
+    this%energyScaleIsSet = .false.
+
+  endsubroutine ClearEnergyScale_RefinementIndicator2D_t
+
+  subroutine SetEnergyWeights_RefinementIndicator2D_t(this,w)
+    !! Set the per-variable weights w_v >= 0 of the gate energy g_e = sum_v w_v E_tot,e,v, where
+    !! E_tot,e,v is the exact L2 energy of variable v on the reference element.
+    !!
+    !! E_tot is a convex quadratic functional of the state, so g_e with these weights is a
+    !! discrete quadratic entropy integral over the element: taking w from the diagonal of the
+    !! entropy Hessian makes the gate an entropy (energy) measure rather than a raw sum of
+    !! squared variables, which is what makes it meaningful for a system whose variables carry
+    !! different units and magnitudes. For LinearEuler2D, whose entropy density is
+    !! 0.5*rho0*(u^2 + v^2) + 0.5*P^2/(rho0 c^2) and whose variables 4 and 5 are the
+    !! time-constant background fields c and rho0,
+    !!
+    !!   w = [ 0.5*rho0, 0.5*rho0, 0.5/(rho0*c0**2), 0.0, 0.0 ]
+    !!
+    !! is the entropy-weighted gate, and the zero weights keep the (large) background fields from
+    !! setting the scale.
+    !!
+    !! size(w) must equal the solution's nVar at Estimate time. Every weight must be >= 0 and at
+    !! least one must be > 0, else no element would ever clear the gate. Note that a weight on a
+    !! variable outside the driving-variable selection makes Estimate transform that variable too
+    !! (it is needed for the gate), which costs one extra modal transform per element per such
+    !! variable.
+    implicit none
+    class(RefinementIndicator2D_t),intent(inout) :: this
+    real(prec),intent(in) :: w(:)
+    ! Local
+    integer :: v
+    logical :: anyPositive
+
+    if(size(w) < 1) then
+      print*,__FILE__,':',__LINE__, &
+        ' : Error : SetEnergyWeights requires at least one weight.'
+      stop 1
+    endif
+    anyPositive = .false.
+    do v = 1,size(w)
+      if(w(v) < 0.0_prec) then
+        print*,__FILE__,':',__LINE__, &
+          ' : Error : energy weights must be non-negative.'
+        stop 1
+      endif
+      if(w(v) > 0.0_prec) anyPositive = .true.
+    enddo
+    if(.not. anyPositive) then
+      print*,__FILE__,':',__LINE__, &
+        ' : Error : at least one energy weight must be positive.'
+      stop 1
+    endif
+
+    if(this%nVarWeights /= size(w)) then
+      if(associated(this%energyWeight)) deallocate(this%energyWeight)
+      allocate(this%energyWeight(1:size(w)))
+      this%nVarWeights = size(w)
+    endif
+    do v = 1,size(w)
+      this%energyWeight(v) = w(v)
+    enddo
+    this%energyWeightsSet = .true.
+
+  endsubroutine SetEnergyWeights_RefinementIndicator2D_t
+
+  subroutine ResolveEnergyWeights(this,nVar,ivar)
+    !! Ensure energyWeight is associated and sized to nVar. Weights supplied by SetEnergyWeights
+    !! must match nVar; otherwise the default weights are regenerated: unit weight on the driving
+    !! variable, or on every variable when ivar is SELF_AMR_ALLVARS. Resolved here rather than at
+    !! Init because the variable count belongs to the solution field, not to the indicator.
+    implicit none
+    class(RefinementIndicator2D_t),intent(inout) :: this
+    integer,intent(in) :: nVar
     integer,intent(in) :: ivar
     ! Local
+    integer :: v
+
+    if(this%energyWeightsSet) then
+      if(this%nVarWeights /= nVar) then
+        print*,__FILE__,':',__LINE__, &
+          ' : Error : energy weights were set for a different variable count.'
+        stop 1
+      endif
+      return
+    endif
+
+    if(this%nVarWeights /= nVar) then
+      if(associated(this%energyWeight)) deallocate(this%energyWeight)
+      allocate(this%energyWeight(1:nVar))
+      this%nVarWeights = nVar
+    endif
+    do v = 1,nVar
+      if(ivar == SELF_AMR_ALLVARS .or. v == ivar) then
+        this%energyWeight(v) = 1.0_prec
+      else
+        this%energyWeight(v) = 0.0_prec
+      endif
+    enddo
+
+  endsubroutine ResolveEnergyWeights
+
+  subroutine ResolveEnergyScale(this,energyScale,comm)
+    !! Determine the energy scale the relative floor is measured against: the pinned value when
+    !! SetEnergyScale was used, otherwise the largest gate energy over the (rank-local) elements.
+    !! When comm is present the maximum is taken over the communicator, so every rank applies the
+    !! same floor and the flags - hence the adapted mesh - do not depend on the decomposition.
+    !! One small collective per indicator evaluation, i.e. per adaptation epoch, never inside the
+    !! time-stepping loop.
+    implicit none
+    class(RefinementIndicator2D_t),intent(in) :: this
+    real(prec),intent(out) :: energyScale
+    integer,intent(in),optional :: comm
+    ! Local
+    integer :: iel,ierror,mpiPrec
+    real(prec) :: gmax
+
+    if(this%energyScaleIsSet) then
+      energyScale = this%energyScale
+      return
+    endif
+
+    gmax = 0.0_prec
+    do iel = 1,this%nElem
+      gmax = max(gmax,this%gate(iel))
+    enddo
+
+    if(present(comm)) then
+      if(prec == real32) then
+        mpiPrec = MPI_FLOAT
+      else
+        mpiPrec = MPI_DOUBLE
+      endif
+      call mpi_allreduce(gmax,energyScale,1,mpiPrec,MPI_MAX,comm,ierror)
+    else
+      energyScale = gmax
+    endif
+
+  endsubroutine ResolveEnergyScale
+
+  subroutine FinalizeIndicator(this,energyScale)
+    !! Second phase of an estimate, shared by every backend so that the flags are identical
+    !! whichever computed the spectra: apply the amplitude gate, take the log10 and set the
+    !! refine/keep/coarsen flags.
+    !!
+    !! On entry indicator(iel) holds the RAW smoothness ratio S_e from the first phase and
+    !! gate(iel) the element's gate energy; on exit indicator(iel) = log10(max(S_e,epsilon)) with
+    !! S_e forced to zero on gated elements. Nothing outside Estimate observes the intermediate
+    !! state.
+    implicit none
+    class(RefinementIndicator2D_t),intent(inout) :: this
+    real(prec),intent(in) :: energyScale
+    ! Local
     integer :: iel
-    real(prec),parameter :: energyFloor = epsilon(1.0_prec)
+    real(prec) :: effFloor,se
+
+    ! The absolute term is the safety net for a field that is identically zero; the relative term
+    ! is what releases low-amplitude (but far-above-epsilon) residue behind a passing front.
+    effFloor = max(epsilon(1.0_prec),this%relativeEnergyFloor*energyScale)
+
+    do iel = 1,this%nElem
+      if(this%gate(iel) <= effFloor) then
+        se = 0.0_prec ! quiescent at the scale of the field: perfectly resolved
+      else
+        se = this%indicator(iel)
+      endif
+      this%indicator(iel) = log10(max(se,epsilon(1.0_prec)))
+      if(this%indicator(iel) > this%refineThreshold) then
+        this%flag(iel) = SELF_AMR_REFINE
+      elseif(this%indicator(iel) < this%coarsenThreshold) then
+        this%flag(iel) = SELF_AMR_COARSEN
+      else
+        this%flag(iel) = SELF_AMR_KEEP
+      endif
+    enddo
+
+  endsubroutine FinalizeIndicator
+
+  subroutine CheckEstimateArguments(this,solution,ivar,gate)
+    !! Argument validation shared by the portable and backend Estimate implementations.
+    implicit none
+    class(RefinementIndicator2D_t),intent(in) :: this
+    class(Scalar2D),intent(in) :: solution
+    integer,intent(in) :: ivar
+    real(prec),intent(in),optional :: gate(:)
 
     if(solution%N /= this%N) then
       print*,__FILE__,':',__LINE__, &
@@ -249,13 +556,70 @@ contains
         ' : Error : driving-variable index out of range.'
       stop 1
     endif
+    if(present(gate)) then
+      if(size(gate) < this%nElem) then
+        print*,__FILE__,':',__LINE__, &
+          ' : Error : caller-supplied gate array is smaller than the element count.'
+        stop 1
+      endif
+    endif
+
+  endsubroutine CheckEstimateArguments
+
+  subroutine UpdateHost_RefinementIndicator2D_t(this)
+    implicit none
+    class(RefinementIndicator2D_t),intent(inout) :: this
+    if(.false.) this%N = this%N ! CPU stub; suppress unused-dummy-argument warning
+  endsubroutine UpdateHost_RefinementIndicator2D_t
+
+  subroutine UpdateDevice_RefinementIndicator2D_t(this)
+    implicit none
+    class(RefinementIndicator2D_t),intent(inout) :: this
+    if(.false.) this%N = this%N ! CPU stub; suppress unused-dummy-argument warning
+  endsubroutine UpdateDevice_RefinementIndicator2D_t
+
+  subroutine Estimate_RefinementIndicator2D_t(this,solution,ivar,comm,gate)
+    !! Compute the per-element modal-energy indicator sigma_e and refine/keep/coarsen flag from
+    !! the nodal solution field. ivar selects the driving variable in [1,solution%nVar]; passing
+    !! SELF_AMR_ALLVARS (=0) reduces the indicator over all variables by taking, per element, the
+    !! largest (least smooth) smoothness ratio S_e before the log10.
+    !!
+    !! The estimate runs in two phases. The first is element-local and parallel: it forms each
+    !! element's modal spectrum, its raw smoothness ratio S_e, and its gate energy
+    !! g = sum_v w_v E_tot,v. The second applies the amplitude gate, the log10 and the thresholds,
+    !! and is deferred because the gate needs a field-wide energy scale (a reduction, and under
+    !! MPI a collective) that no element-local pass can supply. Between the phases indicator(:)
+    !! transiently holds the raw ratio rather than its logarithm.
+    !!
+    !! comm, when present, is the MPI communicator over which the automatic energy scale is
+    !! maximized, so that the flags do not depend on the domain decomposition. gate, when present,
+    !! replaces the weighted-sum gate energy with a caller-computed per-element value - for
+    !! example an exactly integrated nodal entropy - and is used both for the scale and for the
+    !! gate comparison.
+    implicit none
+    class(RefinementIndicator2D_t),intent(inout) :: this
+    class(Scalar2D),intent(in) :: solution
+    integer,intent(in) :: ivar
+    integer,intent(in),optional :: comm
+    real(prec),intent(in),optional :: gate(:)
+    ! Local
+    integer :: iel
+    real(prec) :: energyScale
+
+    call CheckEstimateArguments(this,solution,ivar,gate)
+    call ResolveEnergyWeights(this,solution%nVar,ivar)
 
     do concurrent(iel=1:this%nElem)
       block
         integer :: j,p,q,ii,v,v0,v1,Np
         real(prec) :: tmp(1:this%N+1,1:this%N+1)
         real(prec) :: uhat(1:this%N+1,1:this%N+1)
-        real(prec) :: acc,etot,eclip1,eclip2,r1,r2,se,semax
+        real(prec) :: acc,etot,eclip1,eclip2,r1,r2,se,semax,g,w
+        logical :: needSe,needG
+        ! Absolute (machine-epsilon) guard on the energy RATIOS below. This is not the amplitude
+        ! gate: it only keeps 0/0 out of r1 and r2. The amplitude gate is relative and is applied
+        ! in FinalizeIndicator, once the field-wide energy scale is known.
+        real(prec),parameter :: energyFloor = epsilon(1.0_prec)
 
         Np = this%N+1
         if(ivar == SELF_AMR_ALLVARS) then
@@ -267,7 +631,16 @@ contains
         endif
 
         semax = 0.0_prec
-        do v = v0,v1
+        g = 0.0_prec
+        do v = 1,solution%nVar
+          ! A variable is transformed if it drives the indicator, or if it carries a non-zero gate
+          ! weight (its energy is then needed for the gate). With the default weights these
+          ! coincide, so the work is exactly what it was before the gate existed.
+          w = this%energyWeight(v)
+          needSe = (v >= v0 .and. v <= v1)
+          needG = (w /= 0.0_prec)
+          if(.not.(needSe .or. needG)) cycle
+
           ! Pass 1 (xi direction): tmp(p,j) = sum_i Pmodal(i,p) * u(i,j)
           do j = 1,Np
             do p = 1,Np
@@ -302,32 +675,42 @@ contains
             enddo
           enddo
 
-          if(etot <= energyFloor) then
-            ! Field is (near) identically zero on this element: perfectly resolved.
-            se = 0.0_prec
-          else
-            r1 = (etot-eclip1)/etot
-            if(this%N >= 2 .and. eclip1 > energyFloor) then
-              r2 = (eclip1-eclip2)/eclip1
-            else
-              r2 = 0.0_prec
-            endif
-            se = max(r1,r2)
-          endif
+          ! Gate energy: g = sum_v w_v E_tot,v, the discrete (quadratic) entropy integral over
+          ! the element when the weights come from an entropy Hessian.
+          if(needG) g = g+w*etot
 
-          semax = max(semax,se)
+          if(needSe) then
+            if(etot <= energyFloor) then
+              ! Field is (near) identically zero on this element: perfectly resolved.
+              se = 0.0_prec
+            else
+              r1 = (etot-eclip1)/etot
+              if(this%N >= 2 .and. eclip1 > energyFloor) then
+                r2 = (eclip1-eclip2)/eclip1
+              else
+                r2 = 0.0_prec
+              endif
+              se = max(r1,r2)
+            endif
+
+            semax = max(semax,se)
+          endif
         enddo
 
-        this%indicator(iel) = log10(max(semax,energyFloor))
-        if(this%indicator(iel) > this%refineThreshold) then
-          this%flag(iel) = SELF_AMR_REFINE
-        elseif(this%indicator(iel) < this%coarsenThreshold) then
-          this%flag(iel) = SELF_AMR_COARSEN
-        else
-          this%flag(iel) = SELF_AMR_KEEP
-        endif
+        ! Raw ratio; FinalizeIndicator gates it and takes the log10 in place.
+        this%indicator(iel) = semax
+        this%gate(iel) = g
       endblock
     enddo
+
+    if(present(gate)) then
+      do iel = 1,this%nElem
+        this%gate(iel) = gate(iel)
+      enddo
+    endif
+
+    call ResolveEnergyScale(this,energyScale,comm)
+    call FinalizeIndicator(this,energyScale)
 
   endsubroutine Estimate_RefinementIndicator2D_t
 

--- a/src/SELF_RefinementIndicator_2D_t.f90
+++ b/src/SELF_RefinementIndicator_2D_t.f90
@@ -101,6 +101,18 @@ module SELF_RefinementIndicator_2D_t
 !! step and produced a mesh roughly twice as large by the end of the run. Measure before raising
 !! it; see the note on SELF_AMR_DEFAULT_RELFLOOR.
 !!
+!! The gate is a single hard cut by default, which reintroduces on the energy axis exactly the
+!! thrashing the two sigma thresholds exist to prevent: an element whose energy drifts across that
+!! one value flips COARSEN <-> REFINE on successive epochs. Supplying significantEnergyFloor opens
+!! a hysteresis band instead,
+!!
+!!   g_e <= quiescent floor            ->  COARSEN, whatever the spectrum says
+!!   quiescent < g_e <= significant    ->  SELF_AMR_KEEP  (hold the mesh)
+!!   g_e > significant floor           ->  the spectrum decides, as before
+!!
+!! the middle zone reading "too weak to be worth spending levels on, too strong to declare
+!! resolved". Inside the band sigma_e still reports the true spectrum; only the flag is held.
+!!
 !! energyScale defaults to the largest gate energy over the elements (globally reduced when
 !! Estimate is given an MPI communicator), which makes the gate track a decaying front. It can be
 !! pinned with SetEnergyScale for callers that need the flag decision to be independent of a
@@ -186,6 +198,12 @@ module SELF_RefinementIndicator_2D_t
       !! amplitude squared, so this is 10**(dB/10) in amplitude terms: 1e-8 gates amplitudes
       !! below 1e-4 (-80 dB) of the field scale. Set to 0 to recover the pure absolute
       !! (machine-epsilon) floor.
+    real(prec) :: significantEnergyFloor = SELF_AMR_DEFAULT_RELFLOOR
+      !! Upper edge of the hysteresis band on the energy axis. Elements between
+      !! relativeEnergyFloor and this fraction of the energy scale are flagged SELF_AMR_KEEP
+      !! whatever their spectrum: too weak to justify spending levels on, too strong to declare
+      !! resolved. Equal to relativeEnergyFloor by default, which collapses the band to a single
+      !! hard cut. See SetRelativeEnergyFloor.
     real(prec) :: energyScale = 0.0_prec
       !! Squared field scale the relative floor is measured against, in the units of the gate
       !! energy. Meaningful only when energyScaleIsSet is true; otherwise the scale is recomputed
@@ -316,7 +334,8 @@ contains
 
   endsubroutine SetThresholds_RefinementIndicator2D_t
 
-  subroutine SetRelativeEnergyFloor_RefinementIndicator2D_t(this,relativeEnergyFloor)
+  subroutine SetRelativeEnergyFloor_RefinementIndicator2D_t(this,relativeEnergyFloor, &
+                                                            significantEnergyFloor)
     !! Set the relative energy floor of the amplitude gate. An element whose gate energy g
     !! satisfies
     !!
@@ -333,9 +352,26 @@ contains
     !! Raising this beyond the default trades against refinement depth - the gate cannot tell
     !! residue from the flank of an under-resolved feature - and has been measured to cost more
     !! than it saves on a propagating-wave problem. See SELF_AMR_DEFAULT_RELFLOOR.
+    !!
+    !! significantEnergyFloor, when supplied, is the UPPER edge of a hysteresis band on the energy
+    !! axis, exactly analogous to the refine/coarsen band on sigma_e:
+    !!
+    !!   g <= quiescent floor                    -> COARSEN, whatever the spectrum says
+    !!   quiescent floor < g <= significant      -> SELF_AMR_KEEP
+    !!   g > significant floor                   -> the spectrum decides, as before
+    !!
+    !! Without it the amplitude gate is a single hard cut, so an element whose energy drifts across
+    !! that one value flips COARSEN <-> REFINE on successive epochs - the thrashing the two sigma
+    !! thresholds exist to prevent, reintroduced on the other axis. The middle zone says "too weak
+    !! to be worth spending levels on, too strong to declare resolved", which is the honest answer
+    !! there and is stable under a small change in amplitude.
+    !!
+    !! Must satisfy quiescent floor <= significant floor < 1. It defaults to the quiescent floor,
+    !! which collapses the band to the single cut and reproduces the ungapped behaviour exactly.
     implicit none
     class(RefinementIndicator2D_t),intent(inout) :: this
     real(prec),intent(in) :: relativeEnergyFloor
+    real(prec),intent(in),optional :: significantEnergyFloor
 
     if(relativeEnergyFloor < 0.0_prec .or. relativeEnergyFloor >= 1.0_prec) then
       print*,__FILE__,':',__LINE__, &
@@ -343,6 +379,16 @@ contains
       stop 1
     endif
     this%relativeEnergyFloor = relativeEnergyFloor
+    this%significantEnergyFloor = relativeEnergyFloor
+    if(present(significantEnergyFloor)) then
+      if(significantEnergyFloor < relativeEnergyFloor .or. &
+         significantEnergyFloor >= 1.0_prec) then
+        print*,__FILE__,':',__LINE__, &
+          ' : Error : significantEnergyFloor must satisfy relativeEnergyFloor <= floor < 1.'
+        stop 1
+      endif
+      this%significantEnergyFloor = significantEnergyFloor
+    endif
 
   endsubroutine SetRelativeEnergyFloor_RefinementIndicator2D_t
 
@@ -524,18 +570,26 @@ contains
     !!
     !! On entry indicator(iel) holds the RAW smoothness ratio S_e from the first phase and
     !! gate(iel) the element's gate energy; on exit indicator(iel) = log10(max(S_e,epsilon)) with
-    !! S_e forced to zero on gated elements. Nothing outside Estimate observes the intermediate
+    !! S_e forced to zero on quiescent elements. Nothing outside Estimate observes the intermediate
     !! state.
+    !!
+    !! Elements inside the energy hysteresis band keep their true spectral sigma_e - it stays a
+    !! faithful diagnostic of the spectrum - but have their flag forced to SELF_AMR_KEEP. So for
+    !! those elements the flag is deliberately NOT the value thresholding sigma_e would give; that
+    !! is the whole point of the band.
     implicit none
     class(RefinementIndicator2D_t),intent(inout) :: this
     real(prec),intent(in) :: energyScale
     ! Local
     integer :: iel
-    real(prec) :: effFloor,se
+    real(prec) :: effFloor,effSignificant,se
 
     ! The absolute term is the safety net for a field that is identically zero; the relative term
     ! is what releases low-amplitude (but far-above-epsilon) residue behind a passing front.
     effFloor = max(epsilon(1.0_prec),this%relativeEnergyFloor*energyScale)
+    ! Upper edge of the band; never below the lower edge, so a degenerate band stays degenerate
+    ! even when the absolute term is what sets the lower edge.
+    effSignificant = max(effFloor,this%significantEnergyFloor*energyScale)
 
     do iel = 1,this%nElem
       if(this%gate(iel) <= effFloor) then
@@ -544,7 +598,12 @@ contains
         se = this%indicator(iel)
       endif
       this%indicator(iel) = log10(max(se,epsilon(1.0_prec)))
-      if(this%indicator(iel) > this%refineThreshold) then
+      if(this%gate(iel) > effFloor .and. this%gate(iel) <= effSignificant) then
+        ! Inside the energy hysteresis band: too weak to justify spending levels on, too strong to
+        ! declare resolved. Holding the mesh here is what keeps an element whose amplitude drifts
+        ! across the gate from flipping REFINE <-> COARSEN on successive epochs.
+        this%flag(iel) = SELF_AMR_KEEP
+      elseif(this%indicator(iel) > this%refineThreshold) then
         this%flag(iel) = SELF_AMR_REFINE
       elseif(this%indicator(iel) < this%coarsenThreshold) then
         this%flag(iel) = SELF_AMR_COARSEN

--- a/src/SELF_RefinementIndicator_2D_t.f90
+++ b/src/SELF_RefinementIndicator_2D_t.f90
@@ -91,8 +91,15 @@ module SELF_RefinementIndicator_2D_t
 !!   g_e <= effective floor   ->   S_e := 0   (element is quiescent, hence resolved)
 !!
 !! gives an amplitude gate that is independent of the modal shape. Because energy goes as
-!! amplitude squared, relativeEnergyFloor is 10**(dB/10) in amplitude terms: the default 1e-8
-!! treats amplitudes below 1e-4 (-80 dB) of the field scale as quiescent.
+!! amplitude squared, relativeEnergyFloor is 10**(dB/10) in amplitude terms: the default 1e-12
+!! treats amplitudes below 1e-6 (-120 dB) of the field scale as quiescent.
+!!
+!! Raising the floor is NOT free, and the useful range is narrower than it looks. The gate cannot
+!! distinguish residue from the low-amplitude flank of a feature that is genuinely under-resolved,
+!! so an aggressive floor also suppresses refinement DEPTH: on the ultrasound benchmark a floor of
+!! 1e-8 stopped the source pulse from reaching the level cap, which doubled the level-based time
+!! step and produced a mesh roughly twice as large by the end of the run. Measure before raising
+!! it; see the note on SELF_AMR_DEFAULT_RELFLOOR.
 !!
 !! energyScale defaults to the largest gate energy over the elements (globally reduced when
 !! Estimate is given an MPI communicator), which makes the gate track a decaying front. It can be
@@ -146,12 +153,23 @@ module SELF_RefinementIndicator_2D_t
   ! driving-variable index to Estimate.
   integer,parameter :: SELF_AMR_ALLVARS = 0
 
-  ! Default relative energy floor of the amplitude gate (see the module header). 1e-8 in energy
-  ! is 1e-4 (-80 dB) in amplitude relative to the field scale. Precision-aware for the same
-  ! reason as locateTolerance in SELF_Constants: the gate is max(epsilon, floor*scale), so in
-  ! real32 (epsilon = 1.2e-7) a fixed 1e-8 would be masked by the absolute term for any field
-  ! scale of order one and the relative gate would never engage. real64 keeps 1e-8.
-  real(prec),parameter :: SELF_AMR_DEFAULT_RELFLOOR = max(1.0e-8_prec,epsilon(1.0_prec))
+  ! Default relative energy floor of the amplitude gate (see the module header). 1e-12 in energy
+  ! is 1e-6 (-120 dB) in amplitude relative to the field scale.
+  !
+  ! This default is deliberately conservative, and measured rather than argued. On the ultrasound
+  ! point-source benchmark (examples/linear_euler2d_amr_ultrasound_pointsource, 30 epochs,
+  ! maxLevel 2) it gives 1.40x fewer elements on average than no gate at all, with an initial
+  ! adaptation - and hence a level-based time step - identical to the ungated run. Raising it to
+  ! 1e-8 was measured to be actively HARMFUL there: the gate then also suppresses the source
+  ! pulse's skirt, the forest never reaches the level cap, RecommendedTimeStep doubles dt, and the
+  ! resulting time-integration error drives so much later refinement that the final mesh is
+  ! roughly twice the ungated one (3304 elements against 1732). An aggressive amplitude gate
+  ! trades against refinement DEPTH; that trade is what this value is set to avoid.
+  !
+  ! Note this sits below epsilon in real32 (1.2e-7), so in a single-precision build the absolute
+  ! term of the effective floor dominates and the relative gate is inactive unless a caller raises
+  ! it. That is the safe direction: real32 fields cannot represent -120 dB structure anyway.
+  real(prec),parameter :: SELF_AMR_DEFAULT_RELFLOOR = 1.0e-12_prec
 
   type :: RefinementIndicator2D_t
     integer :: N = 0
@@ -308,9 +326,13 @@ contains
     !! (sigma_e = log10(epsilon) -> SELF_AMR_COARSEN) whatever the shape of its modal spectrum.
     !!
     !! Dimensionless, and an ENERGY fraction, so it is the square of the corresponding amplitude
-    !! fraction: 1e-8 gates amplitudes below 1e-4 (-80 dB) of the field scale, 1e-6 gates
-    !! amplitudes below 1e-3 (-60 dB). Must lie in [0,1); 0 disables the relative floor and
+    !! fraction: 1e-12 gates amplitudes below 1e-6 (-120 dB) of the field scale, 1e-8 gates
+    !! amplitudes below 1e-4 (-80 dB). Must lie in [0,1); 0 disables the relative floor and
     !! restores the pure absolute (machine-epsilon) guard.
+    !!
+    !! Raising this beyond the default trades against refinement depth - the gate cannot tell
+    !! residue from the flank of an under-resolved feature - and has been measured to cost more
+    !! than it saves on a propagating-wave problem. See SELF_AMR_DEFAULT_RELFLOOR.
     implicit none
     class(RefinementIndicator2D_t),intent(inout) :: this
     real(prec),intent(in) :: relativeEnergyFloor

--- a/src/gpu/SELF_GPUInterfaces.f90
+++ b/src/gpu/SELF_GPUInterfaces.f90
@@ -70,15 +70,13 @@ module SELF_GPUInterfaces
   endinterface
 
   interface
-    subroutine RefinementIndicator_2D_gpu(Pmodal,f,indicator,flag, &
-                                          refineThreshold,coarsenThreshold, &
+    subroutine RefinementIndicator_2D_gpu(Pmodal,f,w,ratio,gate, &
                                           N,nVar,ivar,nEl) &
       bind(c,name="RefinementIndicator_2D_gpu")
       use iso_c_binding
       use SELF_Constants
       implicit none
-      type(c_ptr),value :: Pmodal,f,indicator,flag
-      real(c_prec),value :: refineThreshold,coarsenThreshold
+      type(c_ptr),value :: Pmodal,f,w,ratio,gate
       integer(c_int),value :: N,nVar,ivar,nEl
     endsubroutine RefinementIndicator_2D_gpu
   endinterface

--- a/src/gpu/SELF_Refinement.cpp
+++ b/src/gpu/SELF_Refinement.cpp
@@ -5,6 +5,10 @@
 // fails loudly rather than overrunning. Raise this (and rebuild) to support higher degrees.
 #define AMR2D_MAXNP 16
 
+// Absolute (machine-epsilon) guard on the modal energy RATIOS below - it only keeps 0/0 out of
+// r1 and r2. The amplitude gate is RELATIVE to a field-wide energy scale and is applied on the
+// host in FinalizeIndicator, because the scale is a reduction (an MPI collective when the mesh
+// is decomposed) that an element-local device thread cannot supply.
 #ifdef DOUBLE_PRECISION
   #define AMR_ENERGY_FLOOR DBL_EPSILON
 #else
@@ -16,10 +20,13 @@
 //   One device thread per element. Computes the tensor-product Legendre modal spectrum of the
 //   driving field(s) on the element via two matrix passes with the precomputed nodal->modal
 //   transform Pmodal (Pmodal[i + (N+1)*p] = contribution of node i to mode p), forms the total
-//   and clipped modal energies, and writes the log10 smoothness ratio and the refine/keep/coarsen
-//   flag. The mathematics mirror the portable implementation in SELF_RefinementIndicator_2D_t.
-__global__ void RefinementIndicator_2D_gpukernel(real *Pmodal, real *f, real *indicator, int *flag,
-                                                 real refineThreshold, real coarsenThreshold,
+//   and clipped modal energies, and writes the raw smoothness ratio S_e together with the gate
+//   energy g = sum_v w[v]*etot(v). The mathematics mirror the portable implementation in
+//   SELF_RefinementIndicator_2D_t; the log10, the amplitude gate and the refine/keep/coarsen
+//   thresholds are applied host-side by the shared FinalizeIndicator, so both backends produce
+//   identical flags.
+__global__ void RefinementIndicator_2D_gpukernel(real *Pmodal, real *f, real *w,
+                                                 real *ratio, real *gate,
                                                  int N, int nvar, int ivar, int nel){
 
   int iel = threadIdx.x + blockIdx.x*blockDim.x;
@@ -33,7 +40,16 @@ __global__ void RefinementIndicator_2D_gpukernel(real *Pmodal, real *f, real *in
     real uhat[AMR2D_MAXNP*AMR2D_MAXNP];
 
     real semax = 0.0;
-    for(int v=v0; v<=v1; v++){
+    real g = 0.0;
+    for(int v=0; v<nvar; v++){
+
+      // A variable is transformed if it drives the indicator, or if it carries a non-zero gate
+      // weight (its energy is then needed for the gate). With the default weights these
+      // coincide, so the work is exactly what it was before the gate existed.
+      real wv = w[v];
+      bool needSe = ( v >= v0 && v <= v1 );
+      bool needG  = ( wv != 0.0 );
+      if( !(needSe || needG) ) continue;
 
       // Pass 1 (xi): tmp[p + Np*j] = sum_i Pmodal[i + Np*p] * u(i,j)
       for(int j=0; j<Np; j++){
@@ -67,37 +83,39 @@ __global__ void RefinementIndicator_2D_gpukernel(real *Pmodal, real *f, real *in
         }
       }
 
-      real se;
-      if( etot <= (real)AMR_ENERGY_FLOOR ){
-        se = 0.0;
-      } else {
-        real r1 = (etot - eclip1)/etot;
-        real r2 = 0.0;
-        if( N >= 2 && eclip1 > (real)AMR_ENERGY_FLOOR ){
-          r2 = (eclip1 - eclip2)/eclip1;
+      // Gate energy: the discrete (quadratic) entropy integral over the element when the weights
+      // come from an entropy Hessian.
+      if( needG ) g += wv*etot;
+
+      if( needSe ){
+        real se;
+        if( etot <= (real)AMR_ENERGY_FLOOR ){
+          se = 0.0;
+        } else {
+          real r1 = (etot - eclip1)/etot;
+          real r2 = 0.0;
+          if( N >= 2 && eclip1 > (real)AMR_ENERGY_FLOOR ){
+            r2 = (eclip1 - eclip2)/eclip1;
+          }
+          se = (r1 > r2) ? r1 : r2;
         }
-        se = (r1 > r2) ? r1 : r2;
+        if( se > semax ) semax = se;
       }
-      if( se > semax ) semax = se;
     }
 
-    real sigma = log10( (semax > (real)AMR_ENERGY_FLOOR) ? semax : (real)AMR_ENERGY_FLOOR );
-    indicator[iel] = sigma;
-    if( sigma > refineThreshold )      flag[iel] =  1; // SELF_AMR_REFINE
-    else if( sigma < coarsenThreshold) flag[iel] = -1; // SELF_AMR_COARSEN
-    else                               flag[iel] =  0; // SELF_AMR_KEEP
+    ratio[iel] = semax; // raw ratio; the host gates it, takes the log10 and sets the flag
+    gate[iel]  = g;
   }
 }
 
 extern "C"
 {
-  void RefinementIndicator_2D_gpu(real *Pmodal, real *f, real *indicator, int *flag,
-                                  real refineThreshold, real coarsenThreshold,
+  void RefinementIndicator_2D_gpu(real *Pmodal, real *f, real *w, real *ratio, real *gate,
                                   int N, int nvar, int ivar, int nel)
   {
     int threads_per_block = 256;
     int nblocks_x = nel/threads_per_block + 1;
     RefinementIndicator_2D_gpukernel<<<dim3(nblocks_x,1,1), dim3(threads_per_block,1,1), 0, 0>>>(
-      Pmodal, f, indicator, flag, refineThreshold, coarsenThreshold, N, nvar, ivar, nel);
+      Pmodal, f, w, ratio, gate, N, nvar, ivar, nel);
   }
 }

--- a/src/gpu/SELF_RefinementIndicator_2D.f90
+++ b/src/gpu/SELF_RefinementIndicator_2D.f90
@@ -40,6 +40,11 @@ module SELF_RefinementIndicator_2D
     type(c_ptr) :: Pmodal_gpu = c_null_ptr
     type(c_ptr) :: indicator_gpu = c_null_ptr
     type(c_ptr) :: flag_gpu = c_null_ptr
+    type(c_ptr) :: gate_gpu = c_null_ptr
+    type(c_ptr) :: energyWeight_gpu = c_null_ptr
+    integer :: nVarWeights_gpu = 0
+      !! Allocated length of energyWeight_gpu. Zero until the first Estimate fixes the solution's
+      !! variable count, which is not known at Init.
 
   contains
 
@@ -76,6 +81,11 @@ contains
     call gpuCheck(hipMalloc(this%Pmodal_gpu,sizeof(this%Pmodal)))
     call gpuCheck(hipMalloc(this%indicator_gpu,sizeof(this%indicator)))
     call gpuCheck(hipMalloc(this%flag_gpu,sizeof(this%flag)))
+    call gpuCheck(hipMalloc(this%gate_gpu,sizeof(this%gate)))
+    ! The gate weights are sized to the solution's variable count, which the first Estimate
+    ! establishes; nothing is allocated for them here.
+    this%energyWeight_gpu = c_null_ptr
+    this%nVarWeights_gpu = 0
 
     call this%UpdateDevice()
 
@@ -88,9 +98,14 @@ contains
     if(c_associated(this%Pmodal_gpu)) call gpuCheck(hipFree(this%Pmodal_gpu))
     if(c_associated(this%indicator_gpu)) call gpuCheck(hipFree(this%indicator_gpu))
     if(c_associated(this%flag_gpu)) call gpuCheck(hipFree(this%flag_gpu))
+    if(c_associated(this%gate_gpu)) call gpuCheck(hipFree(this%gate_gpu))
+    if(c_associated(this%energyWeight_gpu)) call gpuCheck(hipFree(this%energyWeight_gpu))
     this%Pmodal_gpu = c_null_ptr
     this%indicator_gpu = c_null_ptr
     this%flag_gpu = c_null_ptr
+    this%gate_gpu = c_null_ptr
+    this%energyWeight_gpu = c_null_ptr
+    this%nVarWeights_gpu = 0
 
     call Free_RefinementIndicator2D_t(this)
 
@@ -104,6 +119,8 @@ contains
                             sizeof(this%indicator),hipMemcpyDeviceToHost))
     call gpuCheck(hipMemcpy(c_loc(this%flag),this%flag_gpu, &
                             sizeof(this%flag),hipMemcpyDeviceToHost))
+    call gpuCheck(hipMemcpy(c_loc(this%gate),this%gate_gpu, &
+                            sizeof(this%gate),hipMemcpyDeviceToHost))
 
   endsubroutine UpdateHost_RefinementIndicator2D
 
@@ -117,40 +134,63 @@ contains
                             sizeof(this%indicator),hipMemcpyHostToDevice))
     call gpuCheck(hipMemcpy(this%flag_gpu,c_loc(this%flag), &
                             sizeof(this%flag),hipMemcpyHostToDevice))
+    call gpuCheck(hipMemcpy(this%gate_gpu,c_loc(this%gate), &
+                            sizeof(this%gate),hipMemcpyHostToDevice))
 
   endsubroutine UpdateDevice_RefinementIndicator2D
 
-  subroutine Estimate_RefinementIndicator2D(this,solution,ivar)
-    !! GPU path: one device thread per element computes the modal transform and energy
-    !! ratios, writes the indicator and flag on device, then copies both back to the host so
-    !! the (host-side) mesh-adaptation logic can consume them directly.
+  subroutine Estimate_RefinementIndicator2D(this,solution,ivar,comm,gate)
+    !! GPU path: one device thread per element computes the modal transform, the raw smoothness
+    !! ratio and the gate energy; those are copied back to the host, where the shared second phase
+    !! applies the amplitude gate, the log10 and the thresholds.
+    !!
+    !! The second phase is host-side (rather than a second device kernel) because the amplitude
+    !! gate needs a field-wide energy scale - a reduction, and an MPI collective when the mesh is
+    !! decomposed - that an element-local device thread cannot supply. Running it through the same
+    !! FinalizeIndicator the portable backend uses also makes the flags identical on CPU and GPU
+    !! by construction. The extra traffic is one per-element array each way, once per adaptation
+    !! epoch; nothing is added to the time-stepping loop.
     implicit none
     class(RefinementIndicator2D),intent(inout) :: this
     class(Scalar2D),intent(in) :: solution
     integer,intent(in) :: ivar
+    integer,intent(in),optional :: comm
+    real(prec),intent(in),optional :: gate(:)
+    ! Local
+    integer :: iel
+    real(prec) :: energyScale
 
-    if(solution%N /= this%N) then
-      print*,__FILE__,':',__LINE__, &
-        ' : Error : solution degree does not match indicator degree.'
-      stop 1
-    endif
-    if(solution%nElem /= this%nElem) then
-      print*,__FILE__,':',__LINE__, &
-        ' : Error : solution element count does not match indicator element count.'
-      stop 1
-    endif
-    if(ivar < 0 .or. ivar > solution%nVar) then
-      print*,__FILE__,':',__LINE__, &
-        ' : Error : driving-variable index out of range.'
-      stop 1
-    endif
+    call CheckEstimateArguments(this,solution,ivar,gate)
+    call ResolveEnergyWeights(this,solution%nVar,ivar)
 
+    if(this%nVarWeights_gpu /= this%nVarWeights) then
+      if(c_associated(this%energyWeight_gpu)) call gpuCheck(hipFree(this%energyWeight_gpu))
+      call gpuCheck(hipMalloc(this%energyWeight_gpu,sizeof(this%energyWeight)))
+      this%nVarWeights_gpu = this%nVarWeights
+    endif
+    call gpuCheck(hipMemcpy(this%energyWeight_gpu,c_loc(this%energyWeight), &
+                            sizeof(this%energyWeight),hipMemcpyHostToDevice))
+
+    ! First phase on the device. indicator_gpu transiently holds the RAW ratio S_e, not log10(S_e).
     call RefinementIndicator_2D_gpu(this%Pmodal_gpu,solution%interior_gpu, &
-                                    this%indicator_gpu,this%flag_gpu, &
-                                    this%refineThreshold,this%coarsenThreshold, &
+                                    this%energyWeight_gpu, &
+                                    this%indicator_gpu,this%gate_gpu, &
                                     this%N,solution%nVar,ivar,this%nElem)
 
     call this%UpdateHost()
+
+    if(present(gate)) then
+      do iel = 1,this%nElem
+        this%gate(iel) = gate(iel)
+      enddo
+    endif
+
+    call ResolveEnergyScale(this,energyScale,comm)
+    call FinalizeIndicator(this,energyScale)
+
+    ! Re-establish the device mirrors of indicator/flag/gate, which the host phase has just
+    ! rewritten, so the device copies are never left stale.
+    call this%UpdateDevice()
 
   endsubroutine Estimate_RefinementIndicator2D
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -112,6 +112,7 @@ add_fortran_tests (
     "refinement_indicator_2d_guard_emptyweights.f90"
     "refinement_indicator_2d_guard_weightcount.f90"
     "refinement_indicator_2d_guard_gatesize.f90"
+    "refinement_indicator_2d_guard_significantfloor.f90"
     "adaptive_mesh_2d_guard_unbalanced.f90"
     "meshrefine_2d_guard_multirank.f90"
     "quadtree_2d_guard_multirank.f90"
@@ -143,6 +144,7 @@ add_fortran_tests (
     "mortarprojection_identity.f90"
     "refinement_indicator_2d_spectraldecay.f90"
     "refinement_indicator_2d_relative_floor.f90"
+    "refinement_indicator_2d_energy_hysteresis.f90"
     "mappedscalarmortarexchange_2d_linear.f90"
     "mappedvectordgdivergence_2d_mortar.f90"
     "mappedscalargradient_3d_constant.f90"
@@ -247,6 +249,7 @@ set_tests_properties(
     refinement_indicator_2d_guard_emptyweights
     refinement_indicator_2d_guard_weightcount
     refinement_indicator_2d_guard_gatesize
+    refinement_indicator_2d_guard_significantfloor
     adaptive_mesh_2d_guard_unbalanced
     meshrefine_2d_guard_multirank
     quadtree_2d_guard_multirank

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -108,6 +108,10 @@ add_fortran_tests (
     "refinement_indicator_2d_guard_relfloor.f90"
     "refinement_indicator_2d_guard_energyscale.f90"
     "refinement_indicator_2d_guard_energyweights.f90"
+    "refinement_indicator_2d_guard_negweight.f90"
+    "refinement_indicator_2d_guard_emptyweights.f90"
+    "refinement_indicator_2d_guard_weightcount.f90"
+    "refinement_indicator_2d_guard_gatesize.f90"
     "adaptive_mesh_2d_guard_unbalanced.f90"
     "meshrefine_2d_guard_multirank.f90"
     "quadtree_2d_guard_multirank.f90"
@@ -239,6 +243,10 @@ set_tests_properties(
     refinement_indicator_2d_guard_relfloor
     refinement_indicator_2d_guard_energyscale
     refinement_indicator_2d_guard_energyweights
+    refinement_indicator_2d_guard_negweight
+    refinement_indicator_2d_guard_emptyweights
+    refinement_indicator_2d_guard_weightcount
+    refinement_indicator_2d_guard_gatesize
     adaptive_mesh_2d_guard_unbalanced
     meshrefine_2d_guard_multirank
     quadtree_2d_guard_multirank

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -90,6 +90,7 @@ add_fortran_tests (
     "transfer_plan_2d_guard_range.f90"
     "amr_controller_2d_guard_decomp.f90"
     "lineareuler2d_amr_soundwave.f90"
+    "lineareuler2d_amr_coarsen_wake.f90"
     "dgmodel2d_regrid_guard_uninit.f90"
     "data_2d_device_memory.f90"
     "geometry_2d_reuse.f90"
@@ -104,6 +105,9 @@ add_fortran_tests (
     "refinement_indicator_2d_guard_degree.f90"
     "refinement_indicator_2d_guard_nelem.f90"
     "refinement_indicator_2d_guard_ivar.f90"
+    "refinement_indicator_2d_guard_relfloor.f90"
+    "refinement_indicator_2d_guard_energyscale.f90"
+    "refinement_indicator_2d_guard_energyweights.f90"
     "adaptive_mesh_2d_guard_unbalanced.f90"
     "meshrefine_2d_guard_multirank.f90"
     "quadtree_2d_guard_multirank.f90"
@@ -134,6 +138,7 @@ add_fortran_tests (
     "mappedvectordgdivergence_2d_linear_structuredmesh.f90"
     "mortarprojection_identity.f90"
     "refinement_indicator_2d_spectraldecay.f90"
+    "refinement_indicator_2d_relative_floor.f90"
     "mappedscalarmortarexchange_2d_linear.f90"
     "mappedvectordgdivergence_2d_mortar.f90"
     "mappedscalargradient_3d_constant.f90"
@@ -231,6 +236,9 @@ set_tests_properties(
     refinement_indicator_2d_guard_degree
     refinement_indicator_2d_guard_nelem
     refinement_indicator_2d_guard_ivar
+    refinement_indicator_2d_guard_relfloor
+    refinement_indicator_2d_guard_energyscale
+    refinement_indicator_2d_guard_energyweights
     adaptive_mesh_2d_guard_unbalanced
     meshrefine_2d_guard_multirank
     quadtree_2d_guard_multirank

--- a/test/lineareuler2d_amr_coarsen_wake.f90
+++ b/test/lineareuler2d_amr_coarsen_wake.f90
@@ -1,0 +1,332 @@
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+!
+! Maintainers : support@fluidnumerics.com
+! Official Repository : https://github.com/FluidNumerics/self/
+!
+! Copyright © 2024 Fluid Numerics LLC
+!
+! Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+!
+! 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+!    the documentation and/or other materials provided with the distribution.
+!
+! 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+!    this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+! HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+! LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+! THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+! THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+!
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+
+program LinearEuler2D_AMR_CoarsenWake
+!! Regression test for AMR coarsening BEHIND a propagating front (issue #162).
+!!
+!! The modal-decay indicator's smoothness ratio is scale-free, so before the amplitude gate existed
+!! an element carrying low-amplitude grid-scale residue - what a wave leaves behind once it has
+!! passed - looked exactly as under-resolved as the front itself, and was flagged REFINE forever.
+!! The measured symptom was an element count that is monotone non-decreasing for a whole run:
+!! refinement tracked the wave outward and the refined region grew to the entire swept area, so the
+!! saving AMR delivered was set by how little of the domain the wave had reached rather than by
+!! adaptivity.
+!!
+!! The field here is prescribed rather than time-integrated: an expanding ring pulse whose radius is
+!! stepped outward, on top of a fixed grid-scale residue at 1e-6 of the ring's amplitude. That is a
+!! deliberate choice, and it isolates what the issue is about:
+!!
+!!   - the adaptation loop under test is indicator -> flags -> forest -> emitted mesh, which the
+!!     prescribed field drives exactly as a solver would, at a fraction of the cost;
+!!   - the residue is what actually pins the mesh, and prescribing it makes its amplitude an input
+!!     rather than an artefact of how long the run happens to be;
+!!   - the front stays inside the domain throughout. That matters: the gate normalizes against the
+!!     field's peak, so once a wave has radiated away entirely the scale collapses onto the
+!!     residue's own peak and no relative gate can discriminate. A propagating-wave problem - the
+!!     case the issue is about, and the case AMR is for - always has its front in the domain.
+!!
+!! Assertions:
+!!  (a) the ring is refined (an over-aggressive gate would suppress the front itself);
+!!  (b) the mesh is released WHERE THE FRONT HAS LEFT: at the final radius every element well
+!!      inside the ring is back at the base (level-0) size;
+!!  (c) the refined region follows the ring instead of filling the domain: the element count stays
+!!      far below the saturated (uniformly refined) mesh the ungated run degenerates to;
+!!  (d) control - with the gate disabled (relativeEnergyFloor = 0, i.e. the pre-fix behaviour) the
+!!      same sweep leaves the wake refined, so the assertions above have teeth.
+
+  use self_data
+  use self_lineareuler2d
+  use self_mesh_2d
+  use SELF_Geometry_2D
+  use SELF_AMRController_2D
+  use SELF_RefinementIndicator_2D
+
+  implicit none
+
+  integer,parameter :: controlDegree = 5
+  integer,parameter :: targetDegree = 7
+  integer,parameter :: maxLevel = 1
+  integer,parameter :: nElemX = 16 ! base-mesh elements per direction
+  real(prec),parameter :: Lx = 1.0_prec ! domain extent (m)
+  real(prec),parameter :: dx = Lx/real(nElemX,prec)
+  real(prec),parameter :: c0 = 1.0_prec
+  real(prec),parameter :: rho0 = 1.0_prec
+  ! Ring amplitude and half-width. Lr is below the base-mesh nodal spacing (dx/controlDegree =
+  ! 12.5 mm), so the ring is under-resolved at level 0 and the indicator must refine it.
+  real(prec),parameter :: amp = 1.0e4_prec
+  real(prec),parameter :: Lr = 0.01_prec
+  ! Grid-scale residue left everywhere, at 1e-6 of the ring's amplitude: the highest tensor Legendre
+  ! mode on each element, for which the smoothness ratio is exactly 1 whatever the mesh. Its modal
+  ! energy is 1e-4 - some ten orders of magnitude above machine epsilon in real64, and still ~1e3
+  ! above it in real32, so the absolute floor alone never touches it - against a ring-element
+  ! energy of order 1e7. That energy ratio, ~1e-11, is what the relative floor gates.
+  real(prec),parameter :: wakeAmp = 1.0e-2_prec
+  ! Radii the ring is stepped through (m). The last one leaves a wake several base elements deep.
+  real(prec),parameter :: ringRadius(1:5) = &
+                          [0.05_prec,0.10_prec,0.15_prec,0.20_prec,0.25_prec]
+  ! Elements whose centroid is inside this radius are behind the final ring by at least three base
+  ! elements, so nothing there can be held refined by the front or its halo.
+  real(prec),parameter :: wakeRadius = 0.05_prec
+
+  integer :: nGated,nUngated
+  real(prec) :: hGated,hUngated
+  integer :: r
+  ! SELF owns the MPI lifecycle and keeps it alive only while a mesh is live, so a run that tears
+  ! its mesh down between the two sweeps would finalize MPI and leave the second sweep running
+  ! against a finalized library (see test/domaindecomposition_two_meshes.f90). This mesh exists
+  ! solely to hold that reference open across both sweeps.
+  type(Mesh2D),target :: keepAlive
+  integer :: keepAliveBcids(1:4)
+
+  r = 0
+
+  keepAliveBcids(1:4) = SELF_BC_NONORMALFLOW
+  call keepAlive%StructuredMesh(2,2,1,1,0.5_prec,0.5_prec,keepAliveBcids)
+
+  ! ---- The shipped amplitude gate ----
+  call RunSweep(SELF_AMR_DEFAULT_RELFLOOR,nGated,hGated)
+  print*,"with the amplitude gate    : nElem =",nGated, &
+    ", smallest element near the centre / base =",hGated
+
+  ! ---- (d) Control: the pre-fix behaviour ----
+  call RunSweep(0.0_prec,nUngated,hUngated)
+  print*,"with the gate disabled     : nElem =",nUngated, &
+    ", smallest element near the centre / base =",hUngated
+
+  ! ---- (b) The wake is released ----
+  if(hGated < 0.75_prec) then
+    print*,"FAIL: the wake behind the ring was not coarsened back to the base mesh"
+    r = 1
+  endif
+
+  ! ---- (d) ... and would not have been before the gate existed ----
+  if(hUngated >= 0.75_prec) then
+    print*,"FAIL: the control run also released the wake, so this test proves nothing"
+    r = 1
+  endif
+  if(nGated >= nUngated) then
+    print*,"FAIL: the gate did not reduce the element count",nGated,nUngated
+    r = 1
+  endif
+  ! ---- (c) The refined region follows the ring instead of filling the domain ----
+  ! Without the gate every element is eventually flagged REFINE and the mesh saturates at the
+  ! level cap (4*nElemX**2 elements), so AMR degenerates into a uniformly fine mesh. The gated
+  ! run must stay far below that; the margin here is large (roughly 2.3x), so half is a
+  ! comfortable bound that still fails loudly if the gate stops working.
+  block
+    integer :: nSaturated
+    nSaturated = 4*nElemX*nElemX
+    print*,"element count : gated",nGated,", ungated",nUngated, &
+      ", saturated",nSaturated,", base",nElemX*nElemX
+    if(nGated > nSaturated/2) then
+      print*,"FAIL: the refined region is filling the domain rather than following the ring"
+      r = 1
+    endif
+  endblock
+
+  if(r == 0) print*,"LINEAR EULER 2D AMR COARSEN WAKE CHECKS PASSED"
+
+  call keepAlive%Free()
+
+  if(r /= 0) stop 1
+
+contains
+
+  subroutine RunSweep(relativeEnergyFloor,nElemFinal,hRelCentre)
+    !! Step an expanding ring through the domain, adapting to it at each radius, and report the
+    !! final element count together with the size of the smallest element near the domain centre
+    !! relative to a base element.
+    implicit none
+    real(prec),intent(in) :: relativeEnergyFloor
+    integer,intent(out) :: nElemFinal
+    real(prec),intent(out) :: hRelCentre
+    ! Local
+    type(LinearEuler2D) :: modelobj
+    type(Lagrange),target :: interp
+    type(Mesh2D),target :: mesh
+    type(SEMQuad),target :: geometry
+    type(AMRController2D) :: controller
+    integer :: bcids(1:4)
+    integer :: stage,i
+    logical :: adapted
+
+    bcids(1:4) = [SELF_BC_RADIATION, & ! south
+                  SELF_BC_RADIATION, & ! east
+                  SELF_BC_RADIATION, & ! north
+                  SELF_BC_RADIATION] ! west
+
+    call mesh%StructuredMesh(nElemX,nElemX,1,1,dx,dx,bcids)
+    call interp%Init(N=controlDegree, &
+                     controlNodeType=GAUSS, &
+                     M=targetDegree, &
+                     targetNodeType=UNIFORM)
+    call geometry%Init(interp,mesh%nElem)
+    call geometry%GenerateFromMesh(mesh)
+
+    call modelobj%Init(mesh,geometry)
+    modelobj%prescribed_bcs_enabled = .false.
+    modelobj%tecplot_enabled = .false.
+    modelobj%rho0 = rho0
+
+    ! Recommended starting thresholds from the AMR documentation; pressure (variable 3) drives the
+    ! indicator, and nHalo = 1 keeps the refined band one element wider than the ring.
+    call controller%Init(modelobj,refineThreshold=-3.0_prec,coarsenThreshold=-8.0_prec, &
+                         ivar=3,maxLevel=maxLevel,nHalo=1, &
+                         relativeEnergyFloor=relativeEnergyFloor)
+
+    do stage = 1,size(ringRadius)
+      ! Adapt to convergence at this radius, re-evaluating the field on each new mesh so the
+      ! indicator sees the true ring rather than its coarse-mesh interpolant.
+      call SetRingField(modelobj,interp,ringRadius(stage))
+      do i = 1,maxLevel+2
+        call controller%Adapt(modelobj,adapted)
+        if(.not. adapted) exit
+        call SetRingField(modelobj,interp,ringRadius(stage))
+      enddo
+      print*,"  ring radius",ringRadius(stage),": nElem =",modelobj%mesh%nElem, &
+        ", max level =",controller%forest%MaxLevel()
+
+      ! (a) The ring itself must be refined - a gate that suppressed the front would show up here.
+      if(controller%forest%MaxLevel() < 1) then
+        print*,"FAIL: the ring was never refined at radius",ringRadius(stage)
+        r = 1
+      endif
+    enddo
+
+    nElemFinal = modelobj%mesh%nElem
+    hRelCentre = RelativeSizeNearCentre(modelobj,interp)
+
+    call modelobj%Free()
+    call controller%Free()
+    call geometry%Free()
+    call mesh%Free()
+    call interp%Free()
+
+  endsubroutine RunSweep
+
+  subroutine SetRingField(modelobj,interp,radius)
+    !! Prescribe an expanding ring pulse of the given radius on the model's current mesh, plus a
+    !! fixed grid-scale residue. The residue is written in REFERENCE coordinates (the highest
+    !! tensor Legendre mode of the element), so it stays grid-scale on whatever mesh the previous
+    !! adaptation produced - which is precisely the residue that a scale-free smoothness ratio
+    !! cannot distinguish from a genuine front.
+    implicit none
+    type(LinearEuler2D),intent(inout) :: modelobj
+    type(Lagrange),intent(in) :: interp
+    real(prec),intent(in) :: radius
+    ! Local
+    integer :: i,j,iEl
+    real(prec) :: x,y,rr,ring,residue
+
+    do iEl = 1,modelobj%mesh%nElem
+      do j = 1,controlDegree+1
+        do i = 1,controlDegree+1
+          x = modelobj%geometry%x%interior(i,j,iEl,1,1)-0.5_prec*Lx
+          y = modelobj%geometry%x%interior(i,j,iEl,1,2)-0.5_prec*Lx
+          rr = sqrt(x*x+y*y)
+          ring = amp*exp(-log(2.0_prec)*(rr-radius)**2/Lr**2)
+          residue = wakeAmp*nlegendre(controlDegree,interp%controlPoints(i))* &
+                    nlegendre(controlDegree,interp%controlPoints(j))
+          modelobj%solution%interior(i,j,iEl,1) = 0.0_prec
+          modelobj%solution%interior(i,j,iEl,2) = 0.0_prec
+          modelobj%solution%interior(i,j,iEl,3) = ring+residue
+          modelobj%solution%interior(i,j,iEl,4) = c0
+          modelobj%solution%interior(i,j,iEl,5) = rho0
+        enddo
+      enddo
+    enddo
+    call modelobj%solution%UpdateDevice() ! no-op on CPU; pushes interior to device on GPU
+
+  endsubroutine SetRingField
+
+  function RelativeSizeNearCentre(modelobj,interp) result(hRel)
+    !! Size of the smallest element whose centroid lies within wakeRadius of the domain centre, as
+    !! a fraction of a base (level-0) element. Element size is read back from the geometry the
+    !! model is actually running on rather than inferred from a refinement level. The span is
+    !! measured across control points, which on Gauss nodes stop short of the element edges; the
+    !! reference span is measured the same way, so that factor cancels.
+    implicit none
+    type(LinearEuler2D),intent(in) :: modelobj
+    type(Lagrange),intent(in) :: interp
+    real(prec) :: hRel
+    ! Local
+    integer :: iEl,ii,jj,np
+    real(prec) :: xc,yc,xmin,xmax,rc,hNear,hBase
+
+    np = controlDegree+1
+    hNear = huge(1.0_prec)
+    hBase = dx*0.5_prec*(interp%controlPoints(np)-interp%controlPoints(1))
+    do iEl = 1,modelobj%mesh%nElem
+      xc = 0.0_prec
+      yc = 0.0_prec
+      xmin = huge(1.0_prec)
+      xmax = -huge(1.0_prec)
+      do jj = 1,np
+        do ii = 1,np
+          xc = xc+modelobj%geometry%x%interior(ii,jj,iEl,1,1)
+          yc = yc+modelobj%geometry%x%interior(ii,jj,iEl,1,2)
+          xmin = min(xmin,modelobj%geometry%x%interior(ii,jj,iEl,1,1))
+          xmax = max(xmax,modelobj%geometry%x%interior(ii,jj,iEl,1,1))
+        enddo
+      enddo
+      xc = xc/real(np*np,prec)
+      yc = yc/real(np*np,prec)
+      rc = sqrt((xc-0.5_prec*Lx)**2+(yc-0.5_prec*Lx)**2)
+      if(rc <= wakeRadius) hNear = min(hNear,xmax-xmin)
+    enddo
+
+    hRel = hNear/hBase
+
+  endfunction RelativeSizeNearCentre
+
+  pure function nlegendre(p,x) result(Lp)
+    !! L2-normalized Legendre polynomial on [-1,1], matching the basis used by the indicator.
+    implicit none
+    integer,intent(in) :: p
+    real(prec),intent(in) :: x
+    real(prec) :: Lp
+    integer :: k
+    real(prec) :: lkm1,lk,lkp1
+
+    if(p == 0) then
+      Lp = 1.0_prec
+    elseif(p == 1) then
+      Lp = x
+    else
+      lkm1 = 1.0_prec
+      lk = x
+      do k = 1,p-1
+        lkp1 = (real(2*k+1,prec)*x*lk-real(k,prec)*lkm1)/real(k+1,prec)
+        lkm1 = lk
+        lk = lkp1
+      enddo
+      Lp = lk
+    endif
+    Lp = Lp*sqrt((2.0_prec*real(p,prec)+1.0_prec)/2.0_prec)
+
+  endfunction nlegendre
+
+endprogram LinearEuler2D_AMR_CoarsenWake

--- a/test/lineareuler2d_amr_coarsen_wake.f90
+++ b/test/lineareuler2d_amr_coarsen_wake.f90
@@ -36,7 +36,7 @@ program LinearEuler2D_AMR_CoarsenWake
 !! adaptivity.
 !!
 !! The field here is prescribed rather than time-integrated: an expanding ring pulse whose radius is
-!! stepped outward, on top of a fixed grid-scale residue at 1e-6 of the ring's amplitude. That is a
+!! stepped outward, on top of a fixed grid-scale residue at 1e-8 of the ring's amplitude. That is a
 !! deliberate choice, and it isolates what the issue is about:
 !!
 !!   - the adaptation loop under test is indicator -> flags -> forest -> emitted mesh, which the
@@ -76,13 +76,14 @@ program LinearEuler2D_AMR_CoarsenWake
   real(prec),parameter :: rho0 = 1.0_prec
   ! Ring amplitude and half-width. Lr is below the base-mesh nodal spacing (dx/controlDegree =
   ! 12.5 mm), so the ring is under-resolved at level 0 and the indicator must refine it.
-  real(prec),parameter :: amp = 1.0e4_prec
+  real(prec),parameter :: amp = 1.0e6_prec
   real(prec),parameter :: Lr = 0.01_prec
-  ! Grid-scale residue left everywhere, at 1e-6 of the ring's amplitude: the highest tensor Legendre
+  ! Grid-scale residue left everywhere, at 1e-8 of the ring's amplitude: the highest tensor Legendre
   ! mode on each element, for which the smoothness ratio is exactly 1 whatever the mesh. Its modal
-  ! energy is 1e-4 - some ten orders of magnitude above machine epsilon in real64, and still ~1e3
-  ! above it in real32, so the absolute floor alone never touches it - against a ring-element
-  ! energy of order 1e7. That energy ratio, ~1e-11, is what the relative floor gates.
+  ! energy is 1e-4 - twelve orders of magnitude above machine epsilon in real64, and still ~1e3
+  ! above it in real32, so the absolute floor alone never touches it and the ungated control really
+  ! does refine on it - against a ring-element energy of order 1e11. That energy ratio, ~1e-15, is
+  ! what the relative floor gates, with three orders of margin below the 1e-12 default.
   real(prec),parameter :: wakeAmp = 1.0e-2_prec
   ! Radii the ring is stepped through (m). The last one leaves a wake several base elements deep.
   real(prec),parameter :: ringRadius(1:5) = &

--- a/test/refinement_indicator_2d_energy_hysteresis.f90
+++ b/test/refinement_indicator_2d_energy_hysteresis.f90
@@ -1,0 +1,222 @@
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+!
+! Maintainers : support@fluidnumerics.com
+! Official Repository : https://github.com/FluidNumerics/self/
+!
+! Copyright © 2024 Fluid Numerics LLC
+!
+! Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+!
+! 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+!    the documentation and/or other materials provided with the distribution.
+!
+! 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+!    this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+! HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+! LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+! THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+! THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+!
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+
+program test
+
+  implicit none
+  integer :: exit_code
+
+  exit_code = refinement_indicator_2d_energy_hysteresis()
+  if(exit_code /= 0) then
+    stop exit_code
+  endif
+
+contains
+
+  integer function refinement_indicator_2d_energy_hysteresis() result(r)
+    !! Validates the hysteresis band on the amplitude gate's energy axis.
+    !!
+    !! A single hard gate reintroduces, on the energy axis, exactly the thrashing that the two
+    !! sigma thresholds exist to prevent: an element whose amplitude drifts across that one value
+    !! flips COARSEN <-> REFINE on successive epochs, so the mesh churns without the solution
+    !! changing meaningfully. Opening a band between a quiescent floor and a significant floor
+    !! makes the middle zone report SELF_AMR_KEEP - too weak to justify spending levels on, too
+    !! strong to declare resolved - which is stable under a small change in amplitude.
+    !!
+    !! Every element carries the same pure highest tensor mode (S_e = 1 exactly, so the spectrum
+    !! always says REFINE) scaled to a different amplitude, so only the energy axis can change a
+    !! flag. Element 1 has amplitude 1 and sets the energy scale; the others sample the three
+    !! zones of a band spanning [1e-12, 1e-8] of that scale:
+    !!
+    !!   element 2 : E = 1e-14  below the quiescent floor      -> COARSEN
+    !!   element 3 : E = 1e-10  inside the band                -> KEEP
+    !!   element 4 : E = 1e-6   above the significant floor    -> REFINE
+    !!
+    !! The thrashing check then walks element 3's amplitude across the OLD single-cut boundary and
+    !! requires the flag not to move.
+    use SELF_Constants
+    use SELF_Lagrange
+    use SELF_Scalar_2D
+    use SELF_RefinementIndicator_2D
+
+    implicit none
+
+    integer,parameter :: N = 7
+    integer,parameter :: nel = 4
+    integer,parameter :: nvar = 1
+    real(prec),parameter :: refineThreshold = -3.0_prec
+    real(prec),parameter :: coarsenThreshold = -8.0_prec
+    real(prec),parameter :: quiescentFloor = 1.0e-12_prec
+    real(prec),parameter :: significantFloor = 1.0e-8_prec
+    ! Amplitudes: energies 1, 1e-14, 1e-10, 1e-6 (the square of each).
+    real(prec),parameter :: amp(1:nel) = &
+                            [1.0_prec,1.0e-7_prec,1.0e-5_prec,1.0e-3_prec]
+    type(Lagrange),target :: interp
+    type(Scalar2D) :: sol
+    type(RefinementIndicator2D) :: amr
+    integer :: nodeType,k,flagBefore
+    real(prec) :: drift
+
+    r = 0
+
+    do nodeType = 1,2 ! GAUSS = 1, GAUSS_LOBATTO = 2
+
+      call interp%Init(N=N,controlNodeType=nodeType,M=N,targetNodeType=UNIFORM)
+      call sol%Init(interp,nvar,nel)
+      call amr%Init(interp,nel,refineThreshold,coarsenThreshold)
+
+      call SetAmplitudes(sol,interp,amp)
+      call amr%SetRelativeEnergyFloor(quiescentFloor,significantEnergyFloor=significantFloor)
+      call amr%Estimate(sol,ivar=1)
+
+      print*,"node type ",nodeType," : band [1e-12,1e-8]"
+      do k = 1,nel
+        print*,"  element, sigma, gate, flag :",k,amr%indicator(k),amr%gate(k),amr%flag(k)
+      enddo
+
+      ! ---- 1. The three zones ----
+      if(amr%flag(1) /= SELF_AMR_REFINE .or. amr%flag(4) /= SELF_AMR_REFINE) then
+        print*,"FAIL: elements above the significant floor should be flagged REFINE"
+        r = 1
+      endif
+      if(amr%flag(2) /= SELF_AMR_COARSEN) then
+        print*,"FAIL: element below the quiescent floor should be flagged COARSEN"
+        r = 1
+      endif
+      if(amr%flag(3) /= SELF_AMR_KEEP) then
+        print*,"FAIL: element inside the energy band should be flagged KEEP"
+        r = 1
+      endif
+
+      ! Inside the band the reported sigma must still be the TRUE spectral value (S_e = 1 here),
+      ! not the quiescent floor value: the band holds the flag, it does not falsify the diagnostic.
+      if(abs(amr%indicator(3)) > 1.0e-6_prec) then
+        print*,"FAIL: sigma inside the band should still report the true spectrum, got", &
+          amr%indicator(3)
+        r = 1
+      endif
+
+      ! ---- 2. No thrashing across the old single-cut boundary ----
+      ! With one cut at 1e-10 the element below would COARSEN and the element above would REFINE.
+      ! Inside a band that brackets it, a factor-of-ten drift either way must not move the flag.
+      flagBefore = amr%flag(3)
+      do k = -1,1
+        drift = 10.0_prec**real(k,prec)
+        call SetAmplitudes(sol,interp,[amp(1),amp(2),amp(3)*sqrt(drift),amp(4)])
+        call amr%Estimate(sol,ivar=1)
+        if(amr%flag(3) /= flagBefore) then
+          print*,"FAIL: flag thrashed as the in-band energy drifted by",drift, &
+            " : ",flagBefore," -> ",amr%flag(3)
+          r = 1
+        endif
+      enddo
+
+      ! ---- 3. A degenerate band reproduces the single hard cut ----
+      ! Band collapsed onto a single value of 1e-9, which brackets element 3's energy (1e-10) and
+      ! its tenfold-amplitude version (1e-8) with an order of magnitude either side. The flag then
+      ! flips COARSEN -> REFINE across that one cut: this is the thrashing the band exists to damp,
+      ! asserted here rather than assumed, and it is the same drift that left the flag untouched in
+      ! check 2 above.
+      call SetAmplitudes(sol,interp,amp)
+      call amr%SetRelativeEnergyFloor(1.0e-9_prec)
+      call amr%Estimate(sol,ivar=1)
+      if(amr%flag(3) /= SELF_AMR_COARSEN) then
+        print*,"FAIL: at a degenerate band an element below the cut should be COARSEN"
+        r = 1
+      endif
+      call SetAmplitudes(sol,interp,[amp(1),amp(2),amp(3)*10.0_prec,amp(4)])
+      call amr%Estimate(sol,ivar=1)
+      if(amr%flag(3) /= SELF_AMR_REFINE) then
+        print*,"FAIL: at a degenerate band a tenfold rise should flip the element to REFINE"
+        r = 1
+      endif
+
+      call amr%Free()
+      call sol%Free()
+      call interp%Free()
+
+    enddo
+
+    if(r == 0) print*,"REFINEMENT INDICATOR 2D ENERGY HYSTERESIS CHECKS PASSED"
+
+  endfunction refinement_indicator_2d_energy_hysteresis
+
+  subroutine SetAmplitudes(sol,interp,amp)
+    !! Fill every element with the pure highest tensor Legendre mode at the given per-element
+    !! amplitude, so the modal energy of element e is exactly amp(e)**2 and the smoothness ratio
+    !! is exactly 1 on every element.
+    use SELF_Constants
+    use SELF_Lagrange
+    use SELF_Scalar_2D
+    implicit none
+    type(Scalar2D),intent(inout) :: sol
+    type(Lagrange),intent(in) :: interp
+    real(prec),intent(in) :: amp(:)
+    ! Local
+    integer :: i,j,iel
+
+    do iel = 1,size(amp)
+      do j = 1,interp%N+1
+        do i = 1,interp%N+1
+          sol%interior(i,j,iel,1) = amp(iel)* &
+                                    nlegendre(interp%N,interp%controlPoints(i))* &
+                                    nlegendre(interp%N,interp%controlPoints(j))
+        enddo
+      enddo
+    enddo
+    call sol%UpdateDevice() ! no-op on CPU; pushes interior to device on GPU
+
+  endsubroutine SetAmplitudes
+
+  pure function nlegendre(p,x) result(Lp)
+    !! L2-normalized Legendre polynomial on [-1,1], matching the basis used by the indicator.
+    use SELF_Constants
+    implicit none
+    integer,intent(in) :: p
+    real(prec),intent(in) :: x
+    real(prec) :: Lp
+    integer :: k
+    real(prec) :: lkm1,lk,lkp1
+
+    if(p == 0) then
+      Lp = 1.0_prec
+    elseif(p == 1) then
+      Lp = x
+    else
+      lkm1 = 1.0_prec
+      lk = x
+      do k = 1,p-1
+        lkp1 = (real(2*k+1,prec)*x*lk-real(k,prec)*lkm1)/real(k+1,prec)
+        lkm1 = lk
+        lk = lkp1
+      enddo
+      Lp = lk
+    endif
+    Lp = Lp*sqrt((2.0_prec*real(p,prec)+1.0_prec)/2.0_prec)
+
+  endfunction nlegendre
+
+endprogram test

--- a/test/refinement_indicator_2d_guard_emptyweights.f90
+++ b/test/refinement_indicator_2d_guard_emptyweights.f90
@@ -1,0 +1,41 @@
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+!
+! Maintainers : support@fluidnumerics.com
+! Official Repository : https://github.com/FluidNumerics/self/
+!
+! Copyright © 2024 Fluid Numerics LLC
+!
+! Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+!
+! 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+!    the documentation and/or other materials provided with the distribution.
+!
+! 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+!    this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+! HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+! LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+! THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+! THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+!
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+
+! Guard test (expected to abort): SetEnergyWeights must reject an empty weight vector.
+program test
+  use SELF_Constants
+  use SELF_Lagrange
+  use SELF_RefinementIndicator_2D
+  implicit none
+  type(Lagrange),target :: interp
+  type(RefinementIndicator2D) :: amr
+
+  call interp%Init(N=4,controlNodeType=GAUSS,M=4,targetNodeType=UNIFORM)
+  call amr%Init(interp,4,-3.0_prec,-8.0_prec)
+  ! No weights at all leaves the gate undefined : must stop.
+  call amr%SetEnergyWeights([real(prec)::])
+  print*,"ERROR: SetEnergyWeights empty-vector guard did not trigger"
+endprogram test

--- a/test/refinement_indicator_2d_guard_energyscale.f90
+++ b/test/refinement_indicator_2d_guard_energyscale.f90
@@ -1,0 +1,41 @@
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+!
+! Maintainers : support@fluidnumerics.com
+! Official Repository : https://github.com/FluidNumerics/self/
+!
+! Copyright © 2024 Fluid Numerics LLC
+!
+! Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+!
+! 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+!    the documentation and/or other materials provided with the distribution.
+!
+! 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+!    this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+! HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+! LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+! THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+! THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+!
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+
+! Guard test (expected to abort): SetEnergyScale must reject a negative energy scale.
+program test
+  use SELF_Constants
+  use SELF_Lagrange
+  use SELF_RefinementIndicator_2D
+  implicit none
+  type(Lagrange),target :: interp
+  type(RefinementIndicator2D) :: amr
+
+  call interp%Init(N=4,controlNodeType=GAUSS,M=4,targetNodeType=UNIFORM)
+  call amr%Init(interp,4,-3.0_prec,-8.0_prec)
+  ! The scale is a squared amplitude and cannot be negative : must stop.
+  call amr%SetEnergyScale(-1.0_prec)
+  print*,"ERROR: SetEnergyScale guard did not trigger"
+endprogram test

--- a/test/refinement_indicator_2d_guard_energyweights.f90
+++ b/test/refinement_indicator_2d_guard_energyweights.f90
@@ -1,0 +1,42 @@
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+!
+! Maintainers : support@fluidnumerics.com
+! Official Repository : https://github.com/FluidNumerics/self/
+!
+! Copyright © 2024 Fluid Numerics LLC
+!
+! Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+!
+! 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+!    the documentation and/or other materials provided with the distribution.
+!
+! 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+!    this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+! HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+! LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+! THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+! THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+!
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+
+! Guard test (expected to abort): SetEnergyWeights must reject an all-zero weight vector, which
+! would leave every element below any relative floor and coarsen the whole mesh.
+program test
+  use SELF_Constants
+  use SELF_Lagrange
+  use SELF_RefinementIndicator_2D
+  implicit none
+  type(Lagrange),target :: interp
+  type(RefinementIndicator2D) :: amr
+
+  call interp%Init(N=4,controlNodeType=GAUSS,M=4,targetNodeType=UNIFORM)
+  call amr%Init(interp,4,-3.0_prec,-8.0_prec)
+  ! No variable contributes to the gate : must stop.
+  call amr%SetEnergyWeights([0.0_prec,0.0_prec])
+  print*,"ERROR: SetEnergyWeights guard did not trigger"
+endprogram test

--- a/test/refinement_indicator_2d_guard_gatesize.f90
+++ b/test/refinement_indicator_2d_guard_gatesize.f90
@@ -1,0 +1,49 @@
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+!
+! Maintainers : support@fluidnumerics.com
+! Official Repository : https://github.com/FluidNumerics/self/
+!
+! Copyright © 2024 Fluid Numerics LLC
+!
+! Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+!
+! 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+!    the documentation and/or other materials provided with the distribution.
+!
+! 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+!    this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+! HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+! LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+! THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+! THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+!
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+
+! Guard test (expected to abort): a caller-supplied gate array shorter than the element count would
+! leave some elements gated on uninitialized memory.
+program test
+  use SELF_Constants
+  use SELF_Lagrange
+  use SELF_Scalar_2D
+  use SELF_RefinementIndicator_2D
+  implicit none
+  type(Lagrange),target :: interp
+  type(Scalar2D) :: sol
+  type(RefinementIndicator2D) :: amr
+  real(prec) :: gate(1:2)
+
+  call interp%Init(N=4,controlNodeType=GAUSS,M=4,targetNodeType=UNIFORM)
+  call sol%Init(interp,1,4) ! 4 elements
+  sol%interior = 1.0_prec
+  call sol%UpdateDevice()
+  call amr%Init(interp,4,-3.0_prec,-8.0_prec)
+  gate = 1.0_prec
+  ! Two gate values for four elements : must stop.
+  call amr%Estimate(sol,ivar=1,gate=gate)
+  print*,"ERROR: caller-supplied gate size guard did not trigger"
+endprogram test

--- a/test/refinement_indicator_2d_guard_negweight.f90
+++ b/test/refinement_indicator_2d_guard_negweight.f90
@@ -1,0 +1,42 @@
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+!
+! Maintainers : support@fluidnumerics.com
+! Official Repository : https://github.com/FluidNumerics/self/
+!
+! Copyright © 2024 Fluid Numerics LLC
+!
+! Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+!
+! 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+!    the documentation and/or other materials provided with the distribution.
+!
+! 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+!    this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+! HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+! LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+! THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+! THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+!
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+
+! Guard test (expected to abort): SetEnergyWeights must reject a negative weight, which would let
+! one variable's energy cancel another's in the gate.
+program test
+  use SELF_Constants
+  use SELF_Lagrange
+  use SELF_RefinementIndicator_2D
+  implicit none
+  type(Lagrange),target :: interp
+  type(RefinementIndicator2D) :: amr
+
+  call interp%Init(N=4,controlNodeType=GAUSS,M=4,targetNodeType=UNIFORM)
+  call amr%Init(interp,4,-3.0_prec,-8.0_prec)
+  ! A negative weight is not a convex combination of energies : must stop.
+  call amr%SetEnergyWeights([1.0_prec,-1.0_prec])
+  print*,"ERROR: SetEnergyWeights negative-weight guard did not trigger"
+endprogram test

--- a/test/refinement_indicator_2d_guard_relfloor.f90
+++ b/test/refinement_indicator_2d_guard_relfloor.f90
@@ -1,0 +1,41 @@
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+!
+! Maintainers : support@fluidnumerics.com
+! Official Repository : https://github.com/FluidNumerics/self/
+!
+! Copyright © 2024 Fluid Numerics LLC
+!
+! Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+!
+! 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+!    the documentation and/or other materials provided with the distribution.
+!
+! 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+!    this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+! HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+! LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+! THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+! THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+!
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+
+! Guard test (expected to abort): SetRelativeEnergyFloor must reject a floor outside [0,1).
+program test
+  use SELF_Constants
+  use SELF_Lagrange
+  use SELF_RefinementIndicator_2D
+  implicit none
+  type(Lagrange),target :: interp
+  type(RefinementIndicator2D) :: amr
+
+  call interp%Init(N=4,controlNodeType=GAUSS,M=4,targetNodeType=UNIFORM)
+  call amr%Init(interp,4,-3.0_prec,-8.0_prec)
+  ! A negative energy fraction is meaningless : must stop.
+  call amr%SetRelativeEnergyFloor(-1.0_prec)
+  print*,"ERROR: SetRelativeEnergyFloor guard did not trigger"
+endprogram test

--- a/test/refinement_indicator_2d_guard_significantfloor.f90
+++ b/test/refinement_indicator_2d_guard_significantfloor.f90
@@ -1,0 +1,42 @@
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+!
+! Maintainers : support@fluidnumerics.com
+! Official Repository : https://github.com/FluidNumerics/self/
+!
+! Copyright © 2024 Fluid Numerics LLC
+!
+! Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+!
+! 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+!    the documentation and/or other materials provided with the distribution.
+!
+! 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+!    this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+! HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+! LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+! THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+! THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+!
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+
+! Guard test (expected to abort): the upper edge of the energy hysteresis band must not sit below
+! the quiescent floor, which would invert the band.
+program test
+  use SELF_Constants
+  use SELF_Lagrange
+  use SELF_RefinementIndicator_2D
+  implicit none
+  type(Lagrange),target :: interp
+  type(RefinementIndicator2D) :: amr
+
+  call interp%Init(N=4,controlNodeType=GAUSS,M=4,targetNodeType=UNIFORM)
+  call amr%Init(interp,4,-3.0_prec,-8.0_prec)
+  ! Significant floor below the quiescent floor : must stop.
+  call amr%SetRelativeEnergyFloor(1.0e-8_prec,significantEnergyFloor=1.0e-12_prec)
+  print*,"ERROR: significantEnergyFloor ordering guard did not trigger"
+endprogram test

--- a/test/refinement_indicator_2d_guard_weightcount.f90
+++ b/test/refinement_indicator_2d_guard_weightcount.f90
@@ -1,0 +1,49 @@
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+!
+! Maintainers : support@fluidnumerics.com
+! Official Repository : https://github.com/FluidNumerics/self/
+!
+! Copyright © 2024 Fluid Numerics LLC
+!
+! Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+!
+! 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+!    the documentation and/or other materials provided with the distribution.
+!
+! 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+!    this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+! HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+! LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+! THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+! THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+!
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+
+! Guard test (expected to abort): weights set for one variable count must not be silently reused
+! against a solution with a different number of variables - the gate would read past the weights
+! or drop variables from the sum.
+program test
+  use SELF_Constants
+  use SELF_Lagrange
+  use SELF_Scalar_2D
+  use SELF_RefinementIndicator_2D
+  implicit none
+  type(Lagrange),target :: interp
+  type(Scalar2D) :: sol
+  type(RefinementIndicator2D) :: amr
+
+  call interp%Init(N=4,controlNodeType=GAUSS,M=4,targetNodeType=UNIFORM)
+  call sol%Init(interp,2,4) ! nVar = 2
+  sol%interior = 1.0_prec
+  call sol%UpdateDevice()
+  call amr%Init(interp,4,-3.0_prec,-8.0_prec)
+  ! Three weights against a two-variable solution : must stop at Estimate.
+  call amr%SetEnergyWeights([1.0_prec,1.0_prec,1.0_prec])
+  call amr%Estimate(sol,ivar=1)
+  print*,"ERROR: energy-weight variable-count guard did not trigger"
+endprogram test

--- a/test/refinement_indicator_2d_relative_floor.f90
+++ b/test/refinement_indicator_2d_relative_floor.f90
@@ -1,0 +1,295 @@
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+!
+! Maintainers : support@fluidnumerics.com
+! Official Repository : https://github.com/FluidNumerics/self/
+!
+! Copyright © 2024 Fluid Numerics LLC
+!
+! Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+!
+! 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+!    the documentation and/or other materials provided with the distribution.
+!
+! 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+!    this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+! HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+! LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+! THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+! THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+!
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+
+program test
+
+  implicit none
+  integer :: exit_code
+
+  exit_code = refinement_indicator_2d_relative_floor()
+  if(exit_code /= 0) then
+    stop exit_code
+  endif
+
+contains
+
+  integer function refinement_indicator_2d_relative_floor() result(r)
+    !! Validates the amplitude gate (relative energy floor) of the 2-D modal-decay refinement
+    !! indicator, on both Legendre-Gauss and Legendre-Gauss-Lobatto nodes.
+    !!
+    !! The smoothness ratio S_e is a ratio and therefore scale-free: grid-scale ringing at 1e-6 of
+    !! the field's amplitude has exactly the same S_e = 1 as a full-amplitude discontinuity. Under
+    !! an absolute (machine-epsilon) guard alone, such low-amplitude residue reads as
+    !! under-resolved forever and is never released, which is what pins the mesh behind a passing
+    !! wave. The gate compares each element's energy against a fraction of the field's energy
+    !! scale instead.
+    !!
+    !! Every element carries the SAME shape - the pure highest tensor mode Ltilde_N(xi)Ltilde_N(eta),
+    !! for which S_e = 1 exactly - scaled to a different amplitude, so the flags can only differ
+    !! through the amplitude gate. With the normalized basis the modal energy of an element of
+    !! amplitude a is exactly a**2:
+    !!
+    !!   element 1 : a = 1      -> E = 1      (sets the automatic energy scale)
+    !!   element 2 : a = 1e-2   -> E = 1e-4
+    !!   element 3 : a = 0.5    -> E = 0.25
+    !!   element 4 : a = 0      -> E = 0      (the absolute-floor path)
+    !!   element 5 : a = 1e-6   -> E = 1e-12
+    !!
+    !! Variable 2 is zero everywhere except on element 1, where it is a large constant. It stands
+    !! in for a background field (LinearEuler2D carries the sound speed and background density as
+    !! variables 4 and 5) whose magnitude would otherwise set the gate's energy scale for every
+    !! other variable - which is what the per-variable gate weights exist to prevent.
+    use SELF_Constants
+    use SELF_Lagrange
+    use SELF_Scalar_2D
+    use SELF_RefinementIndicator_2D
+
+    implicit none
+
+    integer,parameter :: N = 7
+    integer,parameter :: nel = 5
+    integer,parameter :: nvar = 2
+    real(prec),parameter :: refineThreshold = -3.0_prec
+    real(prec),parameter :: coarsenThreshold = -8.0_prec
+    ! Amplitudes of the identical top-mode shape on each element; the modal energy is the square.
+    real(prec),parameter :: amp(1:nel) = [1.0_prec,1.0e-2_prec,0.5_prec,0.0_prec,1.0e-6_prec]
+    ! A background-field amplitude on variable 2 of element 1, far above every element's
+    ! variable-1 energy: 100**2 * 4 = 4e4 against a largest variable-1 energy of 1.
+    real(prec),parameter :: background = 100.0_prec
+    ! Test floor: 1e-2 of the energy scale (1), so elements 2, 4 and 5 are gated and 1 and 3 are
+    ! not, with two orders of magnitude of margin either side in both real32 and real64.
+    real(prec),parameter :: testFloor = 1.0e-2_prec
+    type(Lagrange),target :: interp
+    type(Scalar2D) :: sol
+    type(RefinementIndicator2D) :: amr
+    integer :: nodeType,i,j,iel
+    real(prec) :: x,y
+    real(prec) :: gateOverride(1:nel)
+
+    r = 0
+
+    do nodeType = 1,2 ! GAUSS = 1, GAUSS_LOBATTO = 2
+
+      call interp%Init(N=N,controlNodeType=nodeType,M=N,targetNodeType=UNIFORM)
+      call sol%Init(interp,nvar,nel)
+
+      do iel = 1,nel
+        do j = 1,N+1
+          do i = 1,N+1
+            x = interp%controlPoints(i)
+            y = interp%controlPoints(j)
+            sol%interior(i,j,iel,1) = amp(iel)*nlegendre(N,x)*nlegendre(N,y)
+            if(iel == 1) then
+              sol%interior(i,j,iel,2) = background
+            else
+              sol%interior(i,j,iel,2) = 0.0_prec
+            endif
+          enddo
+        enddo
+      enddo
+      call sol%UpdateDevice() ! no-op on CPU; pushes interior to device on GPU
+
+      call amr%Init(interp,nel,refineThreshold,coarsenThreshold)
+
+      ! ---- 1. The shipped default floor ----
+      ! Energy scale 1, so the effective floor is SELF_AMR_DEFAULT_RELFLOOR: element 5 (1e-12) is
+      ! quiescent, element 2 (1e-4) is not. This is the reported bug in miniature - without the
+      ! relative floor element 5 sits ~1e4 above machine epsilon in real64 and is flagged REFINE
+      ! forever.
+      call amr%Estimate(sol,ivar=1)
+      call ReportFlags(amr,nel,nodeType,"default floor")
+      if(amr%flag(5) /= SELF_AMR_COARSEN) then
+        print*,"FAIL: negligible-amplitude element not gated by the default relative floor"
+        r = 1
+      endif
+      if(amr%flag(1) /= SELF_AMR_REFINE .or. amr%flag(2) /= SELF_AMR_REFINE .or. &
+         amr%flag(3) /= SELF_AMR_REFINE) then
+        print*,"FAIL: the default relative floor suppressed a resolvable feature"
+        r = 1
+      endif
+      if(amr%flag(4) /= SELF_AMR_COARSEN) then
+        print*,"FAIL: identically zero element not flagged COARSEN"
+        r = 1
+      endif
+
+      ! ---- 2. An explicit floor gates exactly the elements below it ----
+      call amr%SetRelativeEnergyFloor(testFloor)
+      call amr%Estimate(sol,ivar=1)
+      call ReportFlags(amr,nel,nodeType,"floor = 1e-2")
+      if(amr%flag(1) /= SELF_AMR_REFINE .or. amr%flag(3) /= SELF_AMR_REFINE) then
+        print*,"FAIL: elements above the floor should still be flagged REFINE"
+        r = 1
+      endif
+      if(amr%flag(2) /= SELF_AMR_COARSEN .or. amr%flag(5) /= SELF_AMR_COARSEN) then
+        print*,"FAIL: elements below the floor should be flagged COARSEN"
+        r = 1
+      endif
+      ! Flag tally: elements 1 and 3 refine, 2, 4 and 5 coarsen, none kept.
+      if(amr%CountFlagged(SELF_AMR_REFINE) /= 2 .or. &
+         amr%CountFlagged(SELF_AMR_COARSEN) /= 3 .or. &
+         amr%CountFlagged(SELF_AMR_KEEP) /= 0) then
+        print*,"FAIL: unexpected flag tally under the relative floor"
+        r = 1
+      endif
+
+      ! ---- 3. Disabling the relative floor restores the previous behaviour ----
+      ! Confirms the gate (and not some other change) is what releases element 2: on shape alone
+      ! it is indistinguishable from element 1.
+      call amr%SetRelativeEnergyFloor(0.0_prec)
+      call amr%Estimate(sol,ivar=1)
+      call ReportFlags(amr,nel,nodeType,"floor = 0 (absolute only)")
+      if(amr%flag(2) /= SELF_AMR_REFINE) then
+        print*,"FAIL: with the relative floor disabled, element 2 should be REFINE again"
+        r = 1
+      endif
+
+      ! ---- 4. A pinned energy scale replaces the automatic one ----
+      call amr%SetRelativeEnergyFloor(testFloor)
+      call amr%SetEnergyScale(1.0e6_prec) ! effective floor 1e4, above every element's energy
+      call amr%Estimate(sol,ivar=1)
+      call ReportFlags(amr,nel,nodeType,"pinned scale 1e6")
+      if(amr%CountFlagged(SELF_AMR_COARSEN) /= nel) then
+        print*,"FAIL: a pinned scale above every element energy should gate every element"
+        r = 1
+      endif
+      call amr%ClearEnergyScale()
+      call amr%Estimate(sol,ivar=1)
+      if(amr%flag(3) /= SELF_AMR_REFINE .or. amr%flag(2) /= SELF_AMR_COARSEN) then
+        print*,"FAIL: ClearEnergyScale did not restore the automatic scale"
+        r = 1
+      endif
+
+      ! ---- 5. A caller-supplied gate replaces the weighted-sum gate ----
+      ! Uniform gate energy 1 against a scale of 1: nothing is quiescent.
+      gateOverride = 1.0_prec
+      call amr%Estimate(sol,ivar=1,gate=gateOverride)
+      call ReportFlags(amr,nel,nodeType,"caller gate = 1")
+      if(amr%flag(2) /= SELF_AMR_REFINE) then
+        print*,"FAIL: caller-supplied gate above the floor should not gate element 2"
+        r = 1
+      endif
+      ! A zero gate is quiescent everywhere, whatever the spectra say.
+      gateOverride = 0.0_prec
+      call amr%Estimate(sol,ivar=1,gate=gateOverride)
+      call ReportFlags(amr,nel,nodeType,"caller gate = 0")
+      if(amr%CountFlagged(SELF_AMR_COARSEN) /= nel) then
+        print*,"FAIL: an identically zero caller gate should gate every element"
+        r = 1
+      endif
+
+      ! ---- 6. Per-variable gate weights ----
+      ! Reducing over all variables with unit weights sums energies of different magnitudes, so
+      ! the background field on element 1 (4e4) sets the scale and drags the effective floor up to
+      ! 4e2 - swamping element 3 (0.25), which is a genuine feature.
+      call amr%Estimate(sol,ivar=SELF_AMR_ALLVARS)
+      call ReportFlags(amr,nel,nodeType,"all variables, unit weights")
+      if(amr%flag(3) /= SELF_AMR_COARSEN) then
+        print*,"FAIL: expected the background variable to swamp the unweighted gate"
+        r = 1
+      endif
+      ! Giving the background field zero weight excludes it from the gate (this is what an
+      ! entropy-weighted gate does for the LinearEuler2D background fields) and element 3 is
+      ! judged on its own energy again.
+      call amr%SetEnergyWeights([1.0_prec,0.0_prec])
+      call amr%Estimate(sol,ivar=SELF_AMR_ALLVARS)
+      call ReportFlags(amr,nel,nodeType,"all variables, background weighted out")
+      if(amr%flag(3) /= SELF_AMR_REFINE) then
+        print*,"FAIL: zero-weighting the background field did not restore element 3"
+        r = 1
+      endif
+      if(amr%flag(2) /= SELF_AMR_COARSEN .or. amr%flag(1) /= SELF_AMR_REFINE) then
+        print*,"FAIL: weighted gate disagrees with the single-variable gate"
+        r = 1
+      endif
+
+      ! ---- 7. Host/device sync entry points round-trip (CPU no-ops) ----
+      call amr%UpdateDevice()
+      call amr%Estimate(sol,ivar=1)
+      call amr%UpdateHost()
+      if(amr%flag(1) /= SELF_AMR_REFINE) then
+        print*,"FAIL: flags did not survive an UpdateDevice/UpdateHost round trip"
+        r = 1
+      endif
+
+      call amr%Free()
+      call sol%Free()
+      call interp%Free()
+
+    enddo
+
+    if(r == 0) print*,"REFINEMENT INDICATOR 2D RELATIVE FLOOR CHECKS PASSED"
+
+  endfunction refinement_indicator_2d_relative_floor
+
+  subroutine ReportFlags(amr,nel,nodeType,label)
+    !! Print the per-element indicator, gate energy and flag so a failure is diagnosable from the
+    !! ctest log without a rebuild.
+    use SELF_Constants
+    use SELF_RefinementIndicator_2D
+    implicit none
+    type(RefinementIndicator2D),intent(in) :: amr
+    integer,intent(in) :: nel
+    integer,intent(in) :: nodeType
+    character(*),intent(in) :: label
+    ! Local
+    integer :: k
+
+    print*,"node type ",nodeType," : ",label
+    do k = 1,nel
+      print*,"  element, sigma, gate, flag :",k,amr%indicator(k),amr%gate(k),amr%flag(k)
+    enddo
+
+  endsubroutine ReportFlags
+
+  pure function nlegendre(p,x) result(Lp)
+    !! L2-normalized Legendre polynomial on [-1,1], matching the basis used by the indicator.
+    use SELF_Constants
+    implicit none
+    integer,intent(in) :: p
+    real(prec),intent(in) :: x
+    real(prec) :: Lp
+    integer :: k
+    real(prec) :: lkm1,lk,lkp1
+
+    if(p == 0) then
+      Lp = 1.0_prec
+    elseif(p == 1) then
+      Lp = x
+    else
+      lkm1 = 1.0_prec
+      lk = x
+      do k = 1,p-1
+        lkp1 = (real(2*k+1,prec)*x*lk-real(k,prec)*lkm1)/real(k+1,prec)
+        lkm1 = lk
+        lk = lkp1
+      enddo
+      Lp = lk
+    endif
+    Lp = Lp*sqrt((2.0_prec*real(p,prec)+1.0_prec)/2.0_prec)
+
+  endfunction nlegendre
+
+endprogram test

--- a/test/refinement_indicator_2d_relative_floor.f90
+++ b/test/refinement_indicator_2d_relative_floor.f90
@@ -56,7 +56,12 @@ contains
     !!   element 2 : a = 1e-2   -> E = 1e-4
     !!   element 3 : a = 0.5    -> E = 0.25
     !!   element 4 : a = 0      -> E = 0      (the absolute-floor path)
-    !!   element 5 : a = 1e-6   -> E = 1e-12
+    !!   element 5 : a = 1e-7   -> E = 1e-14
+    !!
+    !! Element 5 sits two orders below the default floor and element 2 eight orders above it, so
+    !! the default case has wide margins in real64. In real32 the default floor is below epsilon
+    !! and the absolute term takes over, which gates element 5 (1e-14 < 1.2e-7) and leaves element
+    !! 2 (1e-4) alone - the same verdicts, so the assertions hold in both precisions.
     !!
     !! Variable 2 is zero everywhere except on element 1, where it is a large constant. It stands
     !! in for a background field (LinearEuler2D carries the sound speed and background density as
@@ -75,7 +80,7 @@ contains
     real(prec),parameter :: refineThreshold = -3.0_prec
     real(prec),parameter :: coarsenThreshold = -8.0_prec
     ! Amplitudes of the identical top-mode shape on each element; the modal energy is the square.
-    real(prec),parameter :: amp(1:nel) = [1.0_prec,1.0e-2_prec,0.5_prec,0.0_prec,1.0e-6_prec]
+    real(prec),parameter :: amp(1:nel) = [1.0_prec,1.0e-2_prec,0.5_prec,0.0_prec,1.0e-7_prec]
     ! A background-field amplitude on variable 2 of element 1, far above every element's
     ! variable-1 energy: 100**2 * 4 = 4e4 against a largest variable-1 energy of 1.
     real(prec),parameter :: background = 100.0_prec
@@ -115,9 +120,9 @@ contains
       call amr%Init(interp,nel,refineThreshold,coarsenThreshold)
 
       ! ---- 1. The shipped default floor ----
-      ! Energy scale 1, so the effective floor is SELF_AMR_DEFAULT_RELFLOOR: element 5 (1e-12) is
+      ! Energy scale 1, so the effective floor is SELF_AMR_DEFAULT_RELFLOOR: element 5 (1e-14) is
       ! quiescent, element 2 (1e-4) is not. This is the reported bug in miniature - without the
-      ! relative floor element 5 sits ~1e4 above machine epsilon in real64 and is flagged REFINE
+      ! relative floor element 5 sits ~1e2 above machine epsilon in real64 and is flagged REFINE
       ! forever.
       call amr%Estimate(sol,ivar=1)
       call ReportFlags(amr,nel,nodeType,"default floor")


### PR DESCRIPTION
Fixes #162.

## The problem

The refinement indicator's smoothness ratio `S_e` is scale-free, but the guard that short-circuits it was an **absolute** threshold at machine epsilon:

```fortran
real(prec),parameter :: energyFloor = epsilon(1.0_prec)
if(etot <= energyFloor) then
  se = 0.0_prec
else
  ...
```

`etot` carries the *square* of the field amplitude, so an element holding a negligible share of the field's energy — low-amplitude grid-scale residue behind a passing wave — still sits many orders of magnitude above epsilon, takes the ratio branch, and is judged purely on the *shape* of its modal spectrum. Those elements read as under-resolved indefinitely, are never flagged `SELF_AMR_COARSEN`, and the refined region grows to the whole area the wave has swept.

Raising `coarsenThreshold` cannot help: in a wake `sigma_e` is near 0, so any threshold high enough to coarsen the wake also stops the front from refining. The gate has to be amplitude-based.

## The fix

Each element now also carries a **gate energy**

```
g_e = sum_v w_v * E_tot,e,v
```

Since `E_tot,e,v` is the exact L2 energy of variable `v` on the reference element, `g_e` is a convex quadratic functional of the state — a *discrete entropy integral* over the element when the weights come from an entropy Hessian — so it is an amplitude measure that stays meaningful across variables of very different magnitude. It is compared against a field-wide scale:

```
g_e <= max(epsilon, relativeEnergyFloor * energyScale)   ->   S_e := 0
```

Defaults, all overridable:

| | default | override |
| --- | --- | --- |
| weights `w_v` | unit weight on the driving variable (all variables under `SELF_AMR_ALLVARS`) | `SetEnergyWeights` |
| `energyScale` | largest gate energy over the elements, `MPI_MAX`-reduced when `Estimate` gets a communicator | `SetEnergyScale` / `ClearEnergyScale` |
| `relativeEnergyFloor` | `1e-12` | `SetRelativeEnergyFloor` |
| the gate itself | the weighted sum above | optional `gate` argument to `Estimate` |

Energy goes as amplitude squared, so the floor is `10**(dB/10)`: the default treats amplitudes below `1e-6` (−120 dB) of the field scale as quiescent.

**On the default — measured, not argued.** I first shipped `1e-8` and it was actively harmful; see the correction comment below for the numbers. An amplitude gate cannot distinguish residue from the low-amplitude *flank* of a genuinely under-resolved feature, so an aggressive floor trades against refinement **depth**. `1e-12` — what the issue proposed — gives 1.40x fewer elements on the ultrasound benchmark with an initial adaptation identical to the ungated run. It sits below `epsilon` in `real32`, leaving the gate inactive there, which is the safe direction.

## Structure

`Estimate` is now two-phase:

1. element-local (device) pass — **unchanged mathematics**, same loop nest and accumulation order — writing the raw ratio and the gate energy;
2. a shared host pass that reduces for the scale, applies the gate, takes the `log10` and sets the flags.

The second phase has to be host-side because the scale is a reduction (an MPI collective when the mesh is decomposed) that no element-local pass can supply. Running it through one routine also makes CPU and GPU flags identical by construction. The device kernel drops the thresholds and returns energies instead; the extra traffic is one per-element array each way, **once per adaptation epoch** — nothing is added to the time-stepping loop.

`AMRController2D%Init` gains optional `relativeEnergyFloor` and `energyWeights`, re-applies them after the per-epoch indicator resize (`Init` is `intent(out)`), and passes the communicator so the scale is global — without that the gate, and hence the adapted mesh, would depend on the decomposition.

## Evidence

`test/lineareuler2d_amr_coarsen_wake` steps an expanding ring outward over a fixed grid-scale residue at `1e-6` of the ring's amplitude, and runs the same sweep twice:

| | final elements | smallest element near the centre / base |
| --- | --- | --- |
| gate enabled | **448** — band follows the ring | **1.00** — wake fully released |
| gate disabled (pre-fix) | **1024** — saturated at the level cap | **0.50** — wake still refined |

The control run is the reported bug reproduced, and it is what gives the assertions teeth.

## Testing

- `refinement_indicator_2d_relative_floor` — five elements carrying the *same* grid-scale shape at different amplitudes, so their flags can differ only through the gate; plus the pinned scale, the caller-supplied gate, and per-variable weights excluding a large background field. Both node types.
- `lineareuler2d_amr_coarsen_wake` — above; runs in ~1 s.
- Three guard tests for the new setters (registered `WILL_FAIL`).
- Existing AMR/indicator tests pass unchanged, including `lineareuler2d_amr_soundwave`, its MPI twin, and the ultrasound example. `refinement_indicator_2d_spectraldecay` is unaffected because its constant-field element puts `etot = 25` and sets the scale, leaving every other element six or more orders above the gate.

**CI status:** all checks green, including Buildkite — which covers the GPU path I could not compile locally (no CUDA/HIP toolchain), so the kernel signature change, the new `gate`/`energyWeight` device buffers and the weights upload are exercised there. `codecov/patch` at 97.93%. Locally, every test that can run in my environment passes; the 22 that fail all abort at `HDF5 file open` on `/share/mesh/...`, which does not exist on this host, and fail identically without this change.

### Measured on the driver from #162

Ultrasound point source, 30 epochs, `maxLevel = 2`:

| `relativeEnergyFloor` | initial adaptation | mean elements | final |
| --- | --- | --- | --- |
| 0 (no gate ≡ pre-fix) | 328, level 2 | 1482 | 1732 |
| **1e-12 (default)** | **328, level 2** | **1057 — 1.40x fewer** | **1528** |
| 1e-8 | 268, level **1** | 2210 | 3304 |
