### PR TITLE
3-D AMR: apply the solution transfer on the device (10-15% off an adaptation)

### DIFF
--- a/docs/Contributing/AMR2D-Design.md
+++ b/docs/Contributing/AMR2D-Design.md
@@ -244,8 +244,10 @@ tree level per cycle.
 
 A `MeshTransfer2D` object encapsulates old→new leaf correspondence; it is
 built on the host during adaptation and applied as batched tensor-product
-operations (host first; device application is a Phase-5 optimization, and the
-operator matrices are already resident on the GPU).
+operations. Host application landed first; device application was the deferred
+Phase-5 optimization and **has since shipped as Stage 6a** (`TransferSolution_2D_gpu`,
+with the 3D analogue `TransferSolution_3D_gpu`), using the operator matrices that
+were already resident on the GPU. The plan itself is still built on the host.
 
 **Numerical-correctness note (CLAUDE.md §3):** transfer is an
 approximation-theoretic operation (interpolation/L2 projection), not a change
@@ -346,8 +348,9 @@ Runs on device:
 - All existing solver machinery on the adapted mesh (RHS, conforming and
   mortar exchanges, RK updates) — unchanged; this is already exercised by the
   mortar GPU tests.
-- Solution transfer apply (Phase 5): batched tensor-product kernels using the
-  device-resident `mortarR_gpu`/`mortarP_gpu`.
+- Solution transfer apply (**implemented**, Stage 6a; was deferred as "Phase 5"):
+  batched tensor-product kernels using the device-resident `mortarR_gpu`/`mortarP_gpu`,
+  so a single-GPU adapting run moves no solution data across the host link.
 
 Runs on host:
 - Tree updates, flag balancing, leaf emission, corner hashing,
@@ -355,9 +358,13 @@ Runs on host:
 
 **Memory churn:** each adaptation frees and re-allocates every field's device
 mirrors plus the lazily-built exchange buffers (existing `Init`/`Free`/
-`UpdateDevice` machinery). v1 accepts this (adaptation is infrequent). Phase-5
-optimization: capacity-based allocation (`nElemCapacity = growthFactor*nElem`)
-inside the data-object `Init`s so most adaptations skip reallocation.
+`UpdateDevice` machinery). v1 accepted this (adaptation is infrequent). The
+deferred "Phase 5" optimization — capacity-based allocation so most adaptations
+skip reallocation — **has since shipped as Stage 6b**, as amortized
+high-water-mark storage with pointer remapping (`src/SELF_DataPool.f90`).
+Profiling contradicted the expectation recorded here: the free/re-initialize
+cycle was the single largest component of an adaptation, not a minor one. See
+the Learning page's Stage 6 section for the measurements.
 
 One environment constraint to respect (and a reason to land issue #151
 first if convenient): device selection currently happens in the mesh's

--- a/docs/Contributing/AMR3D-Design.md
+++ b/docs/Contributing/AMR3D-Design.md
@@ -1,6 +1,11 @@
 # Design: Adaptive Mesh Refinement (AMR) for 3D Models — Octrees + Face Mortars
 
-**Status:** Implementation plan — mirrors the implemented 2D design.
+**Status:** Implemented (Stages 1–6a) — mirrors the implemented 2D design.
+Stages 1–5 landed with #164; the device-resident solution transfer (Stage 6a's
+3D analogue) landed with #165. What is still outstanding from §6 is noted in
+that table. Sections written in the future tense below have been updated where
+the delivered code differs from the plan; where it does not, the plan text is
+the record of what was built.
 **Scope:** 3D hexahedral meshes, octree (2:1) h-refinement built on new 3D
 2:1 face-mortar interface support, spectral (Legendre modal) refinement
 indicator, CPU and GPU backends, MPI-parallel. Pilot model: `LinearEuler3D`.
@@ -163,11 +168,54 @@ guards `MaxLevelJump() <= 1` as in 2D.
 
 ### 2.8 Solution transfer
 
-Prolongation: `U_child = (R_kx ⊗ R_ky ⊗ R_kz) U_parent` (exact),
+**Operators.** Prolongation: `U_child = (R_kx ⊗ R_ky ⊗ R_kz) U_parent` (exact),
 `(kx,ky,kz) = (axc(c)+1, ayc(c)+1, azc(c)+1)`. Restriction:
 `U_parent = Σ_c (P_kx ⊗ P_ky ⊗ P_kz) U_child(c)` — conservative, and
 `Restrict(Prolong(u)) = u` to roundoff via `Σ_k P_k R_k = I` per direction.
-Reference-cell conservation: `Σ w³ u_parent = (1/8) Σ_c Σ w³ u_child`.
+Reference-cell conservation: `Σ w³ u_parent = (1/8) Σ_c Σ w³ u_child`. Each 1D
+`P_k` carries the half-interval Jacobian, so the triple product carries 1/8.
+Implemented in `SELF_SolutionTransfer_3D.f90` as three sequential directional
+contractions; the loop order there is normative, since CLAUDE.md forbids
+reordering floating-point reductions.
+
+**Epoch protocol.** The plan (`SELF_TransferPlan_3D`) is built on the host after
+the last forest mutation and classifies every new leaf as `COPY`, `PROLONG` or
+`RESTRICT`, plus a `depth` and an octant `path` for any further descent. It is
+applied around the regrid as a three-step, type-bound protocol on the model, so
+the backend split that already selects `Regrid` selects the transfer too:
+
+```fortran
+call model%StageSolutionForTransfer()   ! preserve the field; Regrid may then free it
+call model%Regrid(newMesh,newGeom)
+call model%ApplyTransferPlan(plan,interp,eFirst,eLast)
+```
+
+`StageSolutionForTransfer` exists because `Regrid` reallocates (or resizes) the
+storage the solution lives in, so the pre-regrid field must be preserved first.
+The portable implementation stages into `DGModel3D_t%transferStage`, a host
+array whose lifetime is exactly stage-to-apply — it is allocated by the first
+call, consumed and deallocated by the second, and released in `Free`. Calling
+`ApplyTransferPlan` without a preceding stage is a hard error (`stop 1`), pinned
+by `test/dgmodel3d_guard_transfer_unstaged.f90`, because the alternative is
+reading unallocated storage and failing somewhere less obvious.
+
+`ApplyTransferPlan` takes an optional `uGlobal` argument: the **multi-rank
+escape hatch**. The forest is rank-replicated and migration is gather-then-slice
+(2D Stage-5 v1), so on more than one rank the controller allgathers the old
+field on the host and passes it through `uGlobal`; each rank then fills exactly
+its own new contiguous element range and elements that changed ranks are
+migrated by construction. Because the allgather is inherently a host operation,
+that branch stays on the portable host transfer on every backend.
+
+**Device path.** On a single-rank GPU build both steps are overridden
+(`src/gpu/SELF_DGModel3D.f90`): staging is a device-to-device copy into a
+model-owned buffer, and the plan is applied by `TransferSolution_3D_gpu`, so an
+adapting run moves no solution data across the host link at all. Consequence
+worth knowing: the transferred solution is then left on the device and
+`solution%interior` (the host mirror) is **stale** after `Adapt`. That matches
+the rest of the time loop, where the device is authoritative, but it is a
+behaviour change from the host-only implementation, where the mirror happened to
+be fresh. See §4 for the kernel, and the Learning page for the measurements.
 
 ### 2.9 Indicator
 
@@ -215,13 +263,39 @@ its 2D counterpart.
 ## 4. GPU strategy
 
 Same division of labor as 2D: numerics on device, adaptation logic on host.
-New kernels in the existing files' pattern: 3D mortar gather/scatter and
-flux-scatter kernels (in `SELF_Mortar.cpp`), a 3D indicator kernel (one
-thread per element, `AMR3D_MAXNP` bound), and a 3D transfer kernel. The 2D
-transfer kernel's one-block-per-element with `Np²` threads becomes
-one-block-per-element with `Np²` threads looping over the k-slab (a `Np³`
-thread block with three shared `Np³` buffers would exceed practical shared
-memory at N=7/fp64).
+Kernels follow the existing files' pattern: 3D mortar gather/scatter and
+flux-scatter kernels (`SELF_Mortar.cpp`), a 3D indicator kernel
+(`SELF_Refinement.cpp`, `AMR3D_MAXNP` bound), and the 3D transfer kernel
+(`SELF_SolutionTransfer.cpp`). All are implemented.
+
+The transfer kernel is `TransferSolution_3D_gpu`. As planned, the 2D kernel's
+one-block-per-element with `Np²` threads and one thread per node becomes
+one-block-per-element with `Np²` threads where thread `(a,b)` owns one `(a,b)`
+pencil and loops the free index through each of the three directional passes — the
+same decomposition `RefinementIndicator_3D_gpukernel` uses. A `Np³` thread block
+is not an option: it is 4096 threads at N=15, past the block limit, and it would
+push the working buffers into per-thread scratch.
+
+Three `Np³` `__shared__` buffers do fit, at a bound: `AMR3D_MAXNP` is 12, giving
+3·12³·8 B = 41,472 B, inside both the 48 KB CUDA static shared-memory limit and
+the 64 KB gfx90a/gfx942 LDS budget. The allocation is static, so it is 41,472 B
+at every degree, not `(N+1)³`; a dynamic-shared variant sized to the degree in
+use measured 1-3% slower on a B300 and was not adopted (see the Learning page's
+§6.4). The Fortran caller guards `interp%N+1 <= 12` so a larger degree fails
+loudly rather than overrunning.
+
+One deliberate divergence from the host reference, inherited from 2D: the host
+descent calls `ProlongToChildren`, which forms all eight children and discards
+seven, whereas the kernel applies only the operator triple of the child actually
+on the recorded path — an eighth of the work per descent step. What is dropped is
+the seven discarded children, not any part of the retained value: each contraction
+sums the same terms against the same mortar column in the same ascending index
+order as the host loop, so the reduction order CLAUDE.md protects is preserved.
+Device and host nonetheless agree only to round-off rather than bitwise, because
+the device compiler contracts these multiply-accumulates into FMAs.
+`test/solution_transfer_3d_device.f90` pins the kernel's output against the host
+reference value by value; the AMR regressions assert the invariants (conservation,
+entropy non-growth), which conservation arguments make exact either way.
 
 ---
 
@@ -269,6 +343,18 @@ CPU/GPU flag and post-adapt solution agreement enforced by construction
 | 4 | `lineareuler3d_amr_soundwave` (+ coarsen-wake) integration tests, example | #156/#162 |
 | 5 | MPI: forest-from-decomposed-mesh, flag allgather, gather-then-slice migration, 2-rank tests | Stage 5 |
 | 6 | GPU: mortar/indicator/transfer kernels, device staging, geometry upload paths | Stage 6 |
+
+Delivery status: stages 1–3 and 5 landed with #164, together with the
+`lineareuler3d_amr_soundwave` serial and 2-rank integration tests of stage 4.
+Stage 6's mortar and indicator kernels landed with #164; the device-resident
+solution transfer and its staging landed with #165 (`TransferSolution_3D_gpu`,
+`StageSolutionForTransfer_DGModel3D`, `ApplyTransferPlan_DGModel3D`), which also
+delivered stage 4's example, `linear_euler3d_amr_spherical_soundwave`.
+
+Still outstanding: the 3D `coarsen-wake` regression (the analogue of
+`lineareuler2d_amr_coarsen_wake`), and the 3D analogues of 2D Stages 6b/6c
+(amortized high-water-mark storage and geometry reuse) to the extent they are
+not already inherited from the shared data classes.
 
 Stages are landed as separate reviewable commits on one PR (or stacked PRs
 at maintainer preference), each leaving the suite green.

--- a/docs/Learning/AdaptiveMeshRefinement.md
+++ b/docs/Learning/AdaptiveMeshRefinement.md
@@ -1,10 +1,12 @@
 # Adaptive Mesh Refinement (AMR)
 
-This page describes SELF's approach to adaptive mesh refinement for 2-D discontinuous
-Galerkin spectral element models. It documents the **refinement trigger** that is
-implemented today and lays out a **staged design** for the remaining mesh-adaptation
-machinery so that the invasive parts (dynamic mesh mutation, solution transfer, MPI
-re-partitioning, and GPU re-allocation) can be reviewed and landed incrementally.
+This page describes SELF's approach to adaptive mesh refinement for discontinuous Galerkin
+spectral element models. Sections 1-5 document the **2-D** implementation, which came first: the
+refinement trigger, and the staged design along which the invasive parts (dynamic mesh mutation,
+solution transfer, MPI re-partitioning, and GPU re-allocation) were reviewed and landed.
+[Section 6](#6-three-dimensional-amr-octrees-face-mortars) covers the **3-D** stack - octrees and
+2:1 face mortars - which is a deliberate transcription of the 2-D one and records only what
+differs.
 
 AMR in SELF builds directly on the 2:1 nonconforming (mortar) interface support
 (see [Nonconforming (Mortar) Interfaces](../Models/nonconforming-mortar-interfaces.md)).
@@ -913,7 +915,180 @@ band tracking the expanding wavefront.
 
 ---
 
-## 6. References
+## 6. Three-dimensional AMR (octrees + face mortars)
+
+Everything above describes the 2-D implementation, which came first and remains the more
+thoroughly exercised of the two. The 3-D stack is a deliberate transcription of it - octrees in
+place of quadtrees, 2:1 **face** mortars in place of edge mortars, eight children in place of four
+- and is implemented and validated end to end. This section records what is the same, what is
+genuinely different, and what is not done yet.
+
+The design record is [AMR (3D) Design](../Contributing/AMR3D-Design.md); it is a delta document,
+and where a 3-D module is a mechanical transcription the 2-D design remains the authoritative
+rationale.
+
+### 6.1 Status
+
+| Component | 2-D | 3-D |
+| --- | --- | --- |
+| Modal-decay indicator (CPU + GPU) | Implemented | Implemented (`SELF_RefinementIndicator_3D`) |
+| `h`-refinement primitives, uniform refinement | Implemented | Implemented (`SELF_RefinementPrimitives_3D`) |
+| Adaptive forest, level tracking, 2:1 balancing | Quadtree | Octree (`SELF_OctreeMesh_3D`) |
+| Nonconforming mesh emission | Implemented | Implemented (face mortars) |
+| Transfer plan + solution transfer | Implemented | Implemented (`SELF_TransferPlan_3D`) |
+| Model regrid + AMR controller | Implemented | Implemented (`SELF_AMRController_3D`) |
+| MPI re-partitioning (replicated forest, allgathered migration) | Implemented (v1) | Implemented (v1) |
+| Device-side solution transfer | Implemented (Stage 6a) | **Implemented** (§6.4) |
+| Amortized high-water-mark storage | Implemented (Stage 6b) | Inherited via the shared data classes |
+| Geometry reuse across an epoch | Implemented (Stage 6c) | Implemented (`SELF_AMR_GEOM_*` switches) |
+| Example | ultrasound point source | `linear_euler3d_amr_spherical_soundwave` |
+| Coarsen-wake regression | Implemented | **Not yet** |
+
+The pilot model is `LinearEuler3D`. Note it carries `nvar = 6`: `u, v, w, P` are advanced in
+time, while `c` and `rho0` are spatially varying but time-constant background fields. They are
+still solution variables, so the transfer must carry all six - a transfer that moved only the
+prognostic variables would silently blank the medium on every newly created element.
+
+### 6.2 What is genuinely different from 2-D
+
+- **Eight children, not four.** `transferAxc/Ayc/Azc(1:8)` map an octant to its
+  `(x,y,z)` half, in CGNS corner order: children 1-4 walk the x/y quadrants of the lower-z layer,
+  5-8 the same quadrants of the upper-z layer.
+- **Triple tensor products.** Prolongation is
+  `U_child = (R_kx ⊗ R_ky ⊗ R_kz) U_parent`; restriction is
+  `U_parent = Σ_c (P_kx ⊗ P_ky ⊗ P_kz) U_child(c)`. Each 1-D `P_k` carries the half-interval
+  Jacobian, so the triple product carries **1/8** rather than 1/4, which is what makes the 3-D
+  restriction conservative. The identities are the same: `Restrict(Prolong(u)) = u`, and
+  `Σ w³ u_parent = (1/8) Σ_c Σ w³ u_child`.
+- **Cost scales far more steeply.** A level of refinement multiplies the element count by 8
+  rather than 4, and each element carries `(N+1)³` nodes rather than `(N+1)²`. Adaptation is
+  therefore a much larger share of a 3-D epoch than of a 2-D one at comparable settings: in the
+  maxLevel-3 case measured in §6.4, adaptation is 89% of the epoch loop before this change and 88%
+  after, against roughly 50% for the 2-D ultrasound case.
+- **Balancing is face-based.** The forest balances across faces and tolerates 2-level edge and
+  corner jumps, because DG face mortars carry all interface data and hanging edges/corners carry
+  none. `EmitMesh` guards `MaxLevelJump() <= 1`.
+
+### 6.3 The transfer protocol and where the solution lives
+
+The plan (`SELF_TransferPlan_3D`) is built on the host after the last forest mutation, and
+classifies every new leaf as `COPY`, `PROLONG` or `RESTRICT`, with a `depth` and an octant `path`
+for any further descent. It is applied around the regrid as a three-step, type-bound protocol on
+the model, so the backend split that already selects `Regrid` selects the transfer too:
+
+```fortran
+call model%StageSolutionForTransfer()   ! preserve the field; Regrid may then free it
+call model%Regrid(newMesh,newGeom)
+call model%ApplyTransferPlan(plan,interp,eFirst,eLast)
+```
+
+Staging exists because `Regrid` reallocates (or resizes) the storage the solution lives in. The
+portable implementation stages into a host array whose lifetime is exactly stage-to-apply;
+applying without a preceding stage is a hard error, pinned by
+`test/dgmodel3d_guard_transfer_unstaged.f90`.
+
+`ApplyTransferPlan` takes an optional `uGlobal`, the **multi-rank escape hatch**. The forest is
+rank-replicated and migration is gather-then-slice, so on more than one rank the controller
+allgathers the old field on the host and passes it through `uGlobal`; each rank then fills exactly
+its own new element range and elements that changed ranks are migrated by construction. That
+allgather is inherently a host operation, so the multi-rank branch stays on the portable host
+transfer on every backend, exactly as in 2-D.
+
+**Where the solution lives after `Adapt`.** On a single-rank GPU build the transferred solution is
+left on the **device**, so `solution%interior` (the host mirror) is **stale**. This matches the
+rest of the time loop, where the device is authoritative and a caller wanting host data calls
+`UpdateHost()` first, as `Write_DGModel3D_t` does. Before the device transfer existed the mirror
+happened to be fresh; do not rely on that. On CPU builds the two are the same storage.
+
+### 6.4 Device-side transfer (implemented)
+
+Until this landed, a single-rank GPU adaptation epoch moved the entire solution across the host
+link twice - `UpdateHost` before the regrid, `UpdateDevice` after - and ran the triple
+tensor-product interpolation on the CPU in between. Both steps are now overridden on the GPU
+backend: staging is a device-to-device copy into a model-owned buffer, and the plan is applied by
+`TransferSolution_3D_gpu` (`src/gpu/SELF_SolutionTransfer.cpp`).
+
+**Kernel.** One workgroup per new element with `(N+1)²` threads, where thread `(a,b)` owns one
+`(a,b)` pencil and loops the free index through each of the three directional passes - the same
+decomposition the 3-D modal indicator uses. An `(N+1)³` thread block is not an option: it is 4096
+threads at `N = 15`, past the block limit, and it would push the working buffers into per-thread
+scratch. The three `(N+1)³` working buffers are static `__shared__` arrays sized `AMR3D_MAXNP³`
+with `AMR3D_MAXNP = 12`, i.e. 41 kB reserved per block at any degree; the Fortran caller guards
+`N+1 <= 12` so a larger degree fails loudly rather than overrunning.
+
+A dynamic-shared variant sized to the degree actually in use (12 kB at `N = 7`, the idiom
+`SELF_MatrixMultiply.cpp` uses) was implemented and measured, and was **1-3% slower** on a B300
+across three runs at two refinement depths - the SM shared budget there is large enough that 41 kB
+per block does not gate occupancy, so the launch-time sizing was pure overhead. It was therefore
+not adopted. The argument for it has not gone away on a 64 kB-LDS AMD device, where the static
+footprint admits one workgroup per CU rather than five; that case has not been measured, and since
+the alternative on every platform is the host round trip this kernel replaces, the static form
+cannot regress anything as it stands.
+
+**One deliberate divergence from the host.** The host descent calls `ProlongToChildren`, which
+forms all eight children and discards seven; the kernel applies only the operator triple of the
+child actually on the recorded path - an eighth of the work per descent step. What is dropped is
+the seven discarded children, which are independent computations writing disjoint slices, and not
+any term of the retained value: each contraction sums the same products against the same mortar
+column in the same ascending index order as the host loop, so the reduction order is preserved.
+Device and host nonetheless agree to round-off rather than bitwise, because the device compiler
+contracts these multiply-accumulates into FMAs.
+
+`test/solution_transfer_3d_device.f90` pins the result value by value against the portable
+`ApplyTransferPlanRange`, on an epoch built to contain all three transfer kinds and prolongation
+depths 0-2, with a non-polynomial field that differs in every variable. That is the check the AMR
+regressions cannot make: conservation and entropy non-growth are invariants a kernel with a
+transposed direction could still satisfy.
+
+**Measurements.** One B300 (sm_103, CUDA 13, fp64), `linear_euler3d_amr_spherical_soundwave`,
+20 epochs, mean of three runs, before and after differing **only** in the three files that
+implement the transfer. `tAdapt` is reported per adapting epoch, because epochs whose leaf set is
+unchanged cost only an indicator pass and mixing the two makes the metric depend on how many
+epochs happened to adapt:
+
+| maxLevel | elements | adapting epochs | before | after | |
+| --- | --- | --- | --- | --- | --- |
+| 1 | 512 | 1 | 119.5 ms | **101.6 ms** | -15.0% |
+| 2 | 4,096 | 10 | 571.6 ms | **516.3 ms** | -9.7% |
+| 3 | 20,784 | 20 | 2182.6 ms | **1959.6 ms** | -10.2% |
+
+Time integration is unchanged, as it must be - nothing on this path runs inside `ForwardStep`.
+`tForwardStep` over the same runs was 0.672 -> 0.615 s, 2.152 -> 2.116 s and 5.199 -> 5.176 s,
+all inside the run-to-run spread (which is under 1% on `tAdapt`).
+
+**Where the saving actually comes from, which is not where you would guess.** It is tempting to
+credit the two eliminated full-field host/device copies, and the 2-D Stage 6a note above leads
+with them. Do the arithmetic for the maxLevel-3 case: 20,784 elements x 125 nodes x 6 variables x
+8 B is a 125 MB field, so the round trip is 250 MB, which at PCIe Gen5 rates is roughly 5 ms -
+**0.2%** of a 2183 ms adaptation. The copies are not the story at this scale.
+
+The 223 ms actually saved is the **host-side interpolation**: the portable
+`ApplyTransferPlanRange` runs the triple tensor-product contractions on one CPU core for every
+new element, and that work moves onto the GPU. The kernel also does an eighth of the descent work
+the host does, because it prolongs onto the child on the recorded path instead of forming all
+eight and discarding seven. Both effects scale with element count, which is why the saving holds
+at roughly 10% of adaptation across a 40x range in mesh size while the copy time would have
+faded to nothing.
+
+The remaining ~90% of an adaptation is geometry generation, regrid and the indicator - untouched
+by this change, and where the next 3-D optimization work belongs.
+
+### 6.5 What is not done in 3-D
+
+- **A coarsening regression.** 2-D has `lineareuler2d_amr_coarsen_wake`, which pins the amplitude
+  gate's ability to release the mesh behind a passing front (§2.1.1). There is no 3-D analogue, so
+  3-D coarsening is exercised only incidentally, by the soundwave regression and by the transfer
+  tests' hand-built epochs.
+- **Point-to-point migration (Stage-5 v2).** Multi-rank runs still allgather the old field on the
+  host. Until that changes, the device transfer cannot be used on more than one rank, because the
+  migration it would have to feed from is a host operation.
+- **A 3-D visualization script.** 2-D ships `examples/linear_euler2d_amr_plot.py`. The 3-D
+  example writes the same self-describing HDF5 snapshots (solution + geometry per file, so the
+  changing mesh needs no special handling downstream) but no renderer is provided.
+
+---
+
+## 7. References
 
 - P.-O. Persson and J. Peraire, *Sub-cell shock capturing for discontinuous Galerkin methods*,
   AIAA 2006-112 (2006).

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -77,6 +77,7 @@ add_fortran_tests (
   "linear_shallow_water2d_planetaryrossby_wave.f90"
   "linear_shallow_water2d_kelvinwaves.f90"
   "linear_euler3d_spherical_soundwave_radiation.f90"
+  "linear_euler3d_amr_spherical_soundwave.f90"
   "esatmo3d_thermal_bubble.f90"
   "esatmo3d_abc_flow.f90"
   "esatmo2d_thermal_bubble.f90"

--- a/examples/linear_euler3d_amr_spherical_soundwave.f90
+++ b/examples/linear_euler3d_amr_spherical_soundwave.f90
@@ -1,0 +1,394 @@
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+!
+! Maintainers : support@fluidnumerics.com
+! Official Repository : https://github.com/FluidNumerics/self/
+!
+! Copyright © 2024 Fluid Numerics LLC
+!
+! Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+!
+! 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+!    the documentation and/or other materials provided with the distribution.
+!
+! 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+!    this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+! HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+! LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+! THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+! THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+!
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+
+program LinearEuler3D_AMR_SphericalSoundWave
+!! A spherical acoustic pulse in water propagating through a 1 m^3 domain on a dynamically
+!! adapting (octree / face-mortar) mesh - the demonstration problem for 3-D AMR with the linear
+!! Euler model, and the benchmark vehicle for the 3-D adaptation cost.
+!!
+!! It is the 3-D counterpart of linear_euler2d_amr_ultrasound_pointsource, and deliberately
+!! keeps that example's structure, environment overrides and BENCH_ reporting so the two are
+!! directly comparable. The physics differ only in dimension.
+!!
+!! Physical configuration
+!! ----------------------
+!! Water at rest: sound speed c0 = 1500 m/s, background density rho0 = 1000 kg/m^3. A Gaussian
+!! pressure pulse of half-width Lr is released at the domain centre and radiates as a spherical
+!! shell whose width is ~4*Lr, i.e. a dominant wavelength lambda = 4*Lr and dominant frequency
+!! f0 = c0/lambda. All six domain boundaries carry impedance-matched radiation (non-reflecting
+!! outflow) conditions.
+!!
+!! Discretization and adaptivity
+!! -----------------------------
+!! The base mesh is 4 x 4 x 4 elements (h0 = 250 mm) with degree N = 4. At the default depth the
+!! base mesh is marginal rather than hopeless for the pulse (10 points per wavelength once
+!! refined, 5 at level 0); raising maxLevel halves Lr with it, so the case becomes progressively
+!! more under-resolved at level 0 and the refined band correspondingly more localized. The AMR
+!! controller is driven by the Legendre modal-decay indicator on the pressure field (variable 4
+!! in 3-D), with a one-element refine-flag halo. The time step follows the level-based bound
+!! dtBase / 2**MaxLevel per epoch.
+!!
+!! The base mesh is smaller and the degree lower than in the 2-D example on purpose: a level of
+!! refinement multiplies the element count by 8 in 3-D rather than 4, and every element carries
+!! (N+1)^3 nodes rather than (N+1)^2, so an equivalently-sized 3-D case is roughly two orders of
+!! magnitude more work. The defaults are sized to run in a few seconds at -O3 so the example
+!! stays inside the CI budget (examples run in the 90-minute coverage jobs); refinement depth is
+!! the knob for benchmarking, via SELF_AMR_LE3D_MAXLEVEL.
+!!
+!! Environment overrides (all optional; the defaults are the CI-sized configuration):
+!!
+!!   SELF_AMR_LE3D_EPOCHS    number of adaptation epochs (default 2).
+!!   SELF_AMR_LE3D_MAXLEVEL  refinement-level cap (default 1). Lr and epochLength track it
+!!                           automatically, so this alone selects the frequency band, and it is
+!!                           the knob for a depth sweep.
+!!   SELF_AMR_LE3D_LR        source half-width in m, overriding the maxLevel-derived value;
+!!                           f0 = c0/(4*Lr).
+!!   SELF_AMR_LE3D_EPOCHLEN  adaptation cadence in s, overriding stepsPerEpoch * dt.
+!!   SELF_AMR_LE3D_RELFLOOR  relative energy floor of the indicator's amplitude gate
+!!                           (default SELF_AMR_DEFAULT_RELFLOOR); 0 disables the gate.
+!!   SELF_AMR_LE3D_SIGNIFFLOOR  upper edge of the gate's hysteresis band (default: the floor
+!!                           itself, i.e. a single hard cut).
+!!
+!! The run prints a CONFIG_* block (resolved resolution, f0, points per wavelength) and a BENCH_*
+!! block splitting epoch wall time between time integration and adaptation, so a sweep over
+!! maxLevel is interpretable and machine-parseable. Epochs in which the leaf set does not change
+!! cost only an indicator pass, so the adaptation bucket is reported both in total and per
+!! ADAPTING epoch (BENCH_nAdaptEpochs, BENCH_tAdaptPerAdaptation_s): the per-adaptation figure is
+!! the one to compare between builds, because the number of adapting epochs is not guaranteed
+!! identical across backends. BENCH_elemTransferred is its denominator - the elements the
+!! transfer actually produced, summed over adapting epochs.
+!!
+!! Snapshots are written to the working directory as self-describing HDF5 (solution + geometry
+!! per file), one per epoch plus the initial condition. Because every snapshot carries its own
+!! geometry, the changing mesh needs no special handling downstream.
+!!
+!! The run doubles as an integration check: it verifies that refinement occurred, that the
+!! acoustic energy stays finite and non-increasing (upwind flux + radiation boundaries are
+!! dissipative; the solution transfer is conservative), and that the solution is NaN-free.
+
+  use iso_fortran_env,only:int64,real64,output_unit
+  use self_data
+  use self_lineareuler3d
+  use self_mesh_3d
+  use SELF_Geometry_3D
+  use SELF_AMRController_3D
+
+  implicit none
+
+  character(SELF_INTEGRATOR_LENGTH),parameter :: integrator = 'rk3'
+  integer,parameter :: controlDegree = 4
+  integer,parameter :: targetDegree = 4
+  integer,parameter :: defaultMaxLevel = 1
+  real(prec),parameter :: Lx = 1.0_prec ! domain extent (m)
+  integer,parameter :: nElemX = 4 ! base-mesh elements per direction
+  real(prec),parameter :: c0 = 1500.0_prec ! sound speed in water (m/s)
+  real(prec),parameter :: rho0 = 1000.0_prec ! background density (kg/m^3)
+  real(prec),parameter :: defaultLr = 6.25e-2_prec ! pulse half-width (m) at defaultMaxLevel
+  real(prec),parameter :: rhoprime = 1.0e-4_prec ! density-anomaly amplitude (kg/m^3)
+  real(prec),parameter :: dtBase = 4.0e-6_prec ! stable on the level-0 mesh (s)
+  ! Timesteps per adaptation epoch. Because dt = dtBase/2**maxLevel and hFinest = h0/2**maxLevel
+  ! scale together, the wavefront crosses one finest-level element in hFinest/(c0*dt) = 42 steps
+  ! at any depth. The cadence is set to 0.6 of that, so nHalo = 1 still holds the front inside
+  ! the refined band across an epoch that happens not to adapt - the 2-D example buys the same
+  ! margin with nHalo = 2 instead, which is far more expensive in 3-D (26 face/edge/corner
+  ! neighbours per element rather than 8). epochLength is derived from this rather than fixed, so
+  ! it tracks maxLevel automatically.
+  integer,parameter :: stepsPerEpoch = 25
+  ! CI-sized default. Two epochs still exercise the full loop: initial static refinement to the
+  ! level cap, two dynamic adaptations, and the entropy/NaN checks.
+  integer,parameter :: defaultEpochs = 2
+  ! Slack on the entropy non-growth check. The dissipation argument is exact in exact arithmetic,
+  ! so the tolerance is pure round-off accumulation over the run; single precision needs far more
+  ! of it. Same idiom (and same values) as test/lineareuler3d_amr_soundwave.f90.
+#ifdef DOUBLE_PRECISION
+  real(prec),parameter :: entropyTol = 1.0e-10_prec
+#else
+  real(prec),parameter :: entropyTol = 1.0e-3_prec
+#endif
+
+  type(LinearEuler3D) :: modelobj
+  type(Lagrange),target :: interp
+  type(Mesh3D),target :: mesh
+  type(SEMHex),target :: geometry
+  type(AMRController3D) :: controller
+  integer :: bcids(1:6)
+  integer :: nEpochs,epoch,i,envstat
+  integer :: nAdaptEpochs
+  integer(int64) :: nElemTransferred
+  integer :: maxLevel
+  logical :: adapted
+  real(prec) :: e0,ef,dt
+  real(prec) :: Lr,LrRamp,epochLength,hFinest,lambda,f0,ppw
+  real(prec) :: relativeEnergyFloor,significantEnergyFloor
+  character(32) :: envstr
+  ! Wall-clock instrumentation of the epoch loop. system_clock with an integer(int64) count is a
+  ! monotonic wall clock; ForwardStep's own TIMER macro (src/SELF_Macros.h) expands to cpu_time
+  ! in non-multithreaded builds and so cannot be used for GPU timing.
+  integer(int64) :: c0clk,c1clk,c2clk,crate
+  integer(int64) :: nStepsTotal
+  real(real64) :: tFwd,tAdapt,tSim
+
+  ! Number of adaptation epochs: CI-sized by default, override for a benchmark sweep.
+  nEpochs = defaultEpochs
+  call get_environment_variable("SELF_AMR_LE3D_EPOCHS",envstr,status=envstat)
+  if(envstat == 0) then
+    read(envstr,*) nEpochs
+  endif
+
+  ! ---- Refinement depth and the quantities that must track it ----
+  ! The base mesh spacing is Lx/nElemX = 250 mm and each level halves it, so the finest spacing
+  ! is 250 mm / 2**maxLevel.
+  !
+  ! Two other quantities must move with maxLevel, or extra depth buys nothing:
+  !
+  !   Lr  - the source half-width sets the dominant frequency, f0 = c0/(4 Lr). Holding Lr fixed
+  !         while raising maxLevel just refines the same pulse until it is resolved and then
+  !         stops, so Lr is halved per level. This holds points-per-wavelength constant and
+  !         raises f0 geometrically with depth.
+  !
+  !   epochLength - dt = dtBase/2**maxLevel, so a fixed epochLength would put 2**k times more
+  !         timesteps in an epoch and the wavefront would leave the refined patch mid-epoch. It
+  !         is therefore derived as stepsPerEpoch * dt.
+  !
+  ! At maxLevel = defaultMaxLevel both reduce to the documented default constants.
+  maxLevel = defaultMaxLevel
+  call get_environment_variable("SELF_AMR_LE3D_MAXLEVEL",envstr,status=envstat)
+  if(envstat == 0) then
+    read(envstr,*) maxLevel
+  endif
+
+  Lr = defaultLr*2.0_prec**(defaultMaxLevel-maxLevel)
+  call get_environment_variable("SELF_AMR_LE3D_LR",envstr,status=envstat)
+  if(envstat == 0) then
+    read(envstr,*) Lr
+  endif
+
+  epochLength = real(stepsPerEpoch,prec)*dtBase/2.0_prec**maxLevel
+  call get_environment_variable("SELF_AMR_LE3D_EPOCHLEN",envstr,status=envstat)
+  if(envstat == 0) then
+    read(envstr,*) epochLength
+  endif
+
+  ! Amplitude gate of the refinement indicator (see SELF_RefinementIndicator_3D): elements below
+  ! this fraction of the field's peak element ENERGY are treated as quiescent and released, which
+  ! is what lets the mesh coarsen behind the passing shell. 0 restores the pre-gate behaviour, in
+  ! which the refined region grows to the whole swept volume.
+  relativeEnergyFloor = SELF_AMR_DEFAULT_RELFLOOR
+  call get_environment_variable("SELF_AMR_LE3D_RELFLOOR",envstr,status=envstat)
+  if(envstat == 0) then
+    read(envstr,*) relativeEnergyFloor
+  endif
+
+  ! Upper edge of the amplitude gate's hysteresis band; defaults to the floor itself, i.e. a
+  ! single hard cut.
+  significantEnergyFloor = relativeEnergyFloor
+  call get_environment_variable("SELF_AMR_LE3D_SIGNIFFLOOR",envstr,status=envstat)
+  if(envstat == 0) then
+    read(envstr,*) significantEnergyFloor
+  endif
+
+  ! Resolution actually being requested, reported so a sweep over maxLevel is interpretable.
+  hFinest = Lx/real(nElemX,prec)/2.0_prec**maxLevel
+  lambda = 4.0_prec*Lr ! dominant wavelength of the pulse
+  f0 = c0/lambda
+  ppw = real(controlDegree+1,prec)*lambda/hFinest
+  write(output_unit,'(A,I0)') "CONFIG_maxLevel = ",maxLevel
+  write(output_unit,'(A,ES16.7E3)') "CONFIG_hFinest_m = ",hFinest
+  write(output_unit,'(A,ES16.7E3)') "CONFIG_Lr_m = ",Lr
+  write(output_unit,'(A,ES16.7E3)') "CONFIG_lambda_m = ",lambda
+  write(output_unit,'(A,ES16.7E3)') "CONFIG_f0_Hz = ",f0
+  write(output_unit,'(A,ES16.7E3)') "CONFIG_pointsPerWavelength = ",ppw
+  write(output_unit,'(A,ES16.7E3)') "CONFIG_epochLength_s = ",epochLength
+  write(output_unit,'(A,ES16.7E3)') "CONFIG_relativeEnergyFloor = ",relativeEnergyFloor
+  write(output_unit,'(A,ES16.7E3)') "CONFIG_significantEnergyFloor = ",significantEnergyFloor
+
+  bcids(1:6) = [SELF_BC_RADIATION, & ! bottom
+                SELF_BC_RADIATION, & ! south
+                SELF_BC_RADIATION, & ! east
+                SELF_BC_RADIATION, & ! north
+                SELF_BC_RADIATION, & ! west
+                SELF_BC_RADIATION] ! top
+
+  call mesh%StructuredMesh(nElemX,nElemX,nElemX,1,1,1, &
+                           Lx/real(nElemX,prec),Lx/real(nElemX,prec),Lx/real(nElemX,prec),bcids)
+  call interp%Init(N=controlDegree, &
+                   controlNodeType=GAUSS, &
+                   M=targetDegree, &
+                   targetNodeType=UNIFORM)
+  call geometry%Init(interp,mesh%nElem)
+  call geometry%GenerateFromMesh(mesh)
+
+  call modelobj%Init(mesh,geometry)
+  modelobj%prescribed_bcs_enabled = .false.
+  modelobj%tecplot_enabled = .false.
+  modelobj%rho0 = rho0
+  modelobj%c = c0
+  call modelobj%SetTimeIntegrator(integrator)
+
+  ! Pressure (variable 4 in 3-D) drives the indicator; thresholds are the recommended starting
+  ! values from the AMR documentation.
+  call controller%Init(modelobj,refineThreshold=-3.0_prec,coarsenThreshold=-8.0_prec, &
+                       ivar=4,maxLevel=maxLevel,nHalo=1, &
+                       relativeEnergyFloor=relativeEnergyFloor, &
+                       significantEnergyFloor=significantEnergyFloor)
+
+  ! ---- Initial condition + static refinement to the pulse ----
+  ! After each mesh change the pulse is re-evaluated analytically on the new mesh so the
+  ! indicator sees the true field, not its coarse-mesh interpolant; the loop converges once the
+  ! pulse is resolved (or the level cap is reached).
+  !
+  ! Cold start: indicator-driven refinement can only chase structure the current mesh can
+  ! actually see. The base-mesh nodal spacing is Lx/(nElemX*controlDegree) = 62.5 mm - the average
+  ! gap between the N+1 Gauss nodes, which span N intervals, so it is the N convention rather than
+  ! the N+1 one CONFIG_pointsPerWavelength counts with - so a pulse
+  ! narrower than that samples as ~0 on the level-0 mesh, the indicator finds nothing, and
+  ! refinement never starts. The fix is a width ramp - begin with a pulse the base mesh resolves
+  ! and halve its width as each level appears, so there is always resolvable structure to chase,
+  ! until the target Lr is reached. Only engaged for deeper-than-default targets, so default
+  ! behaviour is unchanged.
+  if(maxLevel > defaultMaxLevel) then
+    LrRamp = defaultLr*2.0_prec**defaultMaxLevel ! widest: resolvable on the level-0 mesh
+    call modelobj%SphericalSoundWave(rhoprime,LrRamp,0.5_prec*Lx,0.5_prec*Lx,0.5_prec*Lx)
+    do i = 1,2*maxLevel+4
+      call controller%Adapt(modelobj,adapted)
+      LrRamp = max(Lr,defaultLr*2.0_prec**(defaultMaxLevel-controller%forest%MaxLevel()))
+      call modelobj%SphericalSoundWave(rhoprime,LrRamp,0.5_prec*Lx,0.5_prec*Lx,0.5_prec*Lx)
+      if(.not. adapted .and. LrRamp <= Lr) exit
+    enddo
+    print*,"cold-start ramp finished: Lr =",LrRamp,"(target",Lr,")"
+  else
+    call modelobj%SphericalSoundWave(rhoprime,Lr,0.5_prec*Lx,0.5_prec*Lx,0.5_prec*Lx)
+    do i = 1,maxLevel+2
+      call controller%Adapt(modelobj,adapted)
+      if(.not. adapted) exit
+      call modelobj%SphericalSoundWave(rhoprime,Lr,0.5_prec*Lx,0.5_prec*Lx,0.5_prec*Lx)
+    enddo
+  endif
+  print*,"initial adaptation: nElem =",modelobj%mesh%nElem, &
+    ", max level =",controller%forest%MaxLevel()
+  if(controller%forest%MaxLevel() < 1) then
+    print*,"ERROR: the indicator did not refine around the pulse."
+    stop 1
+  endif
+
+  call modelobj%CalculateEntropy()
+  e0 = modelobj%entropy
+
+  ! Snapshot the initial condition (epoch snapshots follow from ForwardStep's file IO).
+  call modelobj%WriteModel()
+  call modelobj%IncrementIOCounter()
+
+  ! ---- Time-step through adaptation epochs ----
+  ! The epoch loop is timed in two buckets: time integration (ForwardStep) and adaptation (Adapt).
+  !
+  ! What the boundaries actually guarantee, on a GPU build. c1clk is clean: ForwardStep ends with
+  ! an entropy reduction that reads back to the host, so the queue is drained there. c2clk is NOT
+  ! guaranteed clean: on a GPU build Adapt ends by launching the device solution transfer and does
+  ! not synchronize afterwards, so some of that kernel's time can land in the NEXT epoch's
+  ! ForwardStep bucket instead of this epoch's Adapt bucket. No synchronize is added here rather
+  ! than perturbing what is being measured; the effect is bounded by one transfer kernel per epoch,
+  ! which is orders of magnitude below the adaptation cost it is being compared against, and
+  ! tForwardStep is reported so any leakage into it is visible.
+  call system_clock(count_rate=crate)
+  tFwd = 0.0_real64
+  tAdapt = 0.0_real64
+  nStepsTotal = 0
+  nAdaptEpochs = 0
+  nElemTransferred = 0
+  do epoch = 1,nEpochs
+    dt = controller%RecommendedTimeStep(dtBase)
+    call system_clock(c0clk)
+    ! ioInterval = (tn - t) exactly, so ForwardStep's io count is exactly 1 per epoch regardless
+    ! of accumulated floating-point drift in t.
+    call modelobj%ForwardStep(tn=modelobj%t+epochLength,dt=dt, &
+                              ioInterval=(modelobj%t+epochLength)-modelobj%t)
+    call system_clock(c1clk)
+    call controller%Adapt(modelobj,adapted)
+    call system_clock(c2clk)
+    tFwd = tFwd+real(c1clk-c0clk,real64)/real(crate,real64)
+    tAdapt = tAdapt+real(c2clk-c1clk,real64)/real(crate,real64)
+    nStepsTotal = nStepsTotal+int(epochLength/dt,int64)
+    if(adapted) then
+      nAdaptEpochs = nAdaptEpochs+1
+      nElemTransferred = nElemTransferred+int(modelobj%mesh%nElem,int64)
+    endif
+    print*,"epoch",epoch,": t =",modelobj%t,", dt =",dt, &
+      ", nElem =",modelobj%mesh%nElem,", adapted =",adapted
+  enddo
+
+  ! ---- Wall-clock summary (fixed BENCH_ keys for machine parsing) ----
+  tSim = real(nEpochs,real64)*real(epochLength,real64)
+  write(output_unit,'(A)') "BENCH_case = lineareuler3d_amr_sphericalsoundwave"
+  write(output_unit,'(A,I0)') "BENCH_nEpochs = ",nEpochs
+  write(output_unit,'(A,I0)') "BENCH_nSteps = ",nStepsTotal
+  write(output_unit,'(A,I0)') "BENCH_nElemFinal = ",modelobj%mesh%nElem
+  write(output_unit,'(A,ES16.7E3)') "BENCH_simTime_s = ",tSim
+  write(output_unit,'(A,ES16.7E3)') "BENCH_tForwardStep_s = ",tFwd
+  write(output_unit,'(A,ES16.7E3)') "BENCH_tAdapt_s = ",tAdapt
+  write(output_unit,'(A,ES16.7E3)') "BENCH_tEpochLoop_s = ",tFwd+tAdapt
+  write(output_unit,'(A,ES16.7E3)') "BENCH_wallPerStep_s = ",tFwd/real(nStepsTotal,real64)
+  write(output_unit,'(A,ES16.7E3)') "BENCH_wallPerSimTime = ",tFwd/tSim
+  write(output_unit,'(A,ES16.7E3)') "BENCH_wallPerSimTimeIncAMR = ",(tFwd+tAdapt)/tSim
+  write(output_unit,'(A,ES16.7E3)') "BENCH_amrFraction = ",tAdapt/(tFwd+tAdapt)
+  ! An epoch whose leaf set is unchanged costs only an indicator pass, so the total above mixes
+  ! two very different quantities. The per-adaptation figure below is the one to compare between
+  ! builds, with the transferred element count as its denominator.
+  write(output_unit,'(A,I0)') "BENCH_nAdaptEpochs = ",nAdaptEpochs
+  write(output_unit,'(A,I0)') "BENCH_elemTransferred = ",nElemTransferred
+  if(nAdaptEpochs > 0) then
+    write(output_unit,'(A,ES16.7E3)') "BENCH_tAdaptPerAdaptation_s = ", &
+      tAdapt/real(nAdaptEpochs,real64)
+  endif
+  ! Geometry reuse (AMR Stage 6c): the share of elements whose geometry was carried forward from
+  ! the previous epoch instead of being regenerated.
+  write(output_unit,'(A,I0)') "BENCH_geomReused = ",controller%nGeomReused
+  write(output_unit,'(A,I0)') "BENCH_geomGenerated = ",controller%nGeomGenerated
+  if(controller%nGeomReused+controller%nGeomGenerated > 0) then
+    write(output_unit,'(A,ES16.7E3)') "BENCH_geomReuseFraction = ", &
+      real(controller%nGeomReused,real64)/ &
+      real(controller%nGeomReused+controller%nGeomGenerated,real64)
+  endif
+
+  ! ---- Integration checks ----
+  call modelobj%CalculateEntropy()
+  ef = modelobj%entropy
+  print*,"initial, final acoustic energy :",e0,ef
+  if(ef /= ef) then
+    print*,"ERROR: acoustic energy is NaN."
+    stop 1
+  endif
+  if(ef-e0 > entropyTol*max(abs(e0),1.0_prec)) then
+    print*,"ERROR: acoustic energy grew over the adaptive run."
+    stop 1
+  endif
+
+  call modelobj%Free()
+  call controller%Free()
+  call geometry%Free()
+  call mesh%Free()
+  call interp%Free()
+
+endprogram LinearEuler3D_AMR_SphericalSoundWave

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,6 +65,7 @@ nav:
   - Contributing:
     - Documentation: Contributing/Documentation.md
     - AMR (2D) Design Proposal: Contributing/AMR2D-Design.md
+    - AMR (3D) Design: Contributing/AMR3D-Design.md
     - Mortar (2D) Design Proposal: Contributing/Mortar2D-Design.md
 
 theme: 

--- a/src/SELF_AMRController_3D.f90
+++ b/src/SELF_AMRController_3D.f90
@@ -584,11 +584,15 @@ contains
     !! re-evaluate its time step (RecommendedTimeStep) before the next ForwardStep. When the
     !! leaf set is unchanged the model is untouched.
     !!
-    !! Where the transferred solution lives on return: the portable transfer runs on the host
-    !! and uploads the result with solution%UpdateDevice, so both mirrors are fresh. If a
-    !! device-resident transfer override is added later (the 3-D analogue of the 2-D Stage 6a),
-    !! the host mirror becomes stale here and callers must UpdateHost before reading it, as
-    !! Write_DGModel3D_t does.
+    !! Where the transferred solution lives on return: on a GPU build the transfer is performed
+    !! on the device (the 3-D analogue of the 2-D Stage 6a) and the result is left there, so
+    !! solution%interior (the host mirror) is STALE afterwards. This matches the rest of the
+    !! time loop, where the device is authoritative and a caller that wants host data calls
+    !! solution%UpdateHost() first - as Write_DGModel3D_t does before writing a snapshot. Before
+    !! the device transfer existed the mirror happened to be fresh here because the transfer ran
+    !! on the host; do not rely on that. On CPU builds host and device are the same storage and
+    !! the question does not arise. The multi-rank path still transfers on the host (see step 6),
+    !! so both mirrors are fresh there.
     implicit none
     class(AMRController3D),intent(inout) :: this
     class(DGModel3D_t),intent(inout) :: model
@@ -712,12 +716,17 @@ contains
 
     ! ---- 6. Regrid the model and transfer (migrate) the solution ----
     ! The solution is staged before Regrid (which releases the storage it lives in) and
-    ! transferred onto the new mesh afterwards.
+    ! transferred onto the new mesh afterwards. Both steps are type-bound and backend-specific:
+    ! the portable implementation stages on the host and runs ApplyTransferPlanRange, while the
+    ! GPU backend stages device-to-device and applies the plan in a kernel. That moves the
+    ! per-element tensor-product interpolation onto the device - which is where the measured
+    ! saving comes from - and incidentally leaves no solution data crossing the host link.
     !
     ! On several ranks the old field must first be assembled globally, because each rank then
     ! fills exactly its new contiguous element range and elements that changed ranks are
     ! migrated by construction (the 2-D Stage-5 v1 migration). That allgather is a host
-    ! operation, so the multi-rank path stays on the portable host transfer.
+    ! operation, so the multi-rank path stays on the portable host transfer: a device transfer
+    ! only pays off there once migration is point-to-point (Stage-5 v2).
     eFirst = -1 ! set below, once newMesh's decomposition is known
     if(model%mesh%decomp%nRanks > 1) then
       Np = this%interp%N+1

--- a/src/SELF_SolutionTransfer_3D.f90
+++ b/src/SELF_SolutionTransfer_3D.f90
@@ -60,8 +60,14 @@ module SELF_SolutionTransfer_3D
 !!
 !! The routines are element-local and portable (host `do concurrent` over children/variables);
 !! the AMR driver maps forest parent/child relationships onto the element index ranges it passes
-!! in. Transfer runs between time steps, so it is not a per-step hot path; on GPU backends the
-!! transferred field is re-uploaded as part of the Stage-6 device re-allocation.
+!! in. Transfer runs between time steps, so it is not a per-step hot path.
+!!
+!! These routines remain the reference implementation and are what the CPU backend and the
+!! multi-rank migration path execute, and they are what the transfer tests pin. On a single-rank
+!! GPU build the same mathematics run in TransferSolution_3D_gpu
+!! (src/gpu/SELF_SolutionTransfer.cpp), so the contractions below are performed on the device
+!! rather than on one CPU core and the transferred field never crosses the host link; see
+!! ApplyTransferPlan_DGModel3D.
 
   use SELF_Constants
   use SELF_Lagrange

--- a/src/gpu/SELF_DGModel2D.f90
+++ b/src/gpu/SELF_DGModel2D.f90
@@ -532,7 +532,13 @@ contains
       return
     endif
 
-    if(.not. c_associated(this%xferOld_gpu)) then
+    ! The guard is on xferNOld, not on c_associated(xferOld_gpu). The staging buffer is a
+    ! persistent capacity buffer and stays allocated after use, so testing the pointer would only
+    ! catch a missing stage before the FIRST epoch; from the second on, an unpaired call would
+    ! silently transfer the previous epoch's field. xferNOld is set by StageSolutionForTransfer
+    ! and cleared below, so it tracks the stage/apply pairing the way the base implementation's
+    ! allocatable transferStage does. (Fixed alongside the 3-D port, which found it.)
+    if(this%xferNOld <= 0) then
       print*,__FILE__,':',__LINE__, &
         ' : Error : ApplyTransferPlan called without a staged solution.'
       stop 1
@@ -586,6 +592,10 @@ contains
                                  interp%mortarR_gpu,interp%mortarP_gpu, &
                                  pathStride,eFirst-1,interp%N,this%nvar, &
                                  this%xferNOld,this%solution%nElem,nLocal)
+
+    ! The staged field has been consumed. The buffer itself is kept (it is the capacity that
+    ! makes a settled run allocation-free); only the pairing marker is cleared.
+    this%xferNOld = 0
 
   endsubroutine ApplyTransferPlan_DGModel2D
 

--- a/src/gpu/SELF_DGModel3D.f90
+++ b/src/gpu/SELF_DGModel3D.f90
@@ -32,16 +32,34 @@ module SELF_DGModel3D
   use SELF_BoundaryConditions
   use SELF_Geometry_3D
   use SELF_Mesh_3D
+  use SELF_TransferPlan_3D
 
   implicit none
 
   type,extends(DGModel3D_t) :: DGModel3D
+    !! Device-resident staging for the AMR solution transfer (the 3-D analogue of 2-D Stage 6a).
+    !! These buffers persist across adaptation epochs and grow monotonically, so a settled run
+    !! performs no allocation here at all; xferAllocBytes / planAllocElem record the current
+    !! capacity.
+    type(c_ptr) :: xferOld_gpu = c_null_ptr !! pre-regrid solution, staged device-side
+    integer(c_size_t) :: xferAllocBytes = 0
+    type(c_ptr) :: xferKind_gpu = c_null_ptr !! plan%sourceKind
+    type(c_ptr) :: xferElem_gpu = c_null_ptr !! plan%sourceElem
+    type(c_ptr) :: xferFamily_gpu = c_null_ptr !! plan%family
+    type(c_ptr) :: xferDepth_gpu = c_null_ptr !! plan%depth
+    type(c_ptr) :: xferPath_gpu = c_null_ptr !! plan%path
+    integer :: planAllocElem = 0 !! new-element count the plan buffers are sized for
+    integer :: planAllocStride = 0 !! plan%path leading dimension they are sized for
+    integer :: xferNOld = 0 !! element count of the staged field (its device stride)
 
   contains
 
     procedure :: Init => Init_DGModel3D
     procedure :: Free => Free_DGModel3D
     procedure :: Regrid => Regrid_DGModel3D
+
+    procedure :: StageSolutionForTransfer => StageSolutionForTransfer_DGModel3D
+    procedure :: ApplyTransferPlan => ApplyTransferPlan_DGModel3D
 
     procedure :: UpdateSolution => UpdateSolution_DGModel3D
 
@@ -393,9 +411,160 @@ contains
       bc => bc%next
     enddo
 
+    ! Release the AMR transfer staging buffers. These are lazily created by
+    ! StageSolutionForTransfer / ApplyTransferPlan and survive across adaptation epochs (and
+    ! across Regrid, which runs between the two), so they are owned by the model and released
+    ! only here.
+    if(c_associated(this%xferOld_gpu)) call gpuCheck(hipFree(this%xferOld_gpu))
+    if(c_associated(this%xferKind_gpu)) call gpuCheck(hipFree(this%xferKind_gpu))
+    if(c_associated(this%xferElem_gpu)) call gpuCheck(hipFree(this%xferElem_gpu))
+    if(c_associated(this%xferFamily_gpu)) call gpuCheck(hipFree(this%xferFamily_gpu))
+    if(c_associated(this%xferDepth_gpu)) call gpuCheck(hipFree(this%xferDepth_gpu))
+    if(c_associated(this%xferPath_gpu)) call gpuCheck(hipFree(this%xferPath_gpu))
+    this%xferOld_gpu = c_null_ptr
+    this%xferKind_gpu = c_null_ptr
+    this%xferElem_gpu = c_null_ptr
+    this%xferFamily_gpu = c_null_ptr
+    this%xferDepth_gpu = c_null_ptr
+    this%xferPath_gpu = c_null_ptr
+    this%xferAllocBytes = 0
+    this%planAllocElem = 0
+    this%planAllocStride = 0
+    this%xferNOld = 0
+
     call Free_DGModel3D_t(this)
 
   endsubroutine Free_DGModel3D
+
+  subroutine StageSolutionForTransfer_DGModel3D(this)
+    !! Stage the pre-regrid solution on the DEVICE, replacing the base implementation's
+    !! device-to-host copy of the whole field. Pair with ApplyTransferPlan, which consumes the
+    !! staged copy:
+    !!
+    !!     call model%StageSolutionForTransfer()
+    !!     call model%Regrid(newMesh,newGeom)
+    !!     call model%ApplyTransferPlan(plan,interp,eFirst,eLast)
+    !!
+    !! The staging buffer is model-owned and grows monotonically, so a settled adapting run
+    !! performs no allocation in this path; it is released in Free.
+    implicit none
+    class(DGModel3D),intent(inout) :: this
+    ! Local
+    integer(c_size_t) :: nbytes
+
+    nbytes = int(this%solution%interp%N+1,c_size_t)*(this%solution%interp%N+1)* &
+             (this%solution%interp%N+1)*this%solution%nElem*this%nvar*prec
+
+    if(nbytes > this%xferAllocBytes) then
+      if(c_associated(this%xferOld_gpu)) call gpuCheck(hipFree(this%xferOld_gpu))
+      call gpuCheck(hipMalloc(this%xferOld_gpu,nbytes))
+      this%xferAllocBytes = nbytes
+    endif
+
+    call gpuCheck(hipMemcpy(this%xferOld_gpu,this%solution%interior_gpu,nbytes, &
+                            hipMemcpyDeviceToDevice))
+
+    ! Remember the staged field's element count: it is the stride the transfer kernel must use
+    ! to index the staged buffer, and it is no longer recoverable from the model after Regrid.
+    this%xferNOld = this%solution%nElem
+
+  endsubroutine StageSolutionForTransfer_DGModel3D
+
+  subroutine ApplyTransferPlan_DGModel3D(this,plan,interp,eFirst,eLast,uGlobal)
+    !! Apply the transfer plan on the device, writing solution%interior_gpu directly and moving
+    !! no solution data across the PCIe/xGMI link.
+    !!
+    !! uGlobal is the multi-rank escape hatch: when the caller has assembled a global old field
+    !! on the host (the Stage-5 v1 allgather migration), this falls back to the portable host
+    !! path. A device transfer only pays off on several ranks together with a point-to-point
+    !! (Stage-5 v2) migration; on a single rank it stands alone, which is the case optimized
+    !! here.
+    implicit none
+    class(DGModel3D),intent(inout) :: this
+    type(TransferPlan3D),intent(in),target :: plan
+    type(Lagrange),intent(in) :: interp
+    integer,intent(in) :: eFirst
+    integer,intent(in) :: eLast
+    real(prec),intent(in),optional :: uGlobal(:,:,:,:,:)
+    ! Local
+    integer :: nLocal,pathStride
+    integer(c_size_t) :: nb
+
+    if(present(uGlobal)) then
+      call ApplyTransferPlan_DGModel3D_t(this,plan,interp,eFirst,eLast,uGlobal)
+      return
+    endif
+
+    ! The guard is on xferNOld, not on c_associated(xferOld_gpu). The staging buffer is a
+    ! persistent capacity buffer and stays allocated after use, so testing the pointer would only
+    ! catch a missing stage before the FIRST epoch; from the second on, an unpaired call would
+    ! silently transfer the previous epoch's field. xferNOld is set by StageSolutionForTransfer
+    ! and cleared below, so it tracks the stage/apply pairing the way the base implementation's
+    ! allocatable transferStage does.
+    if(this%xferNOld <= 0) then
+      print*,__FILE__,':',__LINE__, &
+        ' : Error : ApplyTransferPlan called without a staged solution.'
+      stop 1
+    endif
+
+    ! The device kernel holds three (N+1)^3 working buffers in shared memory, sized to a compile
+    ! time bound; guard the degree here rather than overrunning them.
+    if(interp%N+1 > 12) then
+      print*,__FILE__,':',__LINE__, &
+        ' : Error : the device solution transfer supports N+1 <= AMR3D_MAXNP (12).'
+      stop 1
+    endif
+
+    nLocal = eLast-eFirst+1
+    pathStride = size(plan%path,1)
+
+    ! (Re)size the device copies of the plan's integer arrays, reusing them across epochs.
+    if(plan%nNew > this%planAllocElem .or. pathStride > this%planAllocStride) then
+      if(c_associated(this%xferKind_gpu)) call gpuCheck(hipFree(this%xferKind_gpu))
+      if(c_associated(this%xferElem_gpu)) call gpuCheck(hipFree(this%xferElem_gpu))
+      if(c_associated(this%xferFamily_gpu)) call gpuCheck(hipFree(this%xferFamily_gpu))
+      if(c_associated(this%xferDepth_gpu)) call gpuCheck(hipFree(this%xferDepth_gpu))
+      if(c_associated(this%xferPath_gpu)) call gpuCheck(hipFree(this%xferPath_gpu))
+
+      nb = int(plan%nNew,c_size_t)*c_int
+      call gpuCheck(hipMalloc(this%xferKind_gpu,nb))
+      call gpuCheck(hipMalloc(this%xferElem_gpu,nb))
+      call gpuCheck(hipMalloc(this%xferDepth_gpu,nb))
+      call gpuCheck(hipMalloc(this%xferFamily_gpu,8_c_size_t*nb))
+      call gpuCheck(hipMalloc(this%xferPath_gpu,int(pathStride,c_size_t)*nb))
+
+      ! All five are freed and re-allocated together, so both capacities describe the same set
+      ! of buffers. They track the last plan rather than a high-water mark (as in the 2-D
+      ! implementation this mirrors): a later epoch that grows either dimension re-allocates,
+      ! and a settled mesh - the case that matters - trips neither condition.
+      this%planAllocElem = plan%nNew
+      this%planAllocStride = pathStride
+    endif
+
+    nb = int(plan%nNew,c_size_t)*c_int
+    call gpuCheck(hipMemcpy(this%xferKind_gpu,c_loc(plan%sourceKind), &
+                            nb,hipMemcpyHostToDevice))
+    call gpuCheck(hipMemcpy(this%xferElem_gpu,c_loc(plan%sourceElem), &
+                            nb,hipMemcpyHostToDevice))
+    call gpuCheck(hipMemcpy(this%xferDepth_gpu,c_loc(plan%depth), &
+                            nb,hipMemcpyHostToDevice))
+    call gpuCheck(hipMemcpy(this%xferFamily_gpu,c_loc(plan%family), &
+                            8_c_size_t*nb,hipMemcpyHostToDevice))
+    call gpuCheck(hipMemcpy(this%xferPath_gpu,c_loc(plan%path), &
+                            int(pathStride,c_size_t)*nb,hipMemcpyHostToDevice))
+
+    call TransferSolution_3D_gpu(this%xferOld_gpu,this%solution%interior_gpu, &
+                                 this%xferKind_gpu,this%xferElem_gpu,this%xferFamily_gpu, &
+                                 this%xferDepth_gpu,this%xferPath_gpu, &
+                                 interp%mortarR_gpu,interp%mortarP_gpu, &
+                                 pathStride,eFirst-1,interp%N,this%nvar, &
+                                 this%xferNOld,this%solution%nElem,nLocal)
+
+    ! The staged field has been consumed. The buffer itself is kept (it is the capacity that
+    ! makes a settled run allocation-free); only the pairing marker is cleared.
+    this%xferNOld = 0
+
+  endsubroutine ApplyTransferPlan_DGModel3D
 
   subroutine Regrid_DGModel3D(this,mesh,geometry)
     !! GPU regrid: release the device copies of the old boundary-condition element/side

--- a/src/gpu/SELF_GPUInterfaces.f90
+++ b/src/gpu/SELF_GPUInterfaces.f90
@@ -211,6 +211,19 @@ module SELF_GPUInterfaces
   endinterface
 
   interface
+    subroutine TransferSolution_3D_gpu(uold,unew,sourcekind,sourceelem,family,depth,path, &
+                                       mortarR,mortarP,pathstride,efirst0,n,nvar,nold,nnew, &
+                                       nlocal) &
+      bind(c,name="TransferSolution_3D_gpu")
+      use iso_c_binding
+      implicit none
+      type(c_ptr),value :: uold,unew,sourcekind,sourceelem,family,depth,path
+      type(c_ptr),value :: mortarR,mortarP
+      integer(c_int),value :: pathStride,eFirst0,N,nvar,nOld,nNew,nLocal
+    endsubroutine TransferSolution_3D_gpu
+  endinterface
+
+  interface
     subroutine MortarScatter_2D_gpu(extboundary,buff,mortarR,mortarP,mortarinfo, &
                                     elemToRank,rankid,offset,n,nl,nmortars,nel) &
       bind(c,name="MortarScatter_2D_gpu")

--- a/src/gpu/SELF_SolutionTransfer.cpp
+++ b/src/gpu/SELF_SolutionTransfer.cpp
@@ -28,10 +28,14 @@
 // Deliberate divergence from the host reference: the host descent calls ProlongToChildren,
 // which forms all four children and discards three (SELF_TransferPlan_2D.f90:283-286). This
 // kernel applies only the operator pair of the child actually on the path, doing a quarter of
-// the work per descent step. The arithmetic per retained value is identical in form but the
-// operation order across a descent differs, so device and host results agree to round-off
-// rather than bitwise; conservation of the Jacobian-weighted integral is exact either way and
-// is what the tests assert.
+// the work per descent step. What is dropped is the three discarded children - independent
+// computations writing disjoint slices - and not any term of the retained child, whose
+// contractions sum the same products against the same mortar column in the same ascending index
+// order as the host. (An earlier revision of this comment claimed the operation order across a
+// descent differs; it does not. See the 3-D header below for the same argument spelled out.)
+// Device and host nonetheless agree to round-off rather than bitwise, because the device
+// compiler contracts these multiply-accumulates into FMAs. Conservation of the Jacobian-weighted
+// integral is exact either way and is what the tests assert.
 //
 // Thread mapping: one workgroup per new element, one thread per (i,j) node of that element,
 // variables handled sequentially. The Np x Np working buffers therefore live in shared memory
@@ -39,11 +43,13 @@
 // memory at realistic degree and variable counts.
 
 // Maximum supported (N+1). Sizes the shared working buffers below; the Fortran caller guards
-// the degree so an unsupported N fails loudly rather than overrunning. Matches the bound used
-// by the modal indicator in SELF_Refinement.cpp.
+// the degree so an unsupported N fails loudly rather than overrunning (the same literal appears
+// in ApplyTransferPlan_DGModel2D and its error message - keep the three in step). Matches the
+// bound used by the modal indicator in SELF_Refinement.cpp.
 #define AMR2D_MAXNP 16
 
-// Transfer-kind tags. Must match the SELF_TRANSFER_* parameters in SELF_TransferPlan_2D.f90.
+// Transfer-kind tags, shared by the 2-D and 3-D kernels. Must match the SELF_TRANSFER_*
+// parameters in BOTH SELF_TransferPlan_2D.f90 and SELF_TransferPlan_3D.f90, which agree.
 #define SELF_TRANSFER_COPY 0
 #define SELF_TRANSFER_PROLONG 1
 #define SELF_TRANSFER_RESTRICT 2
@@ -167,6 +173,252 @@ extern "C"
     if( nLocal <= 0 ){ return; }
     int Np = N+1;
     TransferSolution_2D_gpukernel<<<dim3(nLocal,1,1), dim3(Np*Np,1,1), 0, 0>>>(
+      uOld, uNew, sourceKind, sourceElem, family, depth, path,
+      mortarR, mortarP, pathStride, eFirst0, N, nvar, nOld, nNew);
+  }
+}
+
+// ------------------------------------------------------------------------------------------- //
+// 3-D device-side AMR solution transfer.
+//
+// The 3-D analogue of the kernel above, with the same contract: it applies a prebuilt transfer
+// plan on the device, so the per-element interpolation runs on the GPU instead of on one CPU
+// core and an adapting single-GPU run moves no solution data across the host link. Measured on
+// one B300 at three refinement depths, that is worth ~10-15% off an adaptation, and essentially
+// all of it is the interpolation rather than the link: at 20,784 elements the eliminated round
+// trip is ~250 MB, some 5 ms against a 2.2 s adaptation. See section 6.4 of
+// docs/Learning/AdaptiveMeshRefinement.md. The mathematics mirror the portable reference
+// exactly - SELF_TransferPlan_3D.f90
+// (ApplyTransferPlanRange) driving SELF_SolutionTransfer_3D.f90 (ProlongToChildren /
+// RestrictFromChildren) - with the element-local operators now triple tensor products applied as
+// an xi pass, an eta pass and a zeta pass:
+//
+//   prolong:  t1(i,j,k) = sum_ii mortarR(ii,i,kx) * parent(ii,j,k)
+//             t2(i,j,k) = sum_jj mortarR(jj,j,ky) * t1(i,jj,k)
+//             child     = sum_kk mortarR(kk,k,kz) * t2(i,j,kk)
+//   restrict: t1(i,j,k) = sum_ii mortarP(ii,i,kx) * child(ii,j,k)
+//             t2(i,j,k) = sum_jj mortarP(jj,j,ky) * t1(i,jj,k)
+//             parent   += sum_kk mortarP(kk,k,kz) * t2(i,j,kk)     (accumulated over children)
+//
+// Each 1-D mortarP carries the half-interval Jacobian, so the triple product carries 1/8, which
+// is what makes restriction conservative in 3-D.
+//
+// Thread mapping: one workgroup per new element, (N+1)*(N+1) threads, and thread (a,b) owns one
+// (a,b) pencil and loops the remaining index in each of the three passes - the decomposition the
+// 3-D modal indicator already uses (RefinementIndicator_3D_gpukernel in SELF_Refinement.cpp).
+// An (N+1)^3 thread block is not an option: it is 4096 threads at N=15, past the block limit,
+// and it would put the working buffers in per-thread scratch. Variables are handled sequentially.
+//
+// Deliberate divergence from the host reference, inherited from the 2-D kernel: the host descent
+// calls ProlongToChildren, which forms all EIGHT children and discards seven
+// (SELF_TransferPlan_3D.f90:288-291). This kernel applies only the operator triple of the child
+// actually on the recorded path, doing an eighth of the work per descent step (a quarter in 2-D).
+// The work that is dropped is the seven children that are thrown away, not any part of the
+// retained value: each contraction below sums the same terms against the same mortar column, in
+// the same ascending index order as the host loop, so the reduction order is preserved as
+// CLAUDE.md requires.
+//
+// Device and host are nonetheless expected to agree only to round-off, not bitwise, because the
+// device compiler contracts these multiply-accumulates into FMAs while the host build need not.
+// That is the same situation as every other kernel in this directory. Conservation of the
+// Jacobian-weighted integral is exact either way - it follows from sum_c P_kz P_ky P_kx being a
+// partition of the parent's quadrature, not from the summation order - and that is what the AMR
+// regression asserts per epoch; test/solution_transfer_3d_device.f90 pins the transferred values
+// themselves against the host reference to the DOUBLE_PRECISION tolerance.
+
+// Maximum supported (N+1) for the 3-D transfer kernel, and the size of the three (N+1)^3 working
+// buffers, which live in per-block __shared__ memory. At 12 that is 3*12^3*8 = 41,472 B, inside
+// both the 48 KB CUDA static shared-memory limit and the 64 KB gfx90a/gfx942 LDS budget. The
+// Fortran caller guards the degree (ApplyTransferPlan_DGModel3D carries the same literal, in the
+// test and in its error message - keep the three in step), so an unsupported N fails loudly
+// rather than overrunning. Matches the bound the 3-D modal indicator uses (AMR3D_MAXNP in
+// SELF_Refinement.cpp).
+//
+// Note the static allocation is AMR3D_MAXNP^3 whatever the degree in use, not (N+1)^3: 41,472 B
+// on every launch, where N = 7 would only need 12,288 B. On an NVIDIA device that is not the
+// limiter - a dynamic-shared variant sized 3*(N+1)^3*sizeof(real), which is what
+// SELF_MatrixMultiply.cpp does, measured 1-3% SLOWER on a B300 across three runs at two
+// refinement depths, so it was not adopted. It may still be worth revisiting on a 64 KB-LDS AMD
+// device, where the static footprint admits only one workgroup per CU rather than five; that has
+// not been measured, and since the alternative on every platform is the host round trip this
+// kernel replaces, the static form cannot regress anything as it stands.
+#define AMR3D_MAXNP 12
+
+// Child octant (SELF/CGNS corner order) -> (x-half, y-half, z-half); half h selects mortar
+// sub-interval k = h. Mirrors transferAxc / transferAyc / transferAzc in
+// SELF_SolutionTransfer_3D.f90, less the Fortran 1-based offset.
+__device__ __constant__ int d_transferAxc3D[8] = {0, 1, 1, 0, 0, 1, 1, 0};
+__device__ __constant__ int d_transferAyc3D[8] = {0, 0, 1, 1, 0, 0, 1, 1};
+__device__ __constant__ int d_transferAzc3D[8] = {0, 0, 0, 0, 1, 1, 1, 1};
+
+__global__ void TransferSolution_3D_gpukernel(real *uOld, real *uNew,
+                                              int *sourceKind, int *sourceElem, int *family,
+                                              int *depth, int *path,
+                                              real *mortarR, real *mortarP,
+                                              int pathStride, int eFirst0,
+                                              int N, int nvar, int nOld, int nNew){
+
+  // One block per new (rank-local) element.
+  int lo = blockIdx.x;              // 0-based index into the rank-local new field
+  int gi = eFirst0 + lo;            // 0-based index into the plan's global new-leaf arrays
+
+  int Np = N+1;
+  int tid = threadIdx.x;            // blockDim.x == Np*Np, so every thread is active
+  int a = tid % Np;                 // this thread's first pencil index
+  int b = tid / Np;                 // this thread's second pencil index
+
+  __shared__ real buf[AMR3D_MAXNP*AMR3D_MAXNP*AMR3D_MAXNP];
+  __shared__ real tmp[AMR3D_MAXNP*AMR3D_MAXNP*AMR3D_MAXNP];
+  __shared__ real acc[AMR3D_MAXNP*AMR3D_MAXNP*AMR3D_MAXNP];
+
+  int kind = sourceKind[gi];
+  int d = depth[gi];
+
+  // Both branch conditions below are uniform across the block (they depend only on gi), so every
+  // __syncthreads() is reached by every thread.
+  for(int v=0; v<nvar; v++){
+
+    if( kind == SELF_TRANSFER_RESTRICT ){
+
+      // L2-project the eight children onto their parent, accumulating over children.
+      for(int k=0; k<Np; k++){ acc[a + Np*(b + Np*k)] = 0.0; }
+      __syncthreads();
+
+      for(int c=0; c<8; c++){
+        int src = family[c + 8*gi] - 1;   // Fortran 1-based element index
+        int kx = d_transferAxc3D[c];
+        int ky = d_transferAyc3D[c];
+        int kz = d_transferAzc3D[c];
+
+        // Stage the child into shared memory first. The xi pass contracts over the FIRST node
+        // index, so reading uOld inside it would make every thread's address independent of a -
+        // uncoalesced, and each child value re-read Np times over. Loading it here is coalesced
+        // in a and reads each value once, as the 2-D kernel above does.
+        for(int k=0; k<Np; k++){
+          buf[a + Np*(b + Np*k)] = uOld[SC_3D_INDEX(a,b,k,src,v,N,nOld)];
+        }
+        __syncthreads();
+
+        // xi pass: tmp(a,b,k) = sum_ii mortarP(ii,a,kx) * child(ii,b,k)
+        for(int k=0; k<Np; k++){
+          real s = 0.0;
+          for(int ii=0; ii<Np; ii++){
+            s += mortarP[ii + Np*(a + Np*kx)]*buf[ii + Np*(b + Np*k)];
+          }
+          tmp[a + Np*(b + Np*k)] = s;
+        }
+        // buf is overwritten by the eta pass below, and was just read across threads by the xi
+        // pass, so this barrier closes both that read and the tmp write.
+        __syncthreads();
+
+        // eta pass: buf(a,b,k) = sum_jj mortarP(jj,b,ky) * tmp(a,jj,k)
+        for(int k=0; k<Np; k++){
+          real s = 0.0;
+          for(int jj=0; jj<Np; jj++){
+            s += mortarP[jj + Np*(b + Np*ky)]*tmp[a + Np*(jj + Np*k)];
+          }
+          buf[a + Np*(b + Np*k)] = s;
+        }
+        // tmp was just read across threads and the next child's xi pass rewrites it.
+        __syncthreads();
+
+        // zeta pass (own-pencil in both operands), accumulated over the eight children:
+        //   acc(a,b,r) += sum_kk mortarP(kk,r,kz) * buf(a,b,kk)
+        for(int r=0; r<Np; r++){
+          real s = 0.0;
+          for(int kk=0; kk<Np; kk++){
+            s += mortarP[kk + Np*(r + Np*kz)]*buf[a + Np*(b + Np*kk)];
+          }
+          acc[a + Np*(b + Np*r)] += s;
+        }
+        // The next child's staging pass overwrites buf, which this child's zeta pass has just
+        // read; that read is own-pencil, but the staging write is too, so this barrier is what
+        // keeps the eight children ordered as a block rather than per thread.
+        __syncthreads();
+      }
+
+      for(int k=0; k<Np; k++){ buf[a + Np*(b + Np*k)] = acc[a + Np*(b + Np*k)]; }
+      __syncthreads();
+
+    } else {
+
+      // COPY (d == 0) and PROLONG (d > 0) both start from a single surviving old element.
+      int src = sourceElem[gi] - 1;
+      for(int k=0; k<Np; k++){
+        buf[a + Np*(b + Np*k)] = uOld[SC_3D_INDEX(a,b,k,src,v,N,nOld)];
+      }
+      __syncthreads();
+
+    }
+
+    // Descend the recorded path, prolonging one level per step onto the child that is on the
+    // path (rather than onto all eight).
+    for(int step=0; step<d; step++){
+      // pathStride is the ALLOCATED leading dimension of plan%path, i.e. max(forest%MaxLevel(),1)
+      // - not plan%maxDepth, which is the largest depth actually encountered and is generally
+      // smaller.
+      int c = path[step + pathStride*gi] - 1;  // octant 1..8 -> 0..7
+      int kx = d_transferAxc3D[c];
+      int ky = d_transferAyc3D[c];
+      int kz = d_transferAzc3D[c];
+
+      // xi pass: tmp(a,b,k) = sum_ii mortarR(ii,a,kx) * parent(ii,b,k)
+      for(int k=0; k<Np; k++){
+        real s = 0.0;
+        for(int ii=0; ii<Np; ii++){
+          s += mortarR[ii + Np*(a + Np*kx)]*buf[ii + Np*(b + Np*k)];
+        }
+        tmp[a + Np*(b + Np*k)] = s;
+      }
+      __syncthreads();
+
+      // eta pass: acc(a,b,k) = sum_jj mortarR(jj,b,ky) * tmp(a,jj,k)
+      for(int k=0; k<Np; k++){
+        real s = 0.0;
+        for(int jj=0; jj<Np; jj++){
+          s += mortarR[jj + Np*(b + Np*ky)]*tmp[a + Np*(jj + Np*k)];
+        }
+        acc[a + Np*(b + Np*k)] = s;
+      }
+      // acc is written and read within one thread's own pencil, so strictly this barrier is not
+      // required by the zeta pass below; it is kept because the pass structure here is otherwise
+      // identical to the cross-thread xi/eta pair above, and a future indexing change that made
+      // the zeta contraction cross-thread would silently race without it.
+      __syncthreads();
+
+      // zeta pass: child(a,b,r) = sum_kk mortarR(kk,r,kz) * acc(a,b,kk)
+      for(int r=0; r<Np; r++){
+        real s = 0.0;
+        for(int kk=0; kk<Np; kk++){
+          s += mortarR[kk + Np*(r + Np*kz)]*acc[a + Np*(b + Np*kk)];
+        }
+        buf[a + Np*(b + Np*r)] = s;
+      }
+      __syncthreads();
+    }
+
+    for(int k=0; k<Np; k++){
+      uNew[SC_3D_INDEX(a,b,k,lo,v,N,nNew)] = buf[a + Np*(b + Np*k)];
+    }
+    // The next variable's first pass overwrites buf (and, on the RESTRICT branch, acc), so the
+    // stores above must complete for the whole block before it begins.
+    __syncthreads();
+  }
+
+}
+
+extern "C"
+{
+  void TransferSolution_3D_gpu(real *uOld, real *uNew,
+                               int *sourceKind, int *sourceElem, int *family,
+                               int *depth, int *path,
+                               real *mortarR, real *mortarP,
+                               int pathStride, int eFirst0,
+                               int N, int nvar, int nOld, int nNew, int nLocal)
+  {
+    if( nLocal <= 0 ){ return; }
+    int Np = N+1;
+    TransferSolution_3D_gpukernel<<<dim3(nLocal,1,1), dim3(Np*Np,1,1), 0, 0>>>(
       uOld, uNew, sourceKind, sourceElem, family, depth, path,
       mortarR, mortarP, pathStride, eFirst0, N, nvar, nOld, nNew);
   }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -83,6 +83,7 @@ add_fortran_tests (
     "mesh3d_uniform_refine.f90"
     "solution_transfer_2d.f90"
     "solution_transfer_3d.f90"
+    "solution_transfer_3d_device.f90"
     "quadtree_balance_2d.f90"
     "octree_balance_3d.f90"
     "adaptive_mortar_2d.f90"
@@ -115,6 +116,7 @@ add_fortran_tests (
     "tensor_3d_guard_resize_nvar.f90"
     "dgmodel2d_guard_transfer_unstaged.f90"
     "dgmodel3d_guard_transfer_unstaged.f90"
+    "dgmodel3d_guard_transfer_reapply.f90"
     "amr_controller_2d_guard_maxlevel.f90"
     "amr_controller_3d_guard_maxlevel.f90"
     "amr_controller_2d_guard_wrongmesh.f90"
@@ -337,6 +339,7 @@ set_tests_properties(
     tensor_3d_guard_resize_nvar
     dgmodel2d_guard_transfer_unstaged
     dgmodel3d_guard_transfer_unstaged
+    dgmodel3d_guard_transfer_reapply
     mesh3d_read_guard_missingfile
     mesh3d_read_guard_badconnectivity
     PROPERTIES WILL_FAIL TRUE)

--- a/test/dgmodel3d_guard_transfer_reapply.f90
+++ b/test/dgmodel3d_guard_transfer_reapply.f90
@@ -1,0 +1,91 @@
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+!
+! Maintainers : support@fluidnumerics.com
+! Official Repository : https://github.com/FluidNumerics/self/
+!
+! Copyright © 2024 Fluid Numerics LLC
+!
+! Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+!
+! 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+!    the documentation and/or other materials provided with the distribution.
+!
+! 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+!    this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+! HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+! LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+! THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+! THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+!
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+
+! Guard test (expected to abort): ApplyTransferPlan must reject a SECOND apply that is not
+! preceded by its own StageSolutionForTransfer.
+!
+! The companion test dgmodel3d_guard_transfer_unstaged covers a fresh model, where any guard
+! catches the mistake. This one covers the case that only a consuming guard catches: one full
+! stage -> regrid -> apply cycle has already succeeded, so on a GPU build the device staging
+! buffer is still allocated (it is a persistent capacity buffer, deliberately not released
+! between epochs) and the previous epoch's field is still sitting in it. A guard that merely
+! tested whether that buffer exists would pass the unpaired call through and silently transfer
+! stale data. Registered with WILL_FAIL in CMake, so the stop 1 is the passing outcome.
+program test
+  use SELF_Constants
+  use SELF_Lagrange
+  use self_lineareuler3d
+  use self_mesh_3d
+  use SELF_Geometry_3D
+  use SELF_OctreeMesh_3D
+  use SELF_AdaptiveMesh_3D
+  use SELF_TransferPlan_3D
+  implicit none
+  type(LinearEuler3D) :: modelobj
+  type(Lagrange),target :: interp
+  type(Mesh3D),target :: baseMesh,oldMesh,newMesh
+  type(SEMHex),target :: oldGeom,newGeom
+  type(OctreeMesh3D) :: forest
+  type(TransferPlan3D) :: plan
+  integer :: bcids(1:6)
+  integer :: nOld
+  integer,allocatable :: flag(:),oldLeaf(:)
+
+  bcids(1:6) = SELF_BC_PRESCRIBED
+  call baseMesh%StructuredMesh(2,2,2,1,1,1,0.5_prec,0.5_prec,0.5_prec,bcids)
+  call interp%Init(N=3,controlNodeType=GAUSS,M=3,targetNodeType=UNIFORM)
+
+  call forest%Init(baseMesh)
+  call EmitMesh(forest,baseMesh,oldMesh)
+  call oldGeom%Init(interp,oldMesh%nElem)
+  call oldGeom%GenerateFromMesh(oldMesh)
+  call modelobj%Init(oldMesh,oldGeom)
+
+  nOld = forest%nLeaves
+  allocate(oldLeaf(1:nOld))
+  oldLeaf(1:nOld) = forest%leaf(1:nOld)
+
+  ! One legitimate epoch: refine a root, transfer onto the emitted mesh.
+  allocate(flag(1:nOld))
+  flag = OCTREE_KEEP
+  flag(1) = OCTREE_REFINE
+  call forest%AdaptFromFlags(flag)
+  call forest%Balance2to1()
+  call BuildTransferPlan(forest,nOld,oldLeaf,plan)
+  call EmitMesh(forest,baseMesh,newMesh)
+  call newGeom%Init(interp,newMesh%nElem)
+  call newGeom%GenerateFromMesh(newMesh)
+
+  call modelobj%StageSolutionForTransfer()
+  call modelobj%Regrid(newMesh,newGeom)
+  call modelobj%ApplyTransferPlan(plan,interp,1,plan%nNew)
+
+  ! The staged field has now been consumed. Applying the same plan again without re-staging
+  ! must stop 1 rather than silently reusing it.
+  call modelobj%ApplyTransferPlan(plan,interp,1,plan%nNew)
+
+  print*,"ERROR: ApplyTransferPlan re-apply guard did not trigger"
+endprogram test

--- a/test/solution_transfer_3d_device.f90
+++ b/test/solution_transfer_3d_device.f90
@@ -1,0 +1,280 @@
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+!
+! Maintainers : support@fluidnumerics.com
+! Official Repository : https://github.com/FluidNumerics/self/
+!
+! Copyright © 2024 Fluid Numerics LLC
+!
+! Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+!
+! 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+!    the documentation and/or other materials provided with the distribution.
+!
+! 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+!    this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+! HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+! LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+! THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+! THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+!
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+
+program test
+
+  implicit none
+  integer :: exit_code
+
+  exit_code = solution_transfer_3d_device()
+  if(exit_code /= 0) then
+    stop exit_code
+  endif
+
+contains
+
+  integer function solution_transfer_3d_device() result(r)
+    !! Pins the model-level 3-D AMR solution transfer - StageSolutionForTransfer -> Regrid ->
+    !! ApplyTransferPlan - against the portable reference ApplyTransferPlanRange, value by value.
+    !!
+    !! Why this exists. On a GPU build the model overrides both steps: the solution is staged
+    !! device-to-device and the plan is applied in TransferSolution_3D_gpu, so the transferred
+    !! field never crosses the host link. Nothing else in the suite compares that kernel's output
+    !! against the host implementation; the AMR regressions only assert invariants of the result
+    !! (conservation of the Jacobian-weighted integral, entropy non-growth), which a kernel with
+    !! a transposed direction or a mis-indexed child could still satisfy. This test asserts the
+    !! values themselves.
+    !!
+    !! It is not GPU-gated. On a CPU build both sides run the same reference code and the
+    !! comparison is exact, which keeps the harness itself honest; on a GPU build the left-hand
+    !! side is the kernel. Agreement is asserted to the DOUBLE_PRECISION tolerance rather than
+    !! bitwise, because the device compiler contracts the kernel's multiply-accumulates into FMAs.
+    !!
+    !! The epoch is the one transfer_plan_3d builds, chosen because a single plan then carries all
+    !! three transfer kinds and prolongation depths 0..2:
+    !!
+    !!   COPY      - roots left untouched
+    !!   RESTRICT  - a coarsened family, immediately re-refined, so depth > 0 as well
+    !!   PROLONG   - a refined leaf whose child is refined again (depth 2), plus a
+    !!               2:1-balancing ripple into an untouched root (depth 1)
+    !!
+    !! The driving field is deliberately non-polynomial and DIFFERENT IN EVERY VARIABLE. A
+    !! polynomial of degree <= N is reproduced exactly by both prolongation and restriction, so it
+    !! would hide an error in the operators themselves; and LinearEuler3D carries nvar = 6, of
+    !! which the last two (sound speed and background density) are static background fields, so a
+    !! kernel that transferred only the prognostic variables would corrupt the medium invisibly on
+    !! a uniform-medium test.
+    use SELF_Constants
+    use SELF_Lagrange
+    use SELF_Mesh_3D
+    use SELF_Geometry_3D
+    use SELF_OctreeMesh_3D
+    use SELF_AdaptiveMesh_3D
+    use SELF_TransferPlan_3D
+    use SELF_LinearEuler3D
+
+    implicit none
+
+    integer,parameter :: controlDegree = 4
+#ifdef DOUBLE_PRECISION
+    real(prec),parameter :: tolerance = 1.0e-10_prec
+#else
+    real(prec),parameter :: tolerance = 1.0e-3_prec
+#endif
+    type(Lagrange),target :: interp
+    type(Mesh3D),target :: baseMesh,oldMesh,newMesh
+    type(SEMHex),target :: oldGeom,newGeom
+    type(OctreeMesh3D) :: forest
+    type(TransferPlan3D) :: plan
+    type(LinearEuler3D) :: modelobj
+    integer :: bcids(1:6)
+    integer :: i,j,k,e,iv,Np,nOld,nNew,nvar
+    integer :: nCopy,nProlong,nRestrict,nDeep
+    integer,allocatable :: flag(:),oldLeaf(:)
+    real(prec),allocatable :: uOld(:,:,:,:,:),uRef(:,:,:,:,:)
+    real(prec) :: x,y,z,err,scale
+
+    r = 0
+    bcids(1:6) = [SELF_BC_PRESCRIBED,SELF_BC_PRESCRIBED,SELF_BC_PRESCRIBED, &
+                  SELF_BC_PRESCRIBED,SELF_BC_PRESCRIBED,SELF_BC_PRESCRIBED]
+
+    Np = controlDegree+1
+
+    ! 2 x 2 x 2 element structured base mesh; element ordering is x-fastest, then y, then z.
+    call baseMesh%StructuredMesh(2,2,2,1,1,1,0.5_prec,0.5_prec,0.5_prec,bcids)
+    call interp%Init(N=controlDegree,controlNodeType=GAUSS,M=controlDegree, &
+                     targetNodeType=UNIFORM)
+
+    ! ---- Pre-epoch state: refine root 1 so the epoch has a family available to coarsen ----
+    call forest%Init(baseMesh)
+    allocate(flag(1:forest%nLeaves))
+    flag = OCTREE_KEEP
+    flag(1) = OCTREE_REFINE
+    call forest%AdaptFromFlags(flag)
+    deallocate(flag)
+
+    call EmitMesh(forest,baseMesh,oldMesh)
+    call oldGeom%Init(interp,oldMesh%nElem)
+    call oldGeom%GenerateFromMesh(oldMesh)
+    nOld = forest%nLeaves
+    allocate(oldLeaf(1:nOld))
+    oldLeaf(1:nOld) = forest%leaf(1:nOld)
+
+    ! Single-rank test: the plan's global new-leaf range is the rank-local range, so eFirst = 1.
+    ! (The multi-rank transfer takes the uGlobal path, which is the host reference on every
+    ! backend and is covered by lineareuler3d_amr_soundwave_mpi.)
+    if(oldMesh%decomp%nRanks > 1) then
+      print*,"FAIL: solution_transfer_3d_device is a single-rank test"
+      r = 1
+      return
+    endif
+
+    ! ---- The live model on the old mesh ----
+    call modelobj%Init(oldMesh,oldGeom)
+    modelobj%prescribed_bcs_enabled = .false.
+    modelobj%tecplot_enabled = .false.
+    nvar = modelobj%nvar
+
+    ! Smooth but non-polynomial, and distinct per variable so a variable-indexing error in the
+    ! kernel cannot cancel. The wavenumbers are irrational multiples of the element size, so no
+    ! variable is representable exactly in the degree-N nodal basis.
+    do iv = 1,nvar
+      do e = 1,oldMesh%nElem
+        do k = 1,Np
+          do j = 1,Np
+            do i = 1,Np
+              x = oldGeom%x%interior(i,j,k,e,1,1)
+              y = oldGeom%x%interior(i,j,k,e,1,2)
+              z = oldGeom%x%interior(i,j,k,e,1,3)
+              modelobj%solution%interior(i,j,k,e,iv) = &
+                real(iv,prec)+sin(7.3_prec*x+real(iv,prec))* &
+                cos(5.1_prec*y-real(iv,prec))*sin(3.7_prec*z+0.5_prec*real(iv,prec))
+            enddo
+          enddo
+        enddo
+      enddo
+    enddo
+    call modelobj%solution%UpdateDevice()
+
+    ! The reference input: the old field exactly as staged. On a GPU build the device staging
+    ! copies interior_gpu, which UpdateDevice above has just made equal to this array.
+    allocate(uOld(1:Np,1:Np,1:Np,1:nOld,1:nvar))
+    uOld(1:Np,1:Np,1:Np,1:nOld,1:nvar) = &
+      modelobj%solution%interior(1:Np,1:Np,1:Np,1:nOld,1:nvar)
+
+    ! ---- One adaptation epoch, built to contain all three transfer kinds ----
+    allocate(flag(1:nOld))
+    flag = OCTREE_KEEP
+    flag(1:8) = OCTREE_COARSEN
+    flag(9) = OCTREE_REFINE
+    call forest%AdaptFromFlags(flag)
+    deallocate(flag)
+    call forest%RefineNode(1)
+    call forest%RefineNode(forest%child(3,2))
+    call forest%RebuildLeaves()
+    call forest%Balance2to1()
+
+    call BuildTransferPlan(forest,nOld,oldLeaf,plan)
+    nNew = plan%nNew
+
+    ! Guard the premise: if the plan ever stopped covering all three kinds and a multi-level
+    ! descent, this test would still pass while checking much less than it claims to.
+    nCopy = count(plan%sourceKind(1:nNew) == SELF_TRANSFER_COPY)
+    nProlong = count(plan%sourceKind(1:nNew) == SELF_TRANSFER_PROLONG)
+    nRestrict = count(plan%sourceKind(1:nNew) == SELF_TRANSFER_RESTRICT)
+    nDeep = count(plan%depth(1:nNew) >= 2)
+    print*,"plan: copy",nCopy,", prolong",nProlong,", restrict",nRestrict,", depth>=2",nDeep
+    if(nCopy == 0 .or. nProlong == 0 .or. nRestrict == 0 .or. nDeep == 0) then
+      print*,"FAIL: the epoch no longer exercises every transfer kind and a depth >= 2 descent"
+      r = 1
+    endif
+
+    call EmitMesh(forest,baseMesh,newMesh)
+    call newGeom%Init(interp,newMesh%nElem)
+    call newGeom%GenerateFromMesh(newMesh)
+
+    ! ---- The transfer under test ----
+    call modelobj%StageSolutionForTransfer()
+    call modelobj%Regrid(newMesh,newGeom)
+    call modelobj%ApplyTransferPlan(plan,interp,1,nNew)
+    ! On a GPU build the result is left on the device (the host mirror is stale by contract), so
+    ! it must be pulled back before it can be read.
+    call modelobj%solution%UpdateHost()
+
+    ! ---- The portable reference, from the same staged input ----
+    allocate(uRef(1:Np,1:Np,1:Np,1:nNew,1:nvar))
+    call ApplyTransferPlanRange(plan,interp,nvar,uOld,1,nNew,uRef)
+
+    err = 0.0_prec
+    scale = 0.0_prec
+    do iv = 1,nvar
+      do e = 1,nNew
+        do k = 1,Np
+          do j = 1,Np
+            do i = 1,Np
+              err = max(err,abs(modelobj%solution%interior(i,j,k,e,iv)-uRef(i,j,k,e,iv)))
+              scale = max(scale,abs(uRef(i,j,k,e,iv)))
+            enddo
+          enddo
+        enddo
+      enddo
+    enddo
+    print*,"max |device - host| =",err,", field scale =",scale
+    if(err > tolerance*max(scale,1.0_prec)) then
+      print*,"FAIL: the transferred solution does not match the portable reference"
+      r = 1
+    endif
+
+    ! ---- The staging buffer must be reusable across epochs ----
+    ! A second stage/apply on the settled mesh exercises the buffer-reuse path (no growth, so no
+    ! reallocation) and must reproduce the field it was staged from, element for element: with
+    ! no forest mutation between the two calls, every plan entry is a COPY of itself.
+    call BuildTransferPlan(forest,nNew,forest%leaf(1:nNew),plan)
+    if(any(plan%sourceKind(1:plan%nNew) /= SELF_TRANSFER_COPY)) then
+      print*,"FAIL: an unmutated forest did not produce an all-COPY plan"
+      r = 1
+    endif
+    uRef(1:Np,1:Np,1:Np,1:nNew,1:nvar) = &
+      modelobj%solution%interior(1:Np,1:Np,1:Np,1:nNew,1:nvar)
+    call modelobj%StageSolutionForTransfer()
+    call modelobj%Regrid(newMesh,newGeom)
+    call modelobj%ApplyTransferPlan(plan,interp,1,plan%nNew)
+    call modelobj%solution%UpdateHost()
+
+    err = 0.0_prec
+    do iv = 1,nvar
+      do e = 1,nNew
+        do k = 1,Np
+          do j = 1,Np
+            do i = 1,Np
+              err = max(err,abs(modelobj%solution%interior(i,j,k,e,iv)-uRef(i,j,k,e,iv)))
+            enddo
+          enddo
+        enddo
+      enddo
+    enddo
+    print*,"max |round trip - original| on the re-staged epoch =",err
+    if(err > 0.0_prec) then
+      print*,"FAIL: an all-COPY transfer did not reproduce the field exactly"
+      r = 1
+    endif
+
+    call plan%Free()
+    call modelobj%Free()
+    call newGeom%Free()
+    call oldGeom%Free()
+    call newMesh%Free()
+    call oldMesh%Free()
+    call baseMesh%Free()
+    call forest%Free()
+    call interp%Free()
+    deallocate(uOld,uRef,oldLeaf)
+
+    if(r == 0) print*,"PASS: solution_transfer_3d_device"
+
+  endfunction solution_transfer_3d_device
+
+endprogram test


### PR DESCRIPTION
Closes #165.

The 3-D analogue of 2-D Stage 6a (#158). A single-rank GPU adaptation epoch moved the whole
solution across the host link twice — `UpdateHost()` before `Regrid`, `UpdateDevice()` after —
and ran the triple tensor-product interpolation on one CPU core in between. `StageSolutionForTransfer`
and `ApplyTransferPlan` were already type-bound on `DGModel3D_t`, so this adds only the GPU
overrides: staging becomes a device-to-device copy into a model-owned buffer, and the plan is
applied by a new `TransferSolution_3D_gpu` kernel.

## Measurements

One B300 (sm_103, CUDA 13, fp64), the new example, 20 epochs, mean of three runs on one node.
The before/after trees differ **only** in the three files implementing the transfer — the example
and tests are identical in both. `tAdapt` is per **adapting** epoch, because an epoch whose leaf
set is unchanged costs only an indicator pass:

| maxLevel | elements | before | after | |
| --- | --- | --- | --- | --- |
| 1 | 512 | 119.5 ms | **101.6 ms** | −15.0% |
| 2 | 4,096 | 571.6 ms | **516.3 ms** | −9.7% |
| 3 | 20,784 | 2182.6 ms | **1959.6 ms** | −10.2% |

Time integration is unchanged (5.199 s → 5.176 s at maxLevel 3) — nothing on this path runs
inside `ForwardStep`. Run-to-run spread on `tAdapt` is under 1%.

### Where the saving comes from — not where the 2-D story says

The 2-D commit led with "moves no solution data across the host link", and that framing is
misleading at 3-D scale. At 20,784 elements the eliminated round trip is ~250 MB, roughly 5 ms
against a 2.2 s adaptation — **0.2%**. The ~220 ms actually saved is the per-element interpolation
moving off the CPU, plus the kernel prolonging onto only the child on the recorded path instead of
forming all eight and discarding seven. Both scale with element count, which is why the saving
holds at ~10% across a 40× range in mesh size. The docs now say this, and the 2-D claim is
corrected.

## The kernel

One workgroup per new element with `(N+1)²` threads, thread `(a,b)` owning one pencil and looping
the free index through each of three directional passes — the decomposition `AMR3D-Design.md` §4
prescribed and the 3-D modal indicator already uses. An `(N+1)³` block is not an option: 4096
threads at N=15, and it would push the working buffers into per-thread scratch. The three
`(N+1)³` buffers are static shared memory bounded by `AMR3D_MAXNP = 12` (41,472 B, inside both
the CUDA 48 kB static limit and the gfx90a/gfx942 LDS budget), guarded Fortran-side.

A dynamic-shared variant sized to the degree in use — the `SELF_MatrixMultiply.cpp` idiom, 12 kB
at N=7 — was implemented and measured **1–3% slower** on B300 across three runs at two depths,
because the SM shared budget there is large enough that 41 kB per block does not gate occupancy.
It was not adopted. The argument for it survives on a 64 kB-LDS AMD device, where the static
footprint admits one workgroup per CU rather than five; that is unmeasured and recorded as such in
the kernel comment.

Reduction order is preserved (CLAUDE.md §3): each contraction sums the same products against the
same mortar column in the same ascending index order as the host. What the kernel drops is the
seven discarded children — independent computations writing disjoint slices — not any term of the
retained value. Device and host agree to round-off rather than bitwise only because the device
compiler contracts these multiply-accumulates into FMAs. The 2-D kernel's comment claiming "the
operation order across a descent differs" was over-cautious and is corrected; the two kernels were
making contradictory claims about one construction.

## Behaviour change (matching 2-D)

On a GPU build the transferred solution is left on the device, so `solution%interior` is **stale**
after `Adapt`. This is what the rest of the time loop already does, and `Write_DGModel3D_t` already
calls `UpdateHost` first. Multi-rank runs are unchanged: Stage-5 v1 migration allgathers the old
field on the host, so the `nRanks > 1` branch still routes through the optional `uGlobal` argument
to the portable transfer.

## A bug this found in 2-D

`ApplyTransferPlan_DGModel2D` guarded an unpaired apply with `c_associated(xferOld_gpu)`, but that
buffer is a persistent capacity buffer and is deliberately never released — so the guard only ever
fired before the **first** epoch. From the second on, an `ApplyTransferPlan` without its
`StageSolutionForTransfer` would silently transfer the previous epoch's field. Both dimensions now
key the guard on `xferNOld` and clear it after use, tracking the pairing the way the base
implementation's allocatable `transferStage` does. Fixing only 3-D would have left a mirrored pair
silently divergent.

(For the record, since it came up: this is a defensive guard on API misuse, not a live path. The
controller always pairs the two calls, and the multi-rank branch returns on `present(uGlobal)`
before reaching the guard at all. It is **not** related to #169.)

## Tests

- **`test/solution_transfer_3d_device.f90`** pins the kernel's output value by value against the
  portable `ApplyTransferPlanRange`. No test in either dimension compared the two; the AMR
  regressions only assert invariants (conservation, entropy non-growth) that a kernel with a
  transposed direction could still satisfy. The epoch is built to carry all three transfer kinds
  and prolongation depths 0–2, with a guard that fails loudly if it ever stops doing so. The
  driving field is non-polynomial and distinct in every variable: `LinearEuler3D` carries
  `nvar = 6`, of which `c` and `rho0` are static background fields, so a transfer that moved only
  the prognostic variables would blank the medium invisibly on a uniform-medium case.
- **`test/dgmodel3d_guard_transfer_reapply.f90`** covers the case the old guard missed —
  apply-without-stage after a successful epoch.

**Verified: 259/259 ctest on a CPU build, 242/242 on one B300** (215 serial, 27 MPI).

## Also in this PR

- **`examples/linear_euler3d_amr_spherical_soundwave.f90`** — there was no 3-D AMR example at all,
  which is why the 2-D-style before/after measurement was not previously possible in 3-D. It
  carries the 2-D examples' `BENCH_` instrumentation plus per-adaptation counters, since a
  whole-epoch metric mixes regrids with indicator-only no-ops and the number of adapting epochs is
  not guaranteed equal across backends. Defaults are CI-sized (6.4 s at `-O3`) and are explicitly
  *not* a benchmark configuration; the header states the invocation the figures were taken at.
- **Docs.** `docs/Learning/AdaptiveMeshRefinement.md` had **no 3-D content at all**; it gains a
  section on the 3-D stack, what differs from 2-D, the staging/apply protocol and host-mirror
  contract, and these measurements. `AMR3D-Design.md` moves off "Implementation plan", documents
  the transfer protocol and the delivered kernel, and joins the mkdocs nav, which it was missing
  from. `AMR2D-Design.md` still described the device transfer as a deferred "Phase 5" and
  amortized storage as future work; both shipped long ago.

## Still outstanding in 3-D (now stated in the docs)

- A coarsen-wake regression, the analogue of `lineareuler2d_amr_coarsen_wake`.
- Stage-5 v2 point-to-point migration — without which the device transfer cannot be used on more
  than one rank.
- A 3-D plotting script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
