### PR TITLE
AMR: point-to-point solution migration, replacing the allgather redistribution (#167)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,8 @@ option(SELF_ENABLE_DOUBLE_PRECISION "Option to enable double precision for float
 
 set(SELF_MPIEXEC_NUMPROCS "2" CACHE STRING "The number of MPI ranks to use to launch MPI tests. Only used when launching test programs via ctest.")
 set(SELF_MPIEXEC_OPTIONS "" CACHE STRING "Any additional options, such as binding options, to use for MPI tests.Only used when launching test programs via ctest. Defaults to nothing")
+set(SELF_MPIEXEC_NUMPROCS_MANY "4" CACHE STRING "The number of MPI ranks to use for the tests that need more than two ranks, such as the AMR point-to-point solution migration (two ranks cannot distinguish a routing bug there). Only used when launching test programs via ctest.")
+set(SELF_MPIEXEC_OPTIONS_MANY "" CACHE STRING "Additional options for the >2-rank MPI tests only, appended after SELF_MPIEXEC_OPTIONS. Defaults to --oversubscribe under Open MPI, whose default slot count on a small CI runner is often below SELF_MPIEXEC_NUMPROCS_MANY.")
 
 if(SELF_ENABLE_MULTITHREADING)
     set(SELF_MULITHREADING_NTHREADS "4" CACHE STRING "Number of threads to use for `do concurrent` loop blocks. This option is only used with GNU compilers. Other compilers use OMP_NUM_THREADS environment variable at runtime.")
@@ -132,6 +134,26 @@ endif()
 
 # MPI
 find_package(MPI COMPONENTS Fortran C REQUIRED)
+
+# The >2-rank MPI tests can ask for more ranks than a small CI machine has cores. Open MPI treats
+# cores as slots and refuses to launch in that case, so add --oversubscribe for it (only for those
+# tests, and only when the user has not set the option themselves). MPICH has no such flag and
+# needs none.
+#
+# The launcher is asked directly rather than trusting a FindMPI variable: MPI_Fortran_LIBRARY_-
+# VERSION_STRING is not populated for every MPI/CMake combination (it is absent for the Open MPI
+# builds used here), which would leave the check silently always-false.
+if(SELF_MPIEXEC_OPTIONS_MANY STREQUAL "" AND MPIEXEC_EXECUTABLE)
+    execute_process(COMMAND ${MPIEXEC_EXECUTABLE} --version
+                    OUTPUT_VARIABLE SELF_MPIEXEC_VERSION_OUT
+                    ERROR_VARIABLE SELF_MPIEXEC_VERSION_OUT
+                    OUTPUT_STRIP_TRAILING_WHITESPACE
+                    TIMEOUT 30)
+    if(SELF_MPIEXEC_VERSION_OUT MATCHES "Open MPI|OpenRTE|open-mpi")
+        set(SELF_MPIEXEC_OPTIONS_MANY "--oversubscribe" CACHE STRING "" FORCE)
+        message(STATUS "SELF Build System : Open MPI launcher detected; using --oversubscribe for the >2-rank tests")
+    endif()
+endif()
 
 # HDF5 : See https://cmake.org/cmake/help/latest/module/FindHDF5.html
 find_package(HDF5 REQUIRED Fortran)

--- a/docs/Contributing/AMR2D-Design.md
+++ b/docs/Contributing/AMR2D-Design.md
@@ -317,18 +317,31 @@ can reconstruct geometry per snapshot. Static-mesh outputs are untouched.
   element count is a valid balance measure because all elements share one
   polynomial degree.
 - **Consistent flags:** refine/coarsen flags for ghost-adjacent elements must
-  agree across ranks before 2:1 balancing. v1: `MPI_Allgatherv` of flags (one
-  int per element) so every rank runs identical balancing — deterministic and
-  simple; tree metadata is tiny compared to field data. Rank-local balancing
-  with ghost-layer exchange is a scalability follow-up.
+  agree across ranks before 2:1 balancing. `MPI_Allgatherv` of flags (one int
+  per element) so every rank runs identical balancing — deterministic and
+  simple; tree metadata is tiny compared to field data. *As built, unchanged in
+  v2.* Rank-local balancing with ghost-layer exchange is a scalability
+  follow-up.
 - **Redistribution:** old and new partitions are both contiguous over the same
-  deterministic ordering, so each rank computes exact send/recv ranges
-  (`MPI_Alltoallv` on packed solution payloads). Coarsening groups are applied
-  on the receiving side after redistribution so all four siblings are
-  resident.
+  deterministic ordering, so each rank computes exact send/recv ranges. This
+  plan called for `MPI_Alltoallv` on packed payloads. **As built:** v1 was
+  gather-then-slice (allgather the global old field, slice the new local range),
+  and v2 (#167) is matched nonblocking `MPI_Isend`/`MPI_Irecv` pairs — not
+  `Alltoallv`, for two reasons. Because the forest and the transfer plan are
+  replicated, every rank already knows exactly which peers it needs and how
+  much, so the count exchange that motivates `Alltoallv` is unnecessary; and
+  the pattern is sparse for a balanced repartition — a rank talks to a couple of
+  neighbours in leaf order rather than to everyone (a heavily skewed repartition
+  can reach every peer, which the implementation handles) — so a collective would
+  impose an all-ranks synchronization point on a mostly-zero schedule. Nothing is packed either: a run of elements
+  at a fixed variable is already contiguous in both the source and the
+  destination. Coarsening groups are still applied on the receiving side after
+  redistribution so all four siblings are resident. The normative description
+  is [AMR3D-Design.md](AMR3D-Design.md) §4, which covers both dimensions.
 - **Exchange table rebuild:** the aggregated halo tables (`decomp%halo_*`) and
-  every field's persistent halo requests are partition-specific and are
-  rebuilt lazily after step 4/6 above. The mortar sub-edge global side ids in
+  every field's persistent halo requests are partition-specific. As built, they
+  are torn down on `Resize`, so `Regrid` invalidates them and the next exchange
+  rebuilds them. The mortar sub-edge global side ids in
   the regenerated `mortarInfo` keep the MPI tag convention valid without any
   new machinery.
 - **Constraint compliance:** all collectives happen inside the adaptation
@@ -413,7 +426,7 @@ indicator, transfer, and re-initialization plumbing.
 | 0. Modal infrastructure | `pMatrix` in `Lagrange_t` + device mirrors, indicator math + unit tests | ~600 LOC |
 | 1. Quadtree mesh core | forest, 2:1 balancing, leaf + `sideInfo`/`mortarInfo` emission, `AMRMesh2D_t`, transfer operators (tensor products of mortar matrices), validity/transfer tests | ~1,500 LOC |
 | 2. Model integration (CPU) | `AMRController2D`, field re-init + BC/cache rebuild path, `amr_advection_diffusion_2d`, `AMRLinearEuler2D`, integration tests, examples | ~1,200 LOC |
-| 3. MPI | flag allgather, repartition + `Alltoallv` redistribution, halo/persistent-request invalidation, 2-rank tests | ~800 LOC |
+| 3. MPI | flag allgather, repartition + point-to-point redistribution (v1 gather-then-slice, v2 `Isend`/`Irecv`; §7), halo/persistent-request invalidation, 2- and 4-rank tests | ~800 LOC |
 | 4. GPU | indicator kernels + interfaces, device transfer apply, GPU CI tests | ~800 LOC |
 | 5. Hardening/perf | capacity-based device allocation, adaptation-cost profiling, threshold calibration docs, user docs | ~500 LOC |
 

--- a/docs/Contributing/AMR3D-Design.md
+++ b/docs/Contributing/AMR3D-Design.md
@@ -447,8 +447,12 @@ one can fail for a different reason:
   *tightness* (both ends are actually referenced, so nothing surplus moves), and
   that the windowed apply is bit-identical to the whole-field apply. It fails if
   the table stops reaching those configurations.
-- `transfer_plan_3d_guard_window` (`WILL_FAIL`): a window that does not cover a
-  referenced source must `stop 1` rather than read outside the array.
+- Three `WILL_FAIL` guards on the windowed apply, one per way a wrong window
+  fails: `transfer_plan_3d_guard_window` (the window misses a referenced
+  `sourceElem`), `..._guard_windowfamily` (it misses one of the eight children of
+  a coarsened family - the case that arises when a family straddled a rank
+  boundary), and `..._guard_windowbounds` (the window is not inside `1..nOld` at
+  all). Each must `stop 1` rather than read outside the array.
 - `amr_migrate_3d_window_mpi` (2 and 4 ranks): the real `ExchangeOldWindow`, on
   a deliberately ASYMMETRIC adaptation so old elements genuinely change rank.
   The old field is analytic and encodes each element's global index in its

--- a/docs/Contributing/AMR3D-Design.md
+++ b/docs/Contributing/AMR3D-Design.md
@@ -1,8 +1,10 @@
 # Design: Adaptive Mesh Refinement (AMR) for 3D Models — Octrees + Face Mortars
 
-**Status:** Implemented (Stages 1–6a) — mirrors the implemented 2D design.
-Stages 1–5 landed with #164; the device-resident solution transfer (Stage 6a's
-3D analogue) landed with #165. What is still outstanding from §6 is noted in
+**Status:** Implemented (Stages 1–6a, plus Stage-5 v2 point-to-point solution
+migration) — mirrors the implemented 2D design. Stages 1–5 landed with #164; the
+device-resident solution transfer (Stage 6a's 3D analogue) landed with #165;
+point-to-point migration, replacing the allgather-based redistribution in both
+2D and 3D, landed with #167. What is still outstanding from §7 is noted in
 that table. Sections written in the future tense below have been updated where
 the delivered code differs from the plan; where it does not, the plan text is
 the record of what was built.
@@ -199,13 +201,18 @@ call, consumed and deallocated by the second, and released in `Free`. Calling
 by `test/dgmodel3d_guard_transfer_unstaged.f90`, because the alternative is
 reading unallocated storage and failing somewhere less obvious.
 
-`ApplyTransferPlan` takes an optional `uGlobal` argument: the **multi-rank
-escape hatch**. The forest is rank-replicated and migration is gather-then-slice
-(2D Stage-5 v1), so on more than one rank the controller allgathers the old
-field on the host and passes it through `uGlobal`; each rank then fills exactly
-its own new contiguous element range and elements that changed ranks are
-migrated by construction. Because the allgather is inherently a host operation,
-that branch stays on the portable host transfer on every backend.
+`ApplyTransferPlan` takes an optional `uGlobal` argument, plus an optional
+`oldFirst`: the **multi-rank path**. On more than one rank the controller hands
+in host-side old-field data and each rank fills exactly its own new contiguous
+element range. Two forms exist. By default (Stage-5 v2, §4) `uGlobal` is the
+rank's *window* of the old field — the contiguous run of old elements its new
+range references — and `oldFirst` is that window's first global old element
+index, so the plan's global `sourceElem`/`family` indices still resolve
+correctly. Under `SELF_AMR_MIGRATE_GATHER=1` (Stage-5 v1) it is the whole
+allgathered global old field and `oldFirst` is absent, which is the same call
+with `oldFirst = 1`. Either way migration is a host operation, so that branch
+stays on the portable host transfer on every backend; serving the device
+transfer from a migrated window is the named follow-up to #167.
 
 **Device path.** On a single-rank GPU build both steps are overridden
 (`src/gpu/SELF_DGModel3D.f90`): staging is a device-to-device copy into a
@@ -215,7 +222,7 @@ worth knowing: the transferred solution is then left on the device and
 `solution%interior` (the host mirror) is **stale** after `Adapt`. That matches
 the rest of the time loop, where the device is authoritative, but it is a
 behaviour change from the host-only implementation, where the mirror happened to
-be fresh. See §4 for the kernel, and the Learning page for the measurements.
+be fresh. See §5 for the kernel, and the Learning page for the measurements.
 
 ### 2.9 Indicator
 
@@ -244,9 +251,10 @@ two-phase (device/host) split that keeps CPU and GPU flags identical.
   `BuildTransferPlan` walk over stable node ids, `EmitMesh` regeneration,
   geometry double-buffering with `CopyElements` reuse
   (`sourceKind == COPY` ⇒ same forest node ⇒ bit-identical coordinates),
-  `Regrid` via `Resize` (not Free+Init), Stage-5 v1 gather-then-slice
-  migration, `RecommendedTimeStep = dtBase/2**MaxLevel`, and the
-  `SELF_AMR_GEOM_{FULL,VERIFY,NO_REUSE}` diagnostics.
+  `Regrid` via `Resize` (not Free+Init), Stage-5 v2 point-to-point solution
+  migration (§4), `RecommendedTimeStep = dtBase/2**MaxLevel`, and the
+  `SELF_AMR_GEOM_{FULL,VERIFY,NO_REUSE}` and
+  `SELF_AMR_MIGRATE_{GATHER,VERIFY}` diagnostics.
 
 New 3D-side prerequisites (absent today, required by the controller):
 `Resize` on `Scalar3D`/`Vector3D`/`Tensor3D`/mapped variants,
@@ -260,7 +268,109 @@ its 2D counterpart.
 
 ---
 
-## 4. GPU strategy
+## 4. MPI strategy
+
+The 2D document's §7 sketched this; what follows is the record of what was built,
+for both dimensions, and it supersedes that sketch (see the note at the end).
+
+**Ordering and partition.** The global leaf order is base-mesh root order with
+Morton order inside each tree — deterministic and locality preserving. `EmitMesh`
+re-runs `GenerateDecomposition` over the new leaf count every epoch, so each rank
+owns the contiguous range `offsetElem(rank+1)+1 … offsetElem(rank+2)`. Equal
+element counts are a valid balance measure because every element carries the same
+polynomial degree. Repartitioning is therefore implicit in every epoch, and both
+the old and the new partition are contiguous ranges of *the same* leaf order —
+the fact everything below rests on.
+
+**Replicated state.** The forest is rank-replicated. At `Init`,
+`InitForestFromDecomposedMesh` allgathers the global base-mesh node coordinates,
+side table and material ids (once, at startup). Each epoch the rank-local
+indicator flags are allgathered (one `int` per element) and the indicator's
+amplitude gate is reduced with `MPI_MAX`, so every rank applies identical
+mutations and computes an identical transfer plan. Forest memory is therefore
+O(global elements) per rank; making the forest distributed is the p4est-style
+Stage-2 follow-up in #167 and is deliberately not attempted here.
+
+**Solution migration (Stage-5 v2, #167).** Migration moves only what changes
+rank:
+
+- *The window.* For a rank's new element range `[eFirst,eLast]`, the old
+  elements its plan entries read — `sourceElem`, or all eight `family` members
+  for a coarsened family — lie in a contiguous window `[wFirst,wLast]` of the old
+  element list. `PlanWindows` computes the min/max hull of those indices for
+  every rank in one pass over the plan. Correctness does not depend on the leaf
+  ordering being monotone: a non-monotone ordering only widens the hull, the worst
+  case being the whole old list, which is exactly what v1 moved. Locality, not
+  correctness, is what the space-filling curve buys.
+- *Routing needs no communication.* Because the plan and both `offsetElem` tables
+  are replicated, a rank computes its own window **and every peer's window**
+  locally. The run it must send to peer `r` is the intersection of its own old
+  range with peer `r`'s window; the run it must receive from peer `r` is the
+  intersection of its window with peer `r`'s old range. Both ends of a pair
+  evaluate the same `max`/`min` on the same integers, so the schedules match by
+  construction — there is no count exchange, no handshake, and no collective.
+- *The exchange.* `ExchangeOldWindow` posts all `MPI_Irecv`s before the matching
+  `MPI_Isend`s and closes with one `MPI_Waitall`, the same shape as every other
+  point-to-point exchange in SELF. Nothing is packed: a run of elements at a fixed
+  variable is contiguous in both `solution%interior` and the window buffer, so
+  each message reads and writes the real storage. That is one message per
+  (peer, variable) — a handful of peers for a balanced repartition, and bounded by
+  the rank count in the worst case — and it removes the pack buffer, the unpack loop and two whole-field copies.
+- *Tags.* The tag is the variable index. Ambiguity would require two messages
+  between the same ordered rank pair carrying the same variable in one exchange,
+  and each pair exchanges exactly one run per variable. The exchange is drained
+  before `Regrid`, so migration traffic never coexists with the side, mortar or
+  halo exchanges (which use `globalSideId + nUniqueSides*(ivar-1)`, or tag 0 for
+  the aggregated form) even though all of them share the mesh communicator.
+- *Sequencing.* The exchange runs **before** `model%Regrid`: `EmitMesh` has
+  already decomposed the new mesh, so both partitions are known, and the sends can
+  read the still-live pre-regrid solution. It also means no traffic is in flight
+  across `Regrid`, which rebuilds mesh and decomposition state on the same
+  communicator. Overlapping the two is a possible future optimization and would
+  need a tag space of its own.
+- *Coarsened families.* A family's eight children may be owned by different old
+  ranks. The window hull covers all eight, each child arrives from whichever rank
+  owned it, and `RestrictFromChildren` runs on the receiving rank in child-octant
+  order — so the projection's operand order, and therefore its result, is
+  independent of the partition.
+- *Degenerate cases.* A rank owning no new elements gets an empty window
+  (normalized to `wFirst=1, wLast=0`), posts no receives, skips the apply, and
+  still posts its sends, because peers may need old elements it owns. An empty
+  peer overlap is skipped identically on both sides.
+- *Memory.* The per-rank migration footprint is the window — local elements plus
+  the overhang past the rank's own old range — instead of a full global field. The
+  window buffer is a controller component, persistent and grow-only, so a settled
+  adapting run performs no allocation in this path.
+- *Bit-identity.* The two migrations are bit-identical, not merely close:
+  `ApplyTransferPlanRange` (v1) is `ApplyTransferPlanWindow` (v2) over the whole
+  old field, so both feed the same operands to the same operators in the same
+  order, and no reduction order changes. `SELF_AMR_MIGRATE_VERIFY=1` runs both in
+  one process and compares the window against the allgathered field value by
+  value; `SELF_AMR_MIGRATE_GATHER=1` selects v1 outright, keeping the retained
+  fallback exercised.
+
+**Exchange-table rebuild.** The aggregated halo tables (`decomp%halo_*`) and each
+field's persistent halo requests are partition-specific and are torn down on
+`Resize`, so `Regrid` invalidates them and the next exchange rebuilds them. The
+sub-face global side ids in the regenerated `mortarInfo` keep the tag convention
+valid with no new machinery.
+
+**Constraint compliance.** Every collective and every message lives in the
+adaptation epoch, between time steps — never in `CalculateTendency` or an RK
+stage (CLAUDE.md §5). The communicator is unchanged, no reduction is reordered,
+and the v1 collective path is retained behind an environment switch rather than
+deleted (CLAUDE.md §10).
+
+*Supersedes:* [AMR2D-Design.md](AMR2D-Design.md) §7 specified `MPI_Alltoallv` for
+redistribution. Replicated routing removes the count exchange that motivates
+`Alltoallv`, and the pattern is sparse for a balanced repartition — a rank talks to
+a couple of neighbours in leaf order rather than to everyone, with the worst case
+bounded by the rank count and handled — so matched `Isend`/`Irecv` pairs are both
+cheaper and free of an all-ranks synchronization point.
+
+---
+
+## 5. GPU strategy
 
 Same division of labor as 2D: numerics on device, adaptation logic on host.
 Kernels follow the existing files' pattern: 3D mortar gather/scatter and
@@ -299,7 +409,7 @@ entropy non-growth), which conservation arguments make exact either way.
 
 ---
 
-## 5. Testing & validation plan
+## 6. Testing & validation plan
 
 Serial/CPU (mirroring the 2D suite):
 - `mappedscalarmortarexchange_3d_linear`: linear field reproduced exactly
@@ -323,9 +433,37 @@ Serial/CPU (mirroring the 2D suite):
   guard-test inventory (controller decomp/maxlevel/wrongmesh, unbalanced
   emit, transfer-plan misuse, indicator argument guards, EC mortar guard).
 
-MPI (2 ranks): `mappedscalarmortarexchange_3d_linear_mpi`,
+MPI: `mappedscalarmortarexchange_3d_linear_mpi`,
 `lineareuler3d_mortar_soundwave_mpi`, `lineareuler3d_amr_soundwave_mpi`
 (partition-changing adaptation), `geometry_3d_reuse_mpi` + env-gated verify.
+
+Solution migration (§4, #167) is covered by four additions, chosen so that each
+one can fail for a different reason:
+
+- `transfer_plan_3d_window` (serial): drives `PlanWindows` and `OwnedRun` over a
+  table of hand-written (old, new) partition pairs a 2-rank run could never
+  produce - empty new ranges, empty old ranges, a window spanning four peers, a
+  window that is entirely remote - and checks window coverage, window
+  *tightness* (both ends are actually referenced, so nothing surplus moves), and
+  that the windowed apply is bit-identical to the whole-field apply. It fails if
+  the table stops reaching those configurations.
+- `transfer_plan_3d_guard_window` (`WILL_FAIL`): a window that does not cover a
+  referenced source must `stop 1` rather than read outside the array.
+- `amr_migrate_3d_window_mpi` (2 and 4 ranks): the real `ExchangeOldWindow`, on
+  a deliberately ASYMMETRIC adaptation so old elements genuinely change rank.
+  The old field is analytic and encodes each element's global index in its
+  values, so a misrouted element names itself. It asserts that at least one rank
+  received something from a peer - without that, a symmetric refinement can
+  leave every window local, the exchange a no-op, and a passing verify run
+  meaningless.
+- `SELF_AMR_MIGRATE_VERIFY=1` / `SELF_AMR_MIGRATE_GATHER=1` re-runs of the
+  existing AMR MPI regressions at 2 and 4 ranks: the first asserts v1 and v2
+  agree value for value in-process on real physics, the second keeps the
+  retained v1 path exercised.
+
+Two ranks are not enough on their own: with one peer the send and receive runs
+are forced and no window can straddle more than one peer, which is why the
+4-rank entries exist (`SELF_MPIEXEC_NUMPROCS_MANY`, default 4).
 
 GPU: the same integration tests through the Buildkite MI210/V100 pipelines;
 CPU/GPU flag and post-adapt solution agreement enforced by construction
@@ -333,7 +471,7 @@ CPU/GPU flag and post-adapt solution agreement enforced by construction
 
 ---
 
-## 6. Work breakdown & phasing
+## 7. Work breakdown & phasing
 
 | Stage | Content | Mirrors |
 |---|---|---|
@@ -341,7 +479,8 @@ CPU/GPU flag and post-adapt solution agreement enforced by construction
 | 2 | Octree forest, refinement primitives, uniform refine, `EmitMesh`, validity tests | AMR Stages 2/4a/4b |
 | 3 | Indicator 3D, transfer plan/solution transfer, `Resize`/geometry infrastructure, `Regrid`, controller, unit tests | AMR Stages 1/3/4 |
 | 4 | `lineareuler3d_amr_soundwave` (+ coarsen-wake) integration tests, example | #156/#162 |
-| 5 | MPI: forest-from-decomposed-mesh, flag allgather, gather-then-slice migration, 2-rank tests | Stage 5 |
+| 5 | MPI v1: forest-from-decomposed-mesh, flag allgather, gather-then-slice migration, 2-rank tests | Stage 5 |
+| 5b | MPI v2: point-to-point migration - windowed apply, `PlanWindows`/`OwnedRun`/`ExchangeOldWindow`, `MIGRATE_GATHER` fallback and `MIGRATE_VERIFY` diagnostic, 2- and 4-rank tests | Stage-5 v2 / #167 |
 | 6 | GPU: mortar/indicator/transfer kernels, device staging, geometry upload paths | Stage 6 |
 
 Delivery status: stages 1–3 and 5 landed with #164, together with the
@@ -351,17 +490,23 @@ solution transfer and its staging landed with #165 (`TransferSolution_3D_gpu`,
 `StageSolutionForTransfer_DGModel3D`, `ApplyTransferPlan_DGModel3D`), which also
 delivered stage 4's example, `linear_euler3d_amr_spherical_soundwave`.
 
+Stage 5b landed with #167, in both dimensions.
+
 Still outstanding: the 3D `coarsen-wake` regression (the analogue of
-`lineareuler2d_amr_coarsen_wake`), and the 3D analogues of 2D Stages 6b/6c
+`lineareuler2d_amr_coarsen_wake`); the 3D analogues of 2D Stages 6b/6c
 (amortized high-water-mark storage and geometry reuse) to the extent they are
-not already inherited from the shared data classes.
+not already inherited from the shared data classes; the device transfer on more
+than one rank (the migrated window lands in host memory, so a device-side window
+buffer and an old-element offset in the kernel are what remain); and the
+distributed forest, which is #167's Stage 2 and is deliberately deferred until
+measurement justifies it.
 
 Stages are landed as separate reviewable commits on one PR (or stacked PRs
 at maintainer preference), each leaving the suite green.
 
 ---
 
-## 7. Compliance with repository constraints (CLAUDE.md)
+## 8. Compliance with repository constraints (CLAUDE.md)
 
 Identical posture to the 2D work, which established the precedents:
 - The mortar interface discretization is the same formulation extension

--- a/docs/Learning/AdaptiveMeshRefinement.md
+++ b/docs/Learning/AdaptiveMeshRefinement.md
@@ -30,7 +30,7 @@ layer that adaptive refinement needs is already in place and tested.
 | Adaptation-epoch transfer plan (old-leaf → new-leaf mapping) | **Implemented** |
 | Model regrid (`DGModel2D%Regrid`) + AMR controller (serial, CPU/GPU) | **Implemented** |
 | Ultrasound point-source example + AMR visualization script | **Implemented** |
-| MPI dynamic re-partitioning / load balancing (v1: replicated forest, allgathered migration) | **Implemented** |
+| MPI dynamic re-partitioning / load balancing (v2: replicated forest, point-to-point migration) | **Implemented** |
 | GPU device re-allocation for a changing element count | **Implemented** (amortized high-water-mark storage, Stage 6b) |
 | Device-side solution transfer (no host round trip on one GPU) | **Implemented** (Stage 6a) |
 | Geometry reuse for unchanged elements across an epoch | **Implemented** (Stage 6c) |
@@ -578,18 +578,22 @@ Implemented in `SELF_SolutionTransfer_2D` (see §2.7):
 - **(next)** Optional **neighbour smoothing** of the trigger flags (avoid isolated refined
   elements), on top of the balance pass.
 
-### Stage 5 — MPI dynamic re-partitioning — **implemented (v1)**
+### Stage 5 — MPI dynamic re-partitioning — **implemented (v2)**
 
 *Status: implemented. `QuadTreeMesh2D%InitGlobal` builds the rank-replicated forest from
 allgathered global base tables; `EmitMesh` builds the global connectivity/mortar tables on
 every rank and stores only its contiguous slice of a freshly generated decomposition
 (`sideInfo(3)` global ids, global `nUniqueSides`, fully replicated `mortarInfo`, exactly the
 invariants `SideExchange`/`MortarExchange` require); the controller allgathers the indicator
-flags per epoch and migrates the solution through an allgathered global old field applied to
-the rank-local range (`ApplyTransferPlanRange`). Validated by
-`test/lineareuler2d_amr_soundwave_mpi.f90` (2 ranks): the global element trajectory and
+flags per epoch, and migration is point-to-point: each rank receives only the window of the old
+field its own new element range reads (5d below). Validated by
+`test/lineareuler2d_amr_soundwave_mpi.f90` at 2 and 4 ranks: the global element trajectory and
 entropy history match the serial run, transfers conserve globally, and a leaf-list checksum
-confirms forest replication. The point-to-point migration upgrade remains open (v2).*
+confirms forest replication — plus `SELF_AMR_MIGRATE_VERIFY=1` re-runs, which assert the
+migrated window matches the v1 allgathered field value for value, and the serial
+`test/transfer_plan_{2,3}d_window.f90` routing tables. The v1 gather-then-slice path is retained
+behind `SELF_AMR_MIGRATE_GATHER=1`. What remains open is the distributed forest, whose memory is
+still O(global elements) per rank (issue #167 Stage 2).*
 
 Two observations make a correct first version tractable:
 
@@ -613,11 +617,47 @@ Sub-stages:
   constructors do for `nRanks > 1`, so `SideExchange`/`MortarExchange` consume the result
   unchanged. Repartitioning is implicit: each epoch's emitted mesh is re-decomposed over the
   new leaf list, so equal-count SFC arcs move with the refinement.
-- **(5c) Solution migration.** v1: allgatherv the old rank-local solutions into a global old
-  field, then `ApplyTransferPlan` only for the new rank-local elements. Correct and simple;
-  memory is one global solution copy per rank (fine at single-node scale). The point-to-point
-  upgrade (send exactly the source elements each rank's plan references) is a drop-in
-  replacement behind the same interface.
+- **(5c) Solution migration, v1 — gather-then-slice, retained as a fallback.** Allgatherv the
+  old rank-local solutions into a global old field, then `ApplyTransferPlan` only for the new
+  rank-local elements. Correct and simple; memory and per-rank traffic are one global solution
+  copy per adapting epoch, which is fine at single-node scale and prohibitive beyond it. Still
+  reachable with `SELF_AMR_MIGRATE_GATHER=1`, and exercised in CI so it cannot rot.
+- **(5d) Solution migration, v2 — point-to-point windows (issue #167).** The default. Four
+  things make it simple:
+
+    1. *The window.* The old elements a rank's new range `[eFirst,eLast]` reads through the plan
+       — `sourceElem`, or all four (2-D) / eight (3-D) `family` members of a coarsened family —
+       lie in a contiguous window `[wFirst,wLast]` of the old element list, because both
+       partitions are contiguous ranges of the same leaf order. `PlanWindows` takes the min/max
+       hull of those indices in one pass over the plan. Correctness does not depend on the
+       ordering being monotone: a non-monotone ordering only widens the hull, and the worst case
+       is the whole old list — exactly what v1 moves. Locality, not correctness, is what the
+       space-filling curve buys.
+    2. *Routing needs no communication.* The plan and both `offsetElem` tables are replicated,
+       so a rank computes its own window **and every peer's**, and derives its send runs
+       (its old range ∩ a peer's window) and receive runs (its window ∩ a peer's old range)
+       locally. Both ends of a pair evaluate the same `max`/`min` on the same integers, so the
+       schedules match by construction — no count exchange, no handshake, no collective.
+    3. *Nothing is packed.* A run of elements at a fixed variable is contiguous in both
+       `solution%interior` and the window buffer, so each `MPI_Isend`/`MPI_Irecv` reads and
+       writes the real storage: one message per (peer, variable), a handful of peers, no pack
+       buffer and no unpack loop. (A rank talks to a couple of peers for a balanced repartition;
+       nothing bounds it to that, and a pathological repartition simply produces more, smaller
+       messages.) Receives are posted first and the exchange closes with one
+       `MPI_Waitall`, the shape every other SELF exchange uses. It runs *before* `Regrid`, so
+       the sends read the still-live pre-regrid solution and no traffic is in flight while
+       `Regrid` rebuilds mesh state on the same communicator.
+    4. *`ApplyTransferPlanWindow`* is what consumes it: `ApplyTransferPlanRange` (v1) is that
+       routine over the whole old field, so the two paths share one body and are **bit-identical**
+       — the same operands, the same operators, the same order, no reductions. That is a
+       guarantee, not a tolerance, and `SELF_AMR_MIGRATE_VERIFY=1` asserts it in-process.
+
+  A rank owning no new elements gets an empty window, posts no receives, and skips the apply,
+  but still serves its peers. A coarsened family whose children were owned by different ranks is
+  fully covered by the hull and projected on the receiving rank in child-octant order, so the
+  result does not depend on the partition. The per-rank migration footprint becomes the window —
+  local elements plus the overhang — instead of a full global field, in a controller-owned
+  grow-only buffer, so a settled adapting run allocates nothing here.
 - Tests on ≥ 2 ranks: forest determinism across ranks (identical leaf checksums after an
   epoch), global conservation of the transferred solution (mpi_allreduce), and the AMR
   soundwave regression run distributed.
@@ -712,7 +752,8 @@ between allocate/zero/free churn (`Init_SEMQuad` + `Free_SEMQuad`, 21.6%) and re
 - **Multi-rank.** `sourceElem` indexes the global old element list while a rank holds only its slice,
   so reuse additionally requires the source to be locally owned - a range test against the previous
   decomposition. On one rank that is always true; on several, migrated elements are regenerated. No
-  communication is added.
+  communication is added. (Geometry is therefore still *regenerated* rather than migrated when an
+  element changes rank, even though its solution now migrates point-to-point.)
 
 Measured: 72.8% of elements reused per epoch at maxLevel 3, rising to 76.5% at maxLevel 8. Adaptation
 cost 0.616 s -> 0.585 s, and the bone-and-marrow case 14.2% -> 10.7% AMR share.
@@ -724,7 +765,9 @@ test. `test/geometry_2d_reuse_mpi.f90` covers the multi-rank branch, asserting b
 regeneration actually fire and that the resulting mixed assembly equals a from-scratch generation
 exactly. Three env-gated switches (`SELF_AMR_GEOM_NO_REUSE`, `SELF_AMR_GEOM_FULL`,
 `SELF_AMR_GEOM_VERIFY`) allow a suspected geometry problem to be localized in one run without a
-rebuild.
+rebuild. Two more do the same for multi-rank solution migration: `SELF_AMR_MIGRATE_GATHER=1`
+selects the v1 allgather path, and `SELF_AMR_MIGRATE_VERIFY=1` runs both migrations and compares
+them value for value (§ Stage 5, 5d).
 
 ### A correctness bug the amortized scheme introduced
 
@@ -937,7 +980,8 @@ rationale.
 | Nonconforming mesh emission | Implemented | Implemented (face mortars) |
 | Transfer plan + solution transfer | Implemented | Implemented (`SELF_TransferPlan_3D`) |
 | Model regrid + AMR controller | Implemented | Implemented (`SELF_AMRController_3D`) |
-| MPI re-partitioning (replicated forest, allgathered migration) | Implemented (v1) | Implemented (v1) |
+| MPI re-partitioning (replicated forest, point-to-point migration) | Implemented (v2) | Implemented (v2) |
+| Migration diagnostics (`SELF_AMR_MIGRATE_*`) | Implemented | Implemented |
 | Device-side solution transfer | Implemented (Stage 6a) | **Implemented** (§6.4) |
 | Amortized high-water-mark storage | Implemented (Stage 6b) | Inherited via the shared data classes |
 | Geometry reuse across an epoch | Implemented (Stage 6c) | Implemented (`SELF_AMR_GEOM_*` switches) |
@@ -987,12 +1031,14 @@ portable implementation stages into a host array whose lifetime is exactly stage
 applying without a preceding stage is a hard error, pinned by
 `test/dgmodel3d_guard_transfer_unstaged.f90`.
 
-`ApplyTransferPlan` takes an optional `uGlobal`, the **multi-rank escape hatch**. The forest is
-rank-replicated and migration is gather-then-slice, so on more than one rank the controller
-allgathers the old field on the host and passes it through `uGlobal`; each rank then fills exactly
-its own new element range and elements that changed ranks are migrated by construction. That
-allgather is inherently a host operation, so the multi-rank branch stays on the portable host
-transfer on every backend, exactly as in 2-D.
+`ApplyTransferPlan` takes an optional `uGlobal` plus an optional `oldFirst`: the **multi-rank
+path**. On more than one rank the controller hands in host-side old-field data and each rank fills
+exactly its own new element range. By default `uGlobal` is the rank's *window* of the old field
+and `oldFirst` is that window's first global old element index, so the plan's global
+`sourceElem`/`family` indices still resolve (Stage-5 v2, § Stage 5); under
+`SELF_AMR_MIGRATE_GATHER=1` it is the whole allgathered global old field, which is the same call
+with `oldFirst = 1`. Either way migration lands in host memory, so the multi-rank branch stays on
+the portable host transfer on every backend, exactly as in 2-D.
 
 **Where the solution lives after `Adapt`.** On a single-rank GPU build the transferred solution is
 left on the **device**, so `solution%interior` (the host mirror) is **stale**. This matches the
@@ -1079,12 +1125,109 @@ by this change, and where the next 3-D optimization work belongs.
   gate's ability to release the mesh behind a passing front (§2.1.1). There is no 3-D analogue, so
   3-D coarsening is exercised only incidentally, by the soundwave regression and by the transfer
   tests' hand-built epochs.
-- **Point-to-point migration (Stage-5 v2).** Multi-rank runs still allgather the old field on the
-  host. Until that changes, the device transfer cannot be used on more than one rank, because the
-  migration it would have to feed from is a host operation.
+- **The device transfer on more than one rank.** Since #167 the old field reaches a rank
+  point-to-point rather than through an allgather, but it lands in host memory, so the multi-rank
+  branch still applies the plan on the host. Feeding the kernel instead needs a device-side window
+  buffer (the local part device-to-device, the received runs host-to-device) and one extra
+  old-element offset argument in `TransferSolution_3D_gpu`. That is the direct follow-up.
+- **A distributed forest.** The forest and the transfer plan are still replicated on every rank,
+  so forest memory is O(global elements) per rank and the per-epoch flag allgather remains. This is
+  issue #167's Stage 2 (the p4est-style design), deliberately deferred until measurement justifies
+  the much larger change: 2:1 balancing becomes a neighbourhood iteration, and the routing argument
+  that makes migration free of handshakes depends on the plan being replicated.
+- **Weighted partitioning.** The repartition is equal element count per rank, which is the right
+  balance measure only because every element carries the same degree.
 - **A 3-D visualization script.** 2-D ships `examples/linear_euler2d_amr_plot.py`. The 3-D
   example writes the same self-describing HDF5 snapshots (solution + geometry per file, so the
   changing mesh needs no special handling downstream) but no renderer is provided.
+
+### 6.6 Multi-rank migration in 3-D
+
+The mechanism is dimension-independent (§ Stage 5, 5d); what differs in 3-D is the price of getting
+it wrong. An element's payload is `(N+1)^3 * nvar` reals rather than `(N+1)^2 * nvar`, so a full
+field is large: at `maxLevel = 3` the example reaches 20,784 elements, which at 125 nodes and 6
+variables in double precision is **125 MB**. Under the v1 gather every rank received every element
+it did not own, once per adapting epoch, and allocated a second full field alongside the live one.
+Under v2 a rank receives only the old elements its new range reads from a peer, which for a
+balanced repartition is the load-imbalance slack at the ends of its range.
+
+The examples report this directly. `BENCH_migrateBytesRecv`, `BENCH_migrateBytesSent` and
+`BENCH_migrateElemRemote` are per-rank run totals, and both migration paths count them, so one
+binary measures both sides:
+
+```shell
+# after (default) vs before (v1), same binary, same mesh trajectory
+mpirun -n 4 ./examples/linear_euler3d_amr_spherical_soundwave
+SELF_AMR_MIGRATE_GATHER=1 mpirun -n 4 ./examples/linear_euler3d_amr_spherical_soundwave
+```
+
+Compare `BENCH_tAdapt_s / BENCH_nAdaptEpochs` - the cost of an *adapting* epoch - rather than the
+whole-epoch figure, which is diluted by indicator-only no-op epochs; and treat the comparison as
+void unless `BENCH_nAdaptEpochs` and `BENCH_nElemFinal` agree between the two runs, since
+otherwise the two took different mesh trajectories. `BENCH_tForwardStep_s` is the control: nothing
+was added to the time-stepping loop.
+
+#### What was measured
+
+**Communication volume**, from the 3-D spherical soundwave and the 2-D ultrasound point source at
+`maxLevel = 2` / `maxLevel = 4`, six epochs (five adapting), on a 12-thread CPU box. Per-rank
+totals over the run; both runs of a pair have identical `nAdaptEpochs` and `nElemFinal`, and the
+final pressure extrema agree to every printed digit. Note this is a *smaller* mesh than the 125 MB
+example above, which is an illustration of the full-field size at a deeper level, not a measurement
+of these runs.
+
+| case | ranks | received per rank, v1 | received per rank, v2 | remote elements v1 -> v2 |
+|---|---|---|---|---|
+| 3-D | 2 | 35.9 MB | **0** | 5988 -> 0 |
+| 3-D | 4 | 53.9 MB | **0.95 MB** | 8982 -> 159 |
+| 3-D | 8 | 62.9 MB | **1.80 MB** | 10479 -> 300 |
+| 2-D | 2 | 10.9 MB | **0** | 4242 -> 0 |
+| 2-D | 4 | 16.3 MB | **0.55 MB** | 6363 -> 215 |
+| 2-D | 8 | 19.0 MB | **0.28 MB** | 7420 -> 108 |
+
+These count **bytes arriving in a rank's own memory** - the quantity that sets the migration
+footprint - not total network traffic: what a collective moves internally depends on the algorithm
+the MPI implementation selects, which is not something to model from the outside. Read two things
+from the table. First, v1's received volume grows with rank count in both dimensions (each rank
+approaches "everyone else's whole field"), while v2's is set by how far the partition boundary
+actually moves. Second, at 2 ranks v2's traffic is exactly **zero**: a contiguous
+space-filling-curve repartition of a symmetric refinement leaves each rank's new range sourced
+entirely from its own old range - the windows printed under `SELF_AMR_MIGRATE_VERIFY=1` are
+`[1,256]` and `[257,512]`, precisely the two old ranges. That is a property of the refinement
+pattern, not of the mechanism: `test/amr_migrate_{2,3}d_window_mpi.f90` refines asymmetrically on
+purpose and asserts that elements do cross ranks (17 of them at 2 ranks, and at 4 ranks one rank's
+window is entirely remote while another's spans three peers), so a regression that silently made
+the exchange a no-op would fail there.
+
+Peak RSS is **not** a usable signal at this problem size: the deltas (16 MB at 2 ranks, 1 MB at 4,
+7 MB at 8) are smaller than and not proportional to the buffer removed, because the footprint is
+dominated by the replicated forest, the geometry double-buffers and the halo tables. The buffer
+that went away matters at scale, where it is O(global field) per rank; here it is not what sets the
+peak.
+
+**Adaptation time**, on one B300 node with four GPUs (CUDA sm_103, one rank per GPU), `maxLevel = 3`,
+ten adapting epochs, four repetitions per configuration with the two migration paths interleaved
+per repetition so warm-up cannot land preferentially on one of them. Median seconds per adapting
+epoch, with the observed range:
+
+| ranks | v1 gather | v2 point-to-point | received per rank, v1 -> v2 |
+|---|---|---|---|
+| 1 | 0.982 [0.914, 0.985] | 0.965 [0.961, 0.988] | 0 -> 0 (nothing migrates) |
+| 2 | 0.538 [0.525, 0.558] | 0.553 [0.528, 0.558] | 123.5 MB -> **0** |
+| 4 | 0.332 [0.296, 0.340] | 0.287 [0.286, 0.302] | 185.2 MB -> **1.5 MB** |
+
+At one rank the two are the same code path, and they measure the same - which is the check that
+the windowed apply and its bounds guard cost nothing on the path that does not migrate. At two
+ranks eliminating 123 MB per rank of host collective buys no measurable time: an allgather within
+one node is fast, and adaptation is dominated by geometry and the indicator. At four ranks the
+ranges no longer overlap and the point-to-point path is about 13% faster per adapting epoch. The
+volume reduction is the durable result; the time saved is what that volume happened to cost on this
+machine at this scale.
+
+`BENCH_tForwardStep_s` is unchanged between the two paths at every rank count, as it must be.
+(It does grow steeply with rank count on this node - 1.2 s, 4.7 s, 23.8 s - because the halo
+exchange runs through host memory in this container configuration. That is a pre-existing property
+of multi-rank GPU runs, identical in both paths, and unrelated to migration.)
 
 ---
 

--- a/examples/linear_euler2d_amr_ultrasound_pointsource.f90
+++ b/examples/linear_euler2d_amr_ultrasound_pointsource.f90
@@ -125,6 +125,7 @@ program LinearEuler2D_AMR_Ultrasound_PointSource
   integer :: nEpochs,epoch,i,envstat
   integer :: maxLevel
   logical :: adapted
+  integer :: nAdaptEpochs = 0 !! epochs that actually changed the mesh
   real(prec) :: e0,ef,dt
   real(prec) :: Lr,LrRamp,epochLength,hFinest,lambda,f0,ppw
   real(prec) :: relativeEnergyFloor,significantEnergyFloor
@@ -304,6 +305,7 @@ program LinearEuler2D_AMR_Ultrasound_PointSource
     tFwd = tFwd+real(c1clk-c0clk,real64)/real(crate,real64)
     tAdapt = tAdapt+real(c2clk-c1clk,real64)/real(crate,real64)
     nStepsTotal = nStepsTotal+int(epochLength/dt,int64)
+    if(adapted) nAdaptEpochs = nAdaptEpochs+1
     print*,"epoch",epoch,": t =",modelobj%t,", dt =",dt, &
       ", nElem =",modelobj%mesh%nElem,", adapted =",adapted
   enddo
@@ -322,6 +324,23 @@ program LinearEuler2D_AMR_Ultrasound_PointSource
   write(output_unit,'(A,ES16.7E3)') "BENCH_wallPerSimTime = ",tFwd/tSim
   write(output_unit,'(A,ES16.7E3)') "BENCH_wallPerSimTimeIncAMR = ",(tFwd+tAdapt)/tSim
   write(output_unit,'(A,ES16.7E3)') "BENCH_amrFraction = ",tAdapt/(tFwd+tAdapt)
+  ! An epoch whose leaf set is unchanged costs only an indicator pass, so the total above mixes
+  ! two very different quantities; the per-adaptation figure is the one to compare between builds
+  ! or between migration paths (the 3-D example reports the same key).
+  write(output_unit,'(A,I0)') "BENCH_nAdaptEpochs = ",nAdaptEpochs
+  if(nAdaptEpochs > 0) then
+    write(output_unit,'(A,ES16.7E3)') "BENCH_tAdaptPerAdaptation_s = ", &
+      tAdapt/real(nAdaptEpochs,real64)
+  endif
+  ! Migration volume (issue #167). These are per-RANK totals over the whole run, and they are the
+  ! primary comparison between the point-to-point migration and SELF_AMR_MIGRATE_GATHER=1: the
+  ! gather path receives every element the rank does not own on every adapting epoch, the
+  ! point-to-point path only the old elements its new range actually reads from a peer. Both
+  ! paths count, so the two runs are directly comparable. Zero on a single rank, where nothing
+  ! migrates at all.
+  write(output_unit,'(A,I0)') "BENCH_migrateBytesRecv = ",controller%nMigrateBytesRecv
+  write(output_unit,'(A,I0)') "BENCH_migrateBytesSent = ",controller%nMigrateBytesSent
+  write(output_unit,'(A,I0)') "BENCH_migrateElemRemote = ",controller%nMigrateElemRemote
   ! Geometry reuse (AMR Stage 6c): the share of elements whose geometry was carried forward from
   ! the previous epoch instead of being regenerated. This is what the incremental path buys.
   write(output_unit,'(A,I0)') "BENCH_geomReused = ",controller%nGeomReused

--- a/examples/linear_euler3d_amr_spherical_soundwave.f90
+++ b/examples/linear_euler3d_amr_spherical_soundwave.f90
@@ -362,6 +362,15 @@ program LinearEuler3D_AMR_SphericalSoundWave
     write(output_unit,'(A,ES16.7E3)') "BENCH_tAdaptPerAdaptation_s = ", &
       tAdapt/real(nAdaptEpochs,real64)
   endif
+  ! Migration volume (issue #167). These are per-RANK totals over the whole run, and they are the
+  ! primary comparison between the point-to-point migration and SELF_AMR_MIGRATE_GATHER=1: the
+  ! gather path receives every element the rank does not own on every adapting epoch, the
+  ! point-to-point path only the old elements its new range actually reads from a peer. Both
+  ! paths count, so the two runs are directly comparable. Zero on a single rank, where nothing
+  ! migrates at all.
+  write(output_unit,'(A,I0)') "BENCH_migrateBytesRecv = ",controller%nMigrateBytesRecv
+  write(output_unit,'(A,I0)') "BENCH_migrateBytesSent = ",controller%nMigrateBytesSent
+  write(output_unit,'(A,I0)') "BENCH_migrateElemRemote = ",controller%nMigrateElemRemote
   ! Geometry reuse (AMR Stage 6c): the share of elements whose geometry was carried forward from
   ! the previous epoch instead of being regenerated.
   write(output_unit,'(A,I0)') "BENCH_geomReused = ",controller%nGeomReused

--- a/src/SELF_AMRController_2D.f90
+++ b/src/SELF_AMRController_2D.f90
@@ -60,11 +60,20 @@ module SELF_AMRController_2D
 !! flags are allgathered (one small collective) so every rank applies identical mutations and
 !! computes identical transfer plans and global connectivity. EmitMesh re-decomposes the new
 !! leaf list into contiguous (space-filling-curve) ranges, so repartitioning and load balance
-!! are implicit in every epoch. Solution migration gathers the old rank-local solutions into a
-!! global field and applies the plan to the new rank-local range only - simple and correct at
-!! single-node scale; a point-to-point exchange is a drop-in replacement behind the same
-!! interface. All collectives run between time steps at the adaptation cadence; nothing is
-!! added to the time-stepping loop.
+!! are implicit in every epoch.
+!!
+!! Solution migration is point-to-point (Stage-5 v2). The old elements a rank's new element
+!! range reads through the plan form a contiguous WINDOW of the old element list, because both
+!! partitions are contiguous ranges of the same leaf order; and because the plan is replicated,
+!! every rank derives its own window and each peer's window locally - PlanWindows - with no
+!! communication at all. ExchangeOldWindow then moves exactly the runs that cross ranks with
+!! matched MPI_Isend/MPI_Irecv, so per-rank traffic and memory scale with what actually moves
+!! rather than with the global field. SELF_AMR_MIGRATE_GATHER=1 restores the v1 gather-then-
+!! slice migration (an allgathered global old field, sliced to the new rank-local range); the
+!! two are bit-identical, and SELF_AMR_MIGRATE_VERIFY=1 asserts that in-process.
+!!
+!! All communication runs between time steps at the adaptation cadence; nothing is added to the
+!! time-stepping loop.
 !!
 !! Because refinement halves the element scale per level, an explicit-stability time step
 !! chosen for the base mesh must shrink with the finest active level;
@@ -98,6 +107,15 @@ module SELF_AMRController_2D
   logical,save :: geomVerify = .false.
   logical,save :: geomFull = .false. !! SELF_AMR_GEOM_FULL=1: bypass the incremental path
 
+  !! Debug switches for the multi-rank solution migration, resolved in the same place:
+  !!
+  !!   SELF_AMR_MIGRATE_GATHER=1  migrate through the Stage-5 v1 allgather instead of the
+  !!                              point-to-point window exchange
+  !!   SELF_AMR_MIGRATE_VERIFY=1  run BOTH migrations and compare the received window against
+  !!                              the allgathered global field, bit for bit
+  logical,save :: migrateGather = .false.
+  logical,save :: migrateVerify = .false.
+
   type :: AMRController2D
     type(QuadTreeMesh2D) :: forest
     type(RefinementIndicator2D) :: indicator
@@ -122,6 +140,21 @@ module SELF_AMRController_2D
     !! elements avoided regeneration rather than leaving the payoff to be estimated.
     integer(int64) :: nGeomReused = 0
     integer(int64) :: nGeomGenerated = 0
+    !! Point-to-point solution migration state. xferWin holds this rank's window of the OLD
+    !! field - the contiguous run of old elements its new element range references - and is
+    !! persistent and grow-only, so a settled adapting run performs no allocation in the
+    !! migration path. It is flat because it is viewed through a rank-remapped pointer whose
+    !! element lower bound is the window's first GLOBAL old element index, which is the
+    !! numbering the transfer plan uses. winFirst/winLast hold that window for every rank.
+    real(prec),allocatable :: xferWin(:)
+    integer,allocatable :: winFirst(:)
+    integer,allocatable :: winLast(:)
+    !! Cumulative migration accounting, so the communication volume a repartition actually
+    !! costs is measured rather than estimated. Both migration paths count, so the two are
+    !! directly comparable in one binary.
+    integer(int64) :: nMigrateBytesRecv = 0
+    integer(int64) :: nMigrateBytesSent = 0
+    integer(int64) :: nMigrateElemRemote = 0 !! old elements received from other ranks
     integer :: ivar = SELF_AMR_ALLVARS !! driving variable for the indicator
     integer :: maxLevel = 1 !! refinement-level cap
     integer :: nHalo = 1 !! refine-flag halo-expansion passes
@@ -327,6 +360,229 @@ contains
 
   endsubroutine AllgatherPerElemReals
 
+  subroutine OwnedRun(offsetElem,r,first,last,a,b)
+    !! The run of elements that rank r-1 owns and that also lies in [first,last]: a..b, empty when
+    !! b < a. offsetElem is a decomposition's contiguous ownership table, so rank r-1 owns
+    !! offsetElem(r)+1 .. offsetElem(r+1).
+    !!
+    !! Both halves of the migration schedule are this one intersection, evaluated from replicated
+    !! tables: my receive run from peer r-1 is (my window) n (r-1's old range), and my send run to
+    !! peer r-1 is (r-1's window) n (my old range). Factored out so that the sender and the
+    !! receiver cannot drift apart, and so a serial test can exercise the arithmetic the exchange
+    !! actually uses rather than a copy of it.
+    implicit none
+    integer,intent(in) :: offsetElem(:)
+    integer,intent(in) :: r !! 1-based table index; the rank is r-1
+    integer,intent(in) :: first
+    integer,intent(in) :: last
+    integer,intent(out) :: a
+    integer,intent(out) :: b
+
+    a = max(first,offsetElem(r)+1)
+    b = min(last,offsetElem(r+1))
+
+  endsubroutine OwnedRun
+
+  subroutine PlanWindows(plan,nRanks,newOffset,winFirst,winLast)
+    !! For every rank r, the contiguous window [winFirst(r),winLast(r)] of GLOBAL old element
+    !! indices that rank r's new element range references through the transfer plan. The plan is
+    !! rank-replicated, so this is a purely local computation: no communication is needed to
+    !! learn what a peer wants, which is what makes the point-to-point migration cheap here.
+    !!
+    !! A rank owning no new elements gets the empty sentinel winFirst > winLast.
+    !!
+    !! Correctness does not depend on the leaf ordering being monotone in the old ordering: the
+    !! window is the min/max hull of the referenced indices, so a non-monotone ordering only
+    !! widens it, the worst case being the whole old element list - i.e. exactly what the v1
+    !! gather-then-slice migration moves. Efficiency, not correctness, rests on the
+    !! space-filling-curve locality.
+    !!
+    !! Cost is ONE pass over the plan, not nRanks x nNew: the rank loop partitions 1..nNew.
+    implicit none
+    type(TransferPlan2D),intent(in) :: plan
+    integer,intent(in) :: nRanks
+    integer,intent(in) :: newOffset(1:nRanks+1)
+    integer,intent(out) :: winFirst(1:nRanks)
+    integer,intent(out) :: winLast(1:nRanks)
+    ! Local
+    integer :: r,li,c,src
+
+    do r = 1,nRanks
+      winFirst(r) = plan%nOld+1
+      winLast(r) = 0
+      do li = newOffset(r)+1,newOffset(r+1)
+        if(plan%sourceKind(li) == SELF_TRANSFER_RESTRICT) then
+          do c = 1,4
+            src = plan%family(c,li)
+            winFirst(r) = min(winFirst(r),src)
+            winLast(r) = max(winLast(r),src)
+          enddo
+        else
+          src = plan%sourceElem(li)
+          winFirst(r) = min(winFirst(r),src)
+          winLast(r) = max(winLast(r),src)
+        endif
+      enddo
+    enddo
+
+  endsubroutine PlanWindows
+
+  subroutine ExchangeOldWindow(decomp,Np,nvar,nLocalOld,uLocal,winFirst,winLast, &
+                               wFirst,wLast,uWin,nBytesRecv,nBytesSent,nElemRemote)
+    !! Migrate the pre-regrid solution into this rank's old-element window with point-to-point
+    !! messages: the Stage-5 v2 replacement for allgathering the whole old field onto every rank.
+    !!
+    !! Each peer contributes exactly one contiguous run of old elements - the intersection of the
+    !! range it owned before the epoch with this rank's window - because both partitions are
+    !! contiguous ranges of the same leaf order. Both ends of a pair derive that run from the
+    !! same replicated offsetElem and window tables with the same integer arithmetic, so the
+    !! send and receive lists match by construction: no handshake, no collective, and nothing to
+    !! agree on at run time.
+    !!
+    !! Nothing is packed. A run of elements at a fixed variable is contiguous in both the source
+    !! (%interior) and the destination (the window), so each message reads and writes the real
+    !! storage directly; that costs one message per (peer,variable) instead of one per peer. For
+    !! a balanced repartition the peer count is a small handful; nothing bounds it to that, so the
+    !! request arrays are sized for the worst case of every rank.
+    !!
+    !! The whole window is written every epoch, not just the elements the plan reads: the local
+    !! part plus the per-peer runs tile [wFirst,wLast] exactly once, because the old partition
+    !! tiles the old element list. So uWin carries nothing stale from a previous epoch even
+    !! though the buffer is reused, and the verification path may compare all of it.
+    !!
+    !! Runs once per adapting epoch, between time steps - never inside the time-stepping loop.
+    implicit none
+    type(DomainDecomposition),intent(in) :: decomp
+    integer,intent(in) :: Np !! nodes per direction (N+1)
+    integer,intent(in) :: nvar
+    integer,intent(in) :: nLocalOld !! elements this rank owned before the epoch
+    real(prec),intent(in) :: uLocal(1:Np,1:Np,1:nLocalOld,1:nvar)
+    integer,intent(in) :: winFirst(1:decomp%nRanks)
+    integer,intent(in) :: winLast(1:decomp%nRanks)
+    integer,intent(in) :: wFirst !! this rank's window, normalized (wFirst > wLast if empty)
+    integer,intent(in) :: wLast
+    real(prec),intent(inout) :: uWin(1:Np,1:Np,wFirst:wLast,1:nvar)
+    !! intent(inout), not out: the receives write it through MPI rather than through the dummy,
+    !! and an intent(out) dummy would license a compiler to treat it as undefined on entry.
+    integer(int64),intent(inout) :: nBytesRecv
+    integer(int64),intent(inout) :: nBytesSent
+    integer(int64),intent(inout) :: nElemRemote
+    ! Local
+    integer :: r,iv,a,b,cnt,e,msgCount,ierror
+    integer :: myFirst,perElem,nbyte
+    integer,allocatable :: requests(:),stats(:,:)
+
+    myFirst = decomp%offsetElem(decomp%rankId+1)+1
+    ! storage_size, not the kind value prec: the two coincide for the kinds SELF uses, but only
+    ! the intrinsic actually reports a width, and these counters are quoted as bytes.
+    nbyte = storage_size(1.0_prec)/8
+    perElem = Np*Np
+
+    allocate(requests(1:2*nvar*decomp%nRanks))
+    allocate(stats(MPI_STATUS_SIZE,1:2*nvar*decomp%nRanks))
+    msgCount = 0
+
+    ! Receives first, as everywhere else in SELF: the runs of my window that other ranks own.
+    do r = 1,decomp%nRanks
+      if(r-1 == decomp%rankId) cycle
+      call OwnedRun(decomp%offsetElem,r,wFirst,wLast,a,b)
+      if(b < a) cycle
+      cnt = perElem*(b-a+1)
+      nBytesRecv = nBytesRecv+int(cnt,int64)*nvar*nbyte
+      nElemRemote = nElemRemote+int(b-a+1,int64)
+      do iv = 1,nvar
+        msgCount = msgCount+1
+        call MPI_IRECV(uWin(1,1,a,iv),cnt,decomp%mpiPrec, &
+                       r-1,iv,decomp%mpiComm,requests(msgCount),ierror)
+      enddo
+    enddo
+
+    ! Sends: the runs of my old range that other ranks' windows need.
+    do r = 1,decomp%nRanks
+      if(r-1 == decomp%rankId) cycle
+      call OwnedRun(decomp%offsetElem,decomp%rankId+1,winFirst(r),winLast(r),a,b)
+      if(b < a) cycle
+      cnt = perElem*(b-a+1)
+      nBytesSent = nBytesSent+int(cnt,int64)*nvar*nbyte
+      do iv = 1,nvar
+        msgCount = msgCount+1
+        call MPI_ISEND(uLocal(1,1,a-myFirst+1,iv),cnt,decomp%mpiPrec, &
+                       r-1,iv,decomp%mpiComm,requests(msgCount),ierror)
+      enddo
+    enddo
+
+    ! The part of my window I already own, copied while the messages are in flight.
+    call OwnedRun(decomp%offsetElem,decomp%rankId+1,wFirst,wLast,a,b)
+    do iv = 1,nvar
+      do e = a,b
+        uWin(1:Np,1:Np,e,iv) = uLocal(1:Np,1:Np,e-myFirst+1,iv)
+      enddo
+    enddo
+
+    if(msgCount > 0) then
+      call MPI_WAITALL(msgCount,requests(1:msgCount), &
+                       stats(1:MPI_STATUS_SIZE,1:msgCount),ierror)
+    endif
+
+    deallocate(requests,stats)
+
+  endsubroutine ExchangeOldWindow
+
+  subroutine VerifyMigration(decomp,Np,nvar,nOld,nLocalOld,uLocal,wFirst,wLast,uWin)
+    !! Cross-check a migrated window against the v1 allgathered global old field, bit for bit,
+    !! over the whole window. Diagnostic only; gated by SELF_AMR_MIGRATE_VERIFY. Bit-identity is
+    !! the design guarantee (the same numbers routed differently, then fed to the same operators
+    !! in the same order), so any difference at all is a routing defect and stops the run.
+    implicit none
+    type(DomainDecomposition),intent(in) :: decomp
+    integer,intent(in) :: Np
+    integer,intent(in) :: nvar
+    integer,intent(in) :: nOld
+    integer,intent(in) :: nLocalOld
+    real(prec),intent(in) :: uLocal(1:Np,1:Np,1:nLocalOld,1:nvar)
+    integer,intent(in) :: wFirst
+    integer,intent(in) :: wLast
+    real(prec),intent(in) :: uWin(1:Np,1:Np,wFirst:wLast,1:nvar)
+    ! Local
+    integer :: iv,e,i,j,nbad
+    real(prec),allocatable :: uRef(:,:,:,:)
+
+    allocate(uRef(1:Np,1:Np,1:nOld,1:nvar))
+    do iv = 1,nvar
+      call AllgatherPerElemReals(decomp,Np*Np,uLocal(:,:,:,iv),uRef(:,:,:,iv))
+    enddo
+
+    nbad = 0
+    do iv = 1,nvar
+      do e = wFirst,wLast
+        do j = 1,Np
+          do i = 1,Np
+            if(uWin(i,j,e,iv) /= uRef(i,j,e,iv)) then
+              if(nbad == 0) then
+                print*,"MIGRATE_VERIFY mismatch on rank",decomp%rankId, &
+                  " old element",e," variable",iv," node",i,j, &
+                  " window value",uWin(i,j,e,iv)," gathered value",uRef(i,j,e,iv)
+              endif
+              nbad = nbad+1
+            endif
+          enddo
+        enddo
+      enddo
+    enddo
+
+    deallocate(uRef)
+
+    if(nbad > 0) then
+      print*,__FILE__,':',__LINE__, &
+        ' : Error : the migrated window differs from the allgathered old field in ',nbad, &
+        ' values.'
+      stop 1
+    endif
+
+    print*,"MIGRATE_VERIFY rank",decomp%rankId," window",wFirst,wLast," matches the gather"
+
+  endsubroutine VerifyMigration
+
   subroutine BuildGeometry_AMRController2D(this,newMesh,plan,newGeom,nReused)
     !! Fill newGeom for the emitted mesh, reusing the previous epoch's geometry for every element
     !! that did not change and generating only the rest (AMR Stage 6c). nReused reports how many
@@ -437,7 +693,9 @@ contains
   endsubroutine BuildGeometry_AMRController2D
 
   subroutine ResolveGeomDebug()
-    !! Read the Stage 6c geometry debug switches once.
+    !! Read the Stage 6c geometry and the solution-migration debug switches once. Idempotent, so
+    !! it is safe (and intended) to call from every path that consults a switch rather than
+    !! relying on one caller having run first.
     implicit none
     character(8) :: envstr
     integer :: envstat
@@ -451,10 +709,16 @@ contains
     if(envstat == 0) geomVerify = (trim(envstr) == "1")
     call get_environment_variable("SELF_AMR_GEOM_FULL",envstr,status=envstat)
     if(envstat == 0) geomFull = (trim(envstr) == "1")
+    call get_environment_variable("SELF_AMR_MIGRATE_GATHER",envstr,status=envstat)
+    if(envstat == 0) migrateGather = (trim(envstr) == "1")
+    call get_environment_variable("SELF_AMR_MIGRATE_VERIFY",envstr,status=envstat)
+    if(envstat == 0) migrateVerify = (trim(envstr) == "1")
 
     if(geomNoReuse) print*,"SELF_AMR_GEOM_NO_REUSE: geometry reuse disabled"
     if(geomVerify) print*,"SELF_AMR_GEOM_VERIFY: cross-checking incremental geometry"
     if(geomFull) print*,"SELF_AMR_GEOM_FULL: incremental geometry bypassed"
+    if(migrateGather) print*,"SELF_AMR_MIGRATE_GATHER: migrating through the v1 allgather"
+    if(migrateVerify) print*,"SELF_AMR_MIGRATE_VERIFY: cross-checking the migrated window"
 
   endsubroutine ResolveGeomDebug
 
@@ -569,6 +833,12 @@ contains
     this%interp => null()
     this%ownsActive = .false.
     if(allocated(this%energyWeights)) deallocate(this%energyWeights)
+    if(allocated(this%xferWin)) deallocate(this%xferWin)
+    if(allocated(this%winFirst)) deallocate(this%winFirst)
+    if(allocated(this%winLast)) deallocate(this%winLast)
+    this%nMigrateBytesRecv = 0
+    this%nMigrateBytesSent = 0
+    this%nMigrateElemRemote = 0
 
   endsubroutine Free_AMRController2D
 
@@ -587,11 +857,15 @@ contains
     !! mirror happened to be fresh here because the transfer ran on the host; do not rely on
     !! that. On CPU builds host and device are the same storage and the question does not arise.
     implicit none
-    class(AMRController2D),intent(inout) :: this
+    ! target: the migration window buffer is a component of this, and the windowed apply is fed
+    ! through a pointer remapped onto it (see step 6), which requires the target attribute here.
+    class(AMRController2D),intent(inout),target :: this
     class(DGModel2D_t),intent(inout) :: model
     logical,intent(out) :: adapted
     ! Local
     integer :: li,s,pass,node,nbr,ns,nf,nOld,Np,changed,eFirst,eLast,iv
+    integer :: nR,nWin,wFirst,wLast
+    real(prec),pointer :: uWin(:,:,:,:)
     integer,allocatable :: flag(:),spread(:)
     integer,allocatable :: oldLeaf(:)
     integer,allocatable :: leafIdx(:)
@@ -713,20 +987,87 @@ contains
     ! GPU backend stages device-to-device and applies the plan in a kernel, so an adapting run
     ! on one GPU moves no solution data across the host link at all (Stage 6a).
     !
-    ! On several ranks the old field must first be assembled globally, because each rank then
-    ! fills exactly its new contiguous element range and elements that changed ranks are
-    ! migrated by construction (Stage-5 v1 migration). That allgather is a host operation, so
-    ! the multi-rank path stays on the portable host transfer: a device transfer only pays off
-    ! there once migration is point-to-point (Stage-5 v2).
+    ! On several ranks the rank that will own a new element and the rank that owned its old
+    ! source need not be the same, so old-field data has to move. Both partitions are contiguous
+    ! ranges of the same leaf order and the plan is rank-replicated, so each rank computes the
+    ! contiguous WINDOW of old elements its own new range references (PlanWindows) and receives
+    ! exactly that window point-to-point (ExchangeOldWindow) - Stage-5 v2. Per-rank traffic and
+    ! memory are then set by what actually moves rather than by the size of the global field.
+    ! SELF_AMR_MIGRATE_GATHER=1 selects the v1 allgather instead; the two are bit-identical, and
+    ! SELF_AMR_MIGRATE_VERIFY=1 asserts that in-process.
+    !
+    ! The exchange runs BEFORE Regrid: EmitMesh has already decomposed the new mesh, so both
+    ! partitions are known, the sends can read the still-live pre-regrid solution, and no
+    ! point-to-point traffic is left in flight across Regrid - which works on the same
+    ! communicator with its own tag conventions.
+    !
+    ! Either way migration is a host operation, so the multi-rank path stays on the portable
+    ! host transfer; serving the device transfer from a migrated window is the follow-up to #167.
+    call ResolveGeomDebug()
     eFirst = -1 ! set below, once newMesh's decomposition is known
-    if(model%mesh%decomp%nRanks > 1) then
+    if(model%mesh%decomp%nRanks > 1 .and. .not. migrateGather) then
       Np = this%interp%N+1
+      nR = model%mesh%decomp%nRanks
+      if(.not. allocated(this%winFirst)) allocate(this%winFirst(1:nR),this%winLast(1:nR))
+
+      call PlanWindows(plan,nR,newMesh%decomp%offsetElem,this%winFirst,this%winLast)
+
+      eFirst = newMesh%decomp%offsetElem(newMesh%decomp%rankId+1)+1
+      eLast = newMesh%decomp%offsetElem(newMesh%decomp%rankId+2)
+      wFirst = this%winFirst(newMesh%decomp%rankId+1)
+      wLast = this%winLast(newMesh%decomp%rankId+1)
+      if(eLast < eFirst) then ! this rank owns no new elements: empty window
+        wFirst = 1
+        wLast = 0
+      endif
+
+      ! Persistent, grow-only window buffer, viewed through a pointer whose element lower bound
+      ! is the window's first global old element index. Remapping (rather than passing a section
+      ! of a rank-4 capacity array) keeps the actual argument exactly shaped and contiguous, so
+      ! no compiler temporary of the capacity array can appear.
+      nWin = Np*Np*max(wLast-wFirst+1,0)*model%nvar
+      if(.not. allocated(this%xferWin)) allocate(this%xferWin(1:max(nWin,1)))
+      if(nWin > size(this%xferWin)) then
+        deallocate(this%xferWin)
+        allocate(this%xferWin(1:nWin))
+      endif
+      uWin(1:Np,1:Np,wFirst:wLast,1:model%nvar) => this%xferWin(1:nWin)
+
+      call model%solution%UpdateHost()
+      call ExchangeOldWindow(model%mesh%decomp,Np,model%nvar,model%solution%nElem, &
+                             model%solution%interior,this%winFirst,this%winLast, &
+                             wFirst,wLast,uWin,this%nMigrateBytesRecv, &
+                             this%nMigrateBytesSent,this%nMigrateElemRemote)
+      if(migrateVerify) then
+        call VerifyMigration(model%mesh%decomp,Np,model%nvar,nOld,model%solution%nElem, &
+                             model%solution%interior,wFirst,wLast,uWin)
+      endif
+
+      call model%Regrid(newMesh,newGeom)
+
+      ! A rank that owns no new elements has nothing to fill; it still took part in the
+      ! exchange above, because peers may need old elements it owns.
+      if(eLast >= eFirst) then
+        call model%ApplyTransferPlan(plan,this%interp,eFirst,eLast,uWin,wFirst)
+      endif
+      uWin => null()
+    elseif(model%mesh%decomp%nRanks > 1) then
+      Np = this%interp%N+1
+      nR = model%mesh%decomp%nRanks
       allocate(uOld(1:Np,1:Np,1:nOld,1:model%nvar))
       call model%solution%UpdateHost()
       do iv = 1,model%nvar
         call AllgatherPerElemReals(model%mesh%decomp,Np*Np, &
                                    model%solution%interior(:,:,:,iv),uOld(:,:,:,iv))
       enddo
+      ! v1 volume, counted the same way as v2 so the two are directly comparable: every rank
+      ! receives every element it does not own, and sends its own elements to every other rank.
+      this%nMigrateElemRemote = this%nMigrateElemRemote+ &
+                                int(nOld-model%solution%nElem,int64)
+      this%nMigrateBytesRecv = this%nMigrateBytesRecv+int(nOld-model%solution%nElem,int64)* &
+                               Np*Np*model%nvar*(storage_size(1.0_prec)/8)
+      this%nMigrateBytesSent = this%nMigrateBytesSent+int(model%solution%nElem,int64)*(nR-1)* &
+                               Np*Np*model%nvar*(storage_size(1.0_prec)/8)
 
       call model%Regrid(newMesh,newGeom)
 

--- a/src/SELF_AMRController_3D.f90
+++ b/src/SELF_AMRController_3D.f90
@@ -62,11 +62,20 @@ module SELF_AMRController_3D
 !! allgathered (one small collective) so every rank applies identical mutations and computes
 !! identical transfer plans and global connectivity. EmitMesh re-decomposes the new leaf
 !! list into contiguous (space-filling-curve) ranges, so repartitioning and load balance are
-!! implicit in every epoch. Solution migration gathers the old rank-local solutions into a
-!! global field and applies the plan to the new rank-local range only - simple and correct
-!! at single-node scale; a point-to-point exchange is a drop-in replacement behind the same
-!! interface. All collectives run between time steps at the adaptation cadence; nothing is
-!! added to the time-stepping loop.
+!! implicit in every epoch.
+!!
+!! Solution migration is point-to-point (Stage-5 v2). The old elements a rank's new element
+!! range reads through the plan form a contiguous WINDOW of the old element list, because both
+!! partitions are contiguous ranges of the same leaf order; and because the plan is replicated,
+!! every rank derives its own window and each peer's window locally - PlanWindows - with no
+!! communication at all. ExchangeOldWindow then moves exactly the runs that cross ranks with
+!! matched MPI_Isend/MPI_Irecv, so per-rank traffic and memory scale with what actually moves
+!! rather than with the global field. SELF_AMR_MIGRATE_GATHER=1 restores the v1 gather-then-
+!! slice migration (an allgathered global old field, sliced to the new rank-local range); the
+!! two are bit-identical, and SELF_AMR_MIGRATE_VERIFY=1 asserts that in-process.
+!!
+!! All communication runs between time steps at the adaptation cadence; nothing is added to the
+!! time-stepping loop.
 !!
 !! Because refinement halves the element scale per level, an explicit-stability time step
 !! chosen for the base mesh must shrink with the finest active level;
@@ -99,6 +108,15 @@ module SELF_AMRController_3D
   logical,save :: geomVerify = .false.
   logical,save :: geomFull = .false. !! SELF_AMR_GEOM_FULL=1: bypass the incremental path
 
+  !! Debug switches for the multi-rank solution migration, resolved in the same place:
+  !!
+  !!   SELF_AMR_MIGRATE_GATHER=1  migrate through the Stage-5 v1 allgather instead of the
+  !!                              point-to-point window exchange
+  !!   SELF_AMR_MIGRATE_VERIFY=1  run BOTH migrations and compare the received window against
+  !!                              the allgathered global field, bit for bit
+  logical,save :: migrateGather = .false.
+  logical,save :: migrateVerify = .false.
+
   type :: AMRController3D
     type(OctreeMesh3D) :: forest
     type(RefinementIndicator3D) :: indicator
@@ -123,6 +141,21 @@ module SELF_AMRController_3D
     !! avoided regeneration rather than leaving the payoff to be estimated.
     integer(int64) :: nGeomReused = 0
     integer(int64) :: nGeomGenerated = 0
+    !! Point-to-point solution migration state. xferWin holds this rank's window of the OLD
+    !! field - the contiguous run of old elements its new element range references - and is
+    !! persistent and grow-only, so a settled adapting run performs no allocation in the
+    !! migration path. It is flat because it is viewed through a rank-remapped pointer whose
+    !! element lower bound is the window's first GLOBAL old element index, which is the
+    !! numbering the transfer plan uses. winFirst/winLast hold that window for every rank.
+    real(prec),allocatable :: xferWin(:)
+    integer,allocatable :: winFirst(:)
+    integer,allocatable :: winLast(:)
+    !! Cumulative migration accounting, so the communication volume a repartition actually
+    !! costs is measured rather than estimated. Both migration paths count, so the two are
+    !! directly comparable in one binary.
+    integer(int64) :: nMigrateBytesRecv = 0
+    integer(int64) :: nMigrateBytesSent = 0
+    integer(int64) :: nMigrateElemRemote = 0 !! old elements received from other ranks
     integer :: ivar = SELF_AMR_ALLVARS !! driving variable for the indicator
     integer :: maxLevel = 1 !! refinement-level cap
     integer :: nHalo = 1 !! refine-flag halo-expansion passes
@@ -329,6 +362,231 @@ contains
 
   endsubroutine AllgatherPerElemReals
 
+  subroutine OwnedRun(offsetElem,r,first,last,a,b)
+    !! The run of elements that rank r-1 owns and that also lies in [first,last]: a..b, empty when
+    !! b < a. offsetElem is a decomposition's contiguous ownership table, so rank r-1 owns
+    !! offsetElem(r)+1 .. offsetElem(r+1).
+    !!
+    !! Both halves of the migration schedule are this one intersection, evaluated from replicated
+    !! tables: my receive run from peer r-1 is (my window) n (r-1's old range), and my send run to
+    !! peer r-1 is (r-1's window) n (my old range). Factored out so that the sender and the
+    !! receiver cannot drift apart, and so a serial test can exercise the arithmetic the exchange
+    !! actually uses rather than a copy of it.
+    implicit none
+    integer,intent(in) :: offsetElem(:)
+    integer,intent(in) :: r !! 1-based table index; the rank is r-1
+    integer,intent(in) :: first
+    integer,intent(in) :: last
+    integer,intent(out) :: a
+    integer,intent(out) :: b
+
+    a = max(first,offsetElem(r)+1)
+    b = min(last,offsetElem(r+1))
+
+  endsubroutine OwnedRun
+
+  subroutine PlanWindows(plan,nRanks,newOffset,winFirst,winLast)
+    !! For every rank r, the contiguous window [winFirst(r),winLast(r)] of GLOBAL old element
+    !! indices that rank r's new element range references through the transfer plan. The plan is
+    !! rank-replicated, so this is a purely local computation: no communication is needed to
+    !! learn what a peer wants, which is what makes the point-to-point migration cheap here.
+    !!
+    !! A rank owning no new elements gets the empty sentinel winFirst > winLast.
+    !!
+    !! Correctness does not depend on the leaf ordering being monotone in the old ordering: the
+    !! window is the min/max hull of the referenced indices, so a non-monotone ordering only
+    !! widens it, the worst case being the whole old element list - i.e. exactly what the v1
+    !! gather-then-slice migration moves. Efficiency, not correctness, rests on the
+    !! space-filling-curve locality.
+    !!
+    !! Cost is ONE pass over the plan, not nRanks x nNew: the rank loop partitions 1..nNew.
+    implicit none
+    type(TransferPlan3D),intent(in) :: plan
+    integer,intent(in) :: nRanks
+    integer,intent(in) :: newOffset(1:nRanks+1)
+    integer,intent(out) :: winFirst(1:nRanks)
+    integer,intent(out) :: winLast(1:nRanks)
+    ! Local
+    integer :: r,li,c,src
+
+    do r = 1,nRanks
+      winFirst(r) = plan%nOld+1
+      winLast(r) = 0
+      do li = newOffset(r)+1,newOffset(r+1)
+        if(plan%sourceKind(li) == SELF_TRANSFER_RESTRICT) then
+          do c = 1,8
+            src = plan%family(c,li)
+            winFirst(r) = min(winFirst(r),src)
+            winLast(r) = max(winLast(r),src)
+          enddo
+        else
+          src = plan%sourceElem(li)
+          winFirst(r) = min(winFirst(r),src)
+          winLast(r) = max(winLast(r),src)
+        endif
+      enddo
+    enddo
+
+  endsubroutine PlanWindows
+
+  subroutine ExchangeOldWindow(decomp,Np,nvar,nLocalOld,uLocal,winFirst,winLast, &
+                               wFirst,wLast,uWin,nBytesRecv,nBytesSent,nElemRemote)
+    !! Migrate the pre-regrid solution into this rank's old-element window with point-to-point
+    !! messages: the Stage-5 v2 replacement for allgathering the whole old field onto every rank.
+    !!
+    !! Each peer contributes exactly one contiguous run of old elements - the intersection of the
+    !! range it owned before the epoch with this rank's window - because both partitions are
+    !! contiguous ranges of the same leaf order. Both ends of a pair derive that run from the
+    !! same replicated offsetElem and window tables with the same integer arithmetic, so the
+    !! send and receive lists match by construction: no handshake, no collective, and nothing to
+    !! agree on at run time.
+    !!
+    !! Nothing is packed. A run of elements at a fixed variable is contiguous in both the source
+    !! (%interior) and the destination (the window), so each message reads and writes the real
+    !! storage directly; that costs one message per (peer,variable) instead of one per peer. For
+    !! a balanced repartition the peer count is a small handful; nothing bounds it to that, so the
+    !! request arrays are sized for the worst case of every rank.
+    !!
+    !! The whole window is written every epoch, not just the elements the plan reads: the local
+    !! part plus the per-peer runs tile [wFirst,wLast] exactly once, because the old partition
+    !! tiles the old element list. So uWin carries nothing stale from a previous epoch even
+    !! though the buffer is reused, and the verification path may compare all of it.
+    !!
+    !! Runs once per adapting epoch, between time steps - never inside the time-stepping loop.
+    implicit none
+    type(DomainDecomposition),intent(in) :: decomp
+    integer,intent(in) :: Np !! nodes per direction (N+1)
+    integer,intent(in) :: nvar
+    integer,intent(in) :: nLocalOld !! elements this rank owned before the epoch
+    real(prec),intent(in) :: uLocal(1:Np,1:Np,1:Np,1:nLocalOld,1:nvar)
+    integer,intent(in) :: winFirst(1:decomp%nRanks)
+    integer,intent(in) :: winLast(1:decomp%nRanks)
+    integer,intent(in) :: wFirst !! this rank's window, normalized (wFirst > wLast if empty)
+    integer,intent(in) :: wLast
+    real(prec),intent(inout) :: uWin(1:Np,1:Np,1:Np,wFirst:wLast,1:nvar)
+    !! intent(inout), not out: the receives write it through MPI rather than through the dummy,
+    !! and an intent(out) dummy would license a compiler to treat it as undefined on entry.
+    integer(int64),intent(inout) :: nBytesRecv
+    integer(int64),intent(inout) :: nBytesSent
+    integer(int64),intent(inout) :: nElemRemote
+    ! Local
+    integer :: r,iv,a,b,cnt,e,msgCount,ierror
+    integer :: myFirst,perElem,nbyte
+    integer,allocatable :: requests(:),stats(:,:)
+
+    myFirst = decomp%offsetElem(decomp%rankId+1)+1
+    ! storage_size, not the kind value prec: the two coincide for the kinds SELF uses, but only
+    ! the intrinsic actually reports a width, and these counters are quoted as bytes.
+    nbyte = storage_size(1.0_prec)/8
+    perElem = Np*Np*Np
+
+    allocate(requests(1:2*nvar*decomp%nRanks))
+    allocate(stats(MPI_STATUS_SIZE,1:2*nvar*decomp%nRanks))
+    msgCount = 0
+
+    ! Receives first, as everywhere else in SELF: the runs of my window that other ranks own.
+    do r = 1,decomp%nRanks
+      if(r-1 == decomp%rankId) cycle
+      call OwnedRun(decomp%offsetElem,r,wFirst,wLast,a,b)
+      if(b < a) cycle
+      cnt = perElem*(b-a+1)
+      nBytesRecv = nBytesRecv+int(cnt,int64)*nvar*nbyte
+      nElemRemote = nElemRemote+int(b-a+1,int64)
+      do iv = 1,nvar
+        msgCount = msgCount+1
+        call MPI_IRECV(uWin(1,1,1,a,iv),cnt,decomp%mpiPrec, &
+                       r-1,iv,decomp%mpiComm,requests(msgCount),ierror)
+      enddo
+    enddo
+
+    ! Sends: the runs of my old range that other ranks' windows need.
+    do r = 1,decomp%nRanks
+      if(r-1 == decomp%rankId) cycle
+      call OwnedRun(decomp%offsetElem,decomp%rankId+1,winFirst(r),winLast(r),a,b)
+      if(b < a) cycle
+      cnt = perElem*(b-a+1)
+      nBytesSent = nBytesSent+int(cnt,int64)*nvar*nbyte
+      do iv = 1,nvar
+        msgCount = msgCount+1
+        call MPI_ISEND(uLocal(1,1,1,a-myFirst+1,iv),cnt,decomp%mpiPrec, &
+                       r-1,iv,decomp%mpiComm,requests(msgCount),ierror)
+      enddo
+    enddo
+
+    ! The part of my window I already own, copied while the messages are in flight.
+    call OwnedRun(decomp%offsetElem,decomp%rankId+1,wFirst,wLast,a,b)
+    do iv = 1,nvar
+      do e = a,b
+        uWin(1:Np,1:Np,1:Np,e,iv) = uLocal(1:Np,1:Np,1:Np,e-myFirst+1,iv)
+      enddo
+    enddo
+
+    if(msgCount > 0) then
+      call MPI_WAITALL(msgCount,requests(1:msgCount), &
+                       stats(1:MPI_STATUS_SIZE,1:msgCount),ierror)
+    endif
+
+    deallocate(requests,stats)
+
+  endsubroutine ExchangeOldWindow
+
+  subroutine VerifyMigration(decomp,Np,nvar,nOld,nLocalOld,uLocal,wFirst,wLast,uWin)
+    !! Cross-check a migrated window against the v1 allgathered global old field, bit for bit,
+    !! over the whole window. Diagnostic only; gated by SELF_AMR_MIGRATE_VERIFY. Bit-identity is
+    !! the design guarantee (the same numbers routed differently, then fed to the same operators
+    !! in the same order), so any difference at all is a routing defect and stops the run.
+    implicit none
+    type(DomainDecomposition),intent(in) :: decomp
+    integer,intent(in) :: Np
+    integer,intent(in) :: nvar
+    integer,intent(in) :: nOld
+    integer,intent(in) :: nLocalOld
+    real(prec),intent(in) :: uLocal(1:Np,1:Np,1:Np,1:nLocalOld,1:nvar)
+    integer,intent(in) :: wFirst
+    integer,intent(in) :: wLast
+    real(prec),intent(in) :: uWin(1:Np,1:Np,1:Np,wFirst:wLast,1:nvar)
+    ! Local
+    integer :: iv,e,i,j,k,nbad
+    real(prec),allocatable :: uRef(:,:,:,:,:)
+
+    allocate(uRef(1:Np,1:Np,1:Np,1:nOld,1:nvar))
+    do iv = 1,nvar
+      call AllgatherPerElemReals(decomp,Np*Np*Np,uLocal(:,:,:,:,iv),uRef(:,:,:,:,iv))
+    enddo
+
+    nbad = 0
+    do iv = 1,nvar
+      do e = wFirst,wLast
+        do k = 1,Np
+          do j = 1,Np
+            do i = 1,Np
+              if(uWin(i,j,k,e,iv) /= uRef(i,j,k,e,iv)) then
+                if(nbad == 0) then
+                  print*,"MIGRATE_VERIFY mismatch on rank",decomp%rankId, &
+                    " old element",e," variable",iv," node",i,j,k, &
+                    " window value",uWin(i,j,k,e,iv)," gathered value",uRef(i,j,k,e,iv)
+                endif
+                nbad = nbad+1
+              endif
+            enddo
+          enddo
+        enddo
+      enddo
+    enddo
+
+    deallocate(uRef)
+
+    if(nbad > 0) then
+      print*,__FILE__,':',__LINE__, &
+        ' : Error : the migrated window differs from the allgathered old field in ',nbad, &
+        ' values.'
+      stop 1
+    endif
+
+    print*,"MIGRATE_VERIFY rank",decomp%rankId," window",wFirst,wLast," matches the gather"
+
+  endsubroutine VerifyMigration
+
   subroutine BuildGeometry_AMRController3D(this,newMesh,plan,newGeom,nReused)
     !! Fill newGeom for the emitted mesh, reusing the previous epoch's geometry for every
     !! element that did not change and generating only the rest. nReused reports how many
@@ -440,7 +698,9 @@ contains
   endsubroutine BuildGeometry_AMRController3D
 
   subroutine ResolveGeomDebug()
-    !! Read the incremental-geometry debug switches once.
+    !! Read the incremental-geometry and solution-migration debug switches once. Idempotent, so
+    !! it is safe (and intended) to call from every path that consults a switch rather than
+    !! relying on one caller having run first.
     implicit none
     character(8) :: envstr
     integer :: envstat
@@ -454,10 +714,16 @@ contains
     if(envstat == 0) geomVerify = (trim(envstr) == "1")
     call get_environment_variable("SELF_AMR_GEOM_FULL",envstr,status=envstat)
     if(envstat == 0) geomFull = (trim(envstr) == "1")
+    call get_environment_variable("SELF_AMR_MIGRATE_GATHER",envstr,status=envstat)
+    if(envstat == 0) migrateGather = (trim(envstr) == "1")
+    call get_environment_variable("SELF_AMR_MIGRATE_VERIFY",envstr,status=envstat)
+    if(envstat == 0) migrateVerify = (trim(envstr) == "1")
 
     if(geomNoReuse) print*,"SELF_AMR_GEOM_NO_REUSE: geometry reuse disabled"
     if(geomVerify) print*,"SELF_AMR_GEOM_VERIFY: cross-checking incremental geometry"
     if(geomFull) print*,"SELF_AMR_GEOM_FULL: incremental geometry bypassed"
+    if(migrateGather) print*,"SELF_AMR_MIGRATE_GATHER: migrating through the v1 allgather"
+    if(migrateVerify) print*,"SELF_AMR_MIGRATE_VERIFY: cross-checking the migrated window"
 
   endsubroutine ResolveGeomDebug
 
@@ -574,6 +840,12 @@ contains
     this%interp => null()
     this%ownsActive = .false.
     if(allocated(this%energyWeights)) deallocate(this%energyWeights)
+    if(allocated(this%xferWin)) deallocate(this%xferWin)
+    if(allocated(this%winFirst)) deallocate(this%winFirst)
+    if(allocated(this%winLast)) deallocate(this%winLast)
+    this%nMigrateBytesRecv = 0
+    this%nMigrateBytesSent = 0
+    this%nMigrateElemRemote = 0
 
   endsubroutine Free_AMRController3D
 
@@ -594,11 +866,15 @@ contains
     !! the question does not arise. The multi-rank path still transfers on the host (see step 6),
     !! so both mirrors are fresh there.
     implicit none
-    class(AMRController3D),intent(inout) :: this
+    ! target: the migration window buffer is a component of this, and the windowed apply is fed
+    ! through a pointer remapped onto it (see step 6), which requires the target attribute here.
+    class(AMRController3D),intent(inout),target :: this
     class(DGModel3D_t),intent(inout) :: model
     logical,intent(out) :: adapted
     ! Local
     integer :: li,s,pass,node,nbr,ns,nf,nOld,Np,changed,eFirst,eLast,iv
+    integer :: nR,nWin,wFirst,wLast
+    real(prec),pointer :: uWin(:,:,:,:,:)
     integer,allocatable :: flag(:),spread(:)
     integer,allocatable :: oldLeaf(:)
     integer,allocatable :: leafIdx(:)
@@ -722,20 +998,87 @@ contains
     ! per-element tensor-product interpolation onto the device - which is where the measured
     ! saving comes from - and incidentally leaves no solution data crossing the host link.
     !
-    ! On several ranks the old field must first be assembled globally, because each rank then
-    ! fills exactly its new contiguous element range and elements that changed ranks are
-    ! migrated by construction (the 2-D Stage-5 v1 migration). That allgather is a host
-    ! operation, so the multi-rank path stays on the portable host transfer: a device transfer
-    ! only pays off there once migration is point-to-point (Stage-5 v2).
+    ! On several ranks the rank that will own a new element and the rank that owned its old
+    ! source need not be the same, so old-field data has to move. Both partitions are contiguous
+    ! ranges of the same leaf order and the plan is rank-replicated, so each rank computes the
+    ! contiguous WINDOW of old elements its own new range references (PlanWindows) and receives
+    ! exactly that window point-to-point (ExchangeOldWindow) - Stage-5 v2. Per-rank traffic and
+    ! memory are then set by what actually moves rather than by the size of the global field.
+    ! SELF_AMR_MIGRATE_GATHER=1 selects the v1 allgather instead; the two are bit-identical, and
+    ! SELF_AMR_MIGRATE_VERIFY=1 asserts that in-process.
+    !
+    ! The exchange runs BEFORE Regrid: EmitMesh has already decomposed the new mesh, so both
+    ! partitions are known, the sends can read the still-live pre-regrid solution, and no
+    ! point-to-point traffic is left in flight across Regrid - which works on the same
+    ! communicator with its own tag conventions.
+    !
+    ! Either way migration is a host operation, so the multi-rank path stays on the portable
+    ! host transfer; serving the device transfer from a migrated window is the follow-up to #167.
+    call ResolveGeomDebug()
     eFirst = -1 ! set below, once newMesh's decomposition is known
-    if(model%mesh%decomp%nRanks > 1) then
+    if(model%mesh%decomp%nRanks > 1 .and. .not. migrateGather) then
       Np = this%interp%N+1
+      nR = model%mesh%decomp%nRanks
+      if(.not. allocated(this%winFirst)) allocate(this%winFirst(1:nR),this%winLast(1:nR))
+
+      call PlanWindows(plan,nR,newMesh%decomp%offsetElem,this%winFirst,this%winLast)
+
+      eFirst = newMesh%decomp%offsetElem(newMesh%decomp%rankId+1)+1
+      eLast = newMesh%decomp%offsetElem(newMesh%decomp%rankId+2)
+      wFirst = this%winFirst(newMesh%decomp%rankId+1)
+      wLast = this%winLast(newMesh%decomp%rankId+1)
+      if(eLast < eFirst) then ! this rank owns no new elements: empty window
+        wFirst = 1
+        wLast = 0
+      endif
+
+      ! Persistent, grow-only window buffer, viewed through a pointer whose element lower bound
+      ! is the window's first global old element index. Remapping (rather than passing a section
+      ! of a rank-5 capacity array) keeps the actual argument exactly shaped and contiguous, so
+      ! no compiler temporary of the capacity array can appear.
+      nWin = Np*Np*Np*max(wLast-wFirst+1,0)*model%nvar
+      if(.not. allocated(this%xferWin)) allocate(this%xferWin(1:max(nWin,1)))
+      if(nWin > size(this%xferWin)) then
+        deallocate(this%xferWin)
+        allocate(this%xferWin(1:nWin))
+      endif
+      uWin(1:Np,1:Np,1:Np,wFirst:wLast,1:model%nvar) => this%xferWin(1:nWin)
+
+      call model%solution%UpdateHost()
+      call ExchangeOldWindow(model%mesh%decomp,Np,model%nvar,model%solution%nElem, &
+                             model%solution%interior,this%winFirst,this%winLast, &
+                             wFirst,wLast,uWin,this%nMigrateBytesRecv, &
+                             this%nMigrateBytesSent,this%nMigrateElemRemote)
+      if(migrateVerify) then
+        call VerifyMigration(model%mesh%decomp,Np,model%nvar,nOld,model%solution%nElem, &
+                             model%solution%interior,wFirst,wLast,uWin)
+      endif
+
+      call model%Regrid(newMesh,newGeom)
+
+      ! A rank that owns no new elements has nothing to fill; it still took part in the
+      ! exchange above, because peers may need old elements it owns.
+      if(eLast >= eFirst) then
+        call model%ApplyTransferPlan(plan,this%interp,eFirst,eLast,uWin,wFirst)
+      endif
+      uWin => null()
+    elseif(model%mesh%decomp%nRanks > 1) then
+      Np = this%interp%N+1
+      nR = model%mesh%decomp%nRanks
       allocate(uOld(1:Np,1:Np,1:Np,1:nOld,1:model%nvar))
       call model%solution%UpdateHost()
       do iv = 1,model%nvar
         call AllgatherPerElemReals(model%mesh%decomp,Np*Np*Np, &
                                    model%solution%interior(:,:,:,:,iv),uOld(:,:,:,:,iv))
       enddo
+      ! v1 volume, counted the same way as v2 so the two are directly comparable: every rank
+      ! receives every element it does not own, and sends its own elements to every other rank.
+      this%nMigrateElemRemote = this%nMigrateElemRemote+ &
+                                int(nOld-model%solution%nElem,int64)
+      this%nMigrateBytesRecv = this%nMigrateBytesRecv+int(nOld-model%solution%nElem,int64)* &
+                               Np*Np*Np*model%nvar*(storage_size(1.0_prec)/8)
+      this%nMigrateBytesSent = this%nMigrateBytesSent+int(model%solution%nElem,int64)*(nR-1)* &
+                               Np*Np*Np*model%nvar*(storage_size(1.0_prec)/8)
 
       call model%Regrid(newMesh,newGeom)
 

--- a/src/SELF_DGModel2D_t.f90
+++ b/src/SELF_DGModel2D_t.f90
@@ -202,13 +202,16 @@ contains
 
   endsubroutine StageSolutionForTransfer_DGModel2D_t
 
-  subroutine ApplyTransferPlan_DGModel2D_t(this,plan,interp,eFirst,eLast,uGlobal)
+  subroutine ApplyTransferPlan_DGModel2D_t(this,plan,interp,eFirst,eLast,uGlobal,oldFirst)
     !! Transfer the staged pre-regrid solution onto the regridded mesh through plan, filling the
     !! rank-local element range [eFirst,eLast] of the new solution.
     !!
-    !! uGlobal is optional and supplies the GLOBAL old field when the caller has already
-    !! assembled one (the multi-rank allgather path); when absent the locally staged copy from
-    !! StageSolutionForTransfer is used, which is the whole field on a single rank.
+    !! uGlobal is optional and supplies old-field data the caller has already assembled; when
+    !! absent the locally staged copy from StageSolutionForTransfer is used, which is the whole
+    !! field on a single rank. oldFirst is the global old element index of uGlobal's first
+    !! element: absent (or 1) means uGlobal is the whole global old field (the Stage-5 v1
+    !! allgather path), while the point-to-point migration (v2) passes the window it received
+    !! together with the window's first global old element index.
     !!
     !! This base implementation runs the portable host transfer and uploads the result; the GPU
     !! backend overrides it to run the transfer on the device with no host traffic.
@@ -220,11 +223,17 @@ contains
     type(Lagrange),intent(in) :: interp
     integer,intent(in) :: eFirst
     integer,intent(in) :: eLast
-    real(prec),intent(in),optional :: uGlobal(:,:,:,:)
+    real(prec),intent(in),optional,contiguous :: uGlobal(:,:,:,:)
+    integer,intent(in),optional :: oldFirst
+    ! Local
+    integer :: o1,o2
 
     if(present(uGlobal)) then
-      call ApplyTransferPlanRange(plan,interp,this%nvar,uGlobal,eFirst,eLast, &
-                                  this%solution%interior)
+      o1 = 1
+      if(present(oldFirst)) o1 = oldFirst
+      o2 = o1+size(uGlobal,3)-1
+      call ApplyTransferPlanWindow(plan,interp,this%nvar,uGlobal,o1,o2,eFirst,eLast, &
+                                   this%solution%interior)
     else
       if(.not. allocated(this%transferStage)) then
         print*,__FILE__,':',__LINE__, &

--- a/src/SELF_DGModel3D_t.f90
+++ b/src/SELF_DGModel3D_t.f90
@@ -262,13 +262,16 @@ contains
 
   endsubroutine StageSolutionForTransfer_DGModel3D_t
 
-  subroutine ApplyTransferPlan_DGModel3D_t(this,plan,interp,eFirst,eLast,uGlobal)
+  subroutine ApplyTransferPlan_DGModel3D_t(this,plan,interp,eFirst,eLast,uGlobal,oldFirst)
     !! Transfer the staged pre-regrid solution onto the regridded mesh through plan, filling the
     !! rank-local element range [eFirst,eLast] of the new solution.
     !!
-    !! uGlobal is optional and supplies the GLOBAL old field when the caller has already
-    !! assembled one (the multi-rank allgather path); when absent the locally staged copy from
-    !! StageSolutionForTransfer is used, which is the whole field on a single rank.
+    !! uGlobal is optional and supplies old-field data the caller has already assembled; when
+    !! absent the locally staged copy from StageSolutionForTransfer is used, which is the whole
+    !! field on a single rank. oldFirst is the global old element index of uGlobal's first
+    !! element: absent (or 1) means uGlobal is the whole global old field (the Stage-5 v1
+    !! allgather path), while the point-to-point migration (v2) passes the window it received
+    !! together with the window's first global old element index.
     !!
     !! This base implementation runs the portable host transfer and uploads the result; a
     !! device-resident transfer override is the 3-D analogue of the 2-D Stage 6a optimization.
@@ -280,11 +283,17 @@ contains
     type(Lagrange),intent(in) :: interp
     integer,intent(in) :: eFirst
     integer,intent(in) :: eLast
-    real(prec),intent(in),optional :: uGlobal(:,:,:,:,:)
+    real(prec),intent(in),optional,contiguous :: uGlobal(:,:,:,:,:)
+    integer,intent(in),optional :: oldFirst
+    ! Local
+    integer :: o1,o2
 
     if(present(uGlobal)) then
-      call ApplyTransferPlanRange(plan,interp,this%nvar,uGlobal,eFirst,eLast, &
-                                  this%solution%interior)
+      o1 = 1
+      if(present(oldFirst)) o1 = oldFirst
+      o2 = o1+size(uGlobal,4)-1
+      call ApplyTransferPlanWindow(plan,interp,this%nvar,uGlobal,o1,o2,eFirst,eLast, &
+                                   this%solution%interior)
     else
       if(.not. allocated(this%transferStage)) then
         print*,__FILE__,':',__LINE__, &

--- a/src/SELF_TransferPlan_2D.f90
+++ b/src/SELF_TransferPlan_2D.f90
@@ -232,14 +232,48 @@ contains
   subroutine ApplyTransferPlanRange(plan,interp,nVar,uOld,eFirst,eLast,uNew)
     !! Execute the contiguous sub-range eFirst..eLast of a transfer plan: uNew(:,:,k,:)
     !! receives the data of new element eFirst+k-1. uOld is the full (global) old field; the
-    !! output is only the requested slice. This is the decomposed-mesh (AMR Stage 5) entry
-    !! point: each rank passes its own contiguous range of the new element ordering and a
-    !! gathered global old solution, and fills exactly its rank-local storage.
+    !! output is only the requested slice. This is the gather-then-slice (AMR Stage-5 v1)
+    !! decomposed-mesh entry point: each rank passes its own contiguous range of the new
+    !! element ordering and a gathered global old solution, and fills exactly its rank-local
+    !! storage. ApplyTransferPlanWindow is the point-to-point (v2) entry point, which needs
+    !! only the sub-range of the old field the requested new range actually references; this
+    !! routine is that one over the whole old field, so the two are bit-identical by
+    !! construction rather than by inspection.
     implicit none
     type(TransferPlan2D),intent(in) :: plan
     type(Lagrange),intent(in) :: interp
     integer,intent(in) :: nVar
     real(prec),intent(in) :: uOld(1:interp%N+1,1:interp%N+1,1:plan%nOld,1:nVar)
+    integer,intent(in) :: eFirst
+    integer,intent(in) :: eLast
+    real(prec),intent(out) :: uNew(1:interp%N+1,1:interp%N+1,1:eLast-eFirst+1,1:nVar)
+
+    call ApplyTransferPlanWindow(plan,interp,nVar,uOld,1,plan%nOld,eFirst,eLast,uNew)
+
+  endsubroutine ApplyTransferPlanRange
+
+  subroutine ApplyTransferPlanWindow(plan,interp,nVar,uOld,oldFirst,oldLast,eFirst,eLast,uNew)
+    !! Execute the contiguous sub-range eFirst..eLast of a transfer plan against a WINDOW of
+    !! the old field: uOld holds old elements oldFirst..oldLast only, indexed in the global old
+    !! element numbering that plan%sourceElem and plan%family use, rather than the whole global
+    !! field. uNew(:,:,k,:) receives the data of new element eFirst+k-1.
+    !!
+    !! This is the point-to-point migration (AMR Stage-5 v2) entry point. Because both the old
+    !! and the new partition are contiguous ranges of the same space-filling-curve leaf order,
+    !! the old elements a rank's new range references form a contiguous window that a rank
+    !! computes locally from the (rank-replicated) plan - see PlanWindows in the AMR
+    !! controllers - and receives point-to-point instead of allgathering the global field.
+    !!
+    !! Units and layout are those of MappedScalar2D %interior. The transfer operators are
+    !! unchanged, so the operator identities hold as documented in the module header: exact
+    !! prolongation, conservative L2 restriction.
+    implicit none
+    type(TransferPlan2D),intent(in) :: plan
+    type(Lagrange),intent(in) :: interp
+    integer,intent(in) :: nVar
+    integer,intent(in) :: oldFirst
+    integer,intent(in) :: oldLast
+    real(prec),intent(in) :: uOld(1:interp%N+1,1:interp%N+1,oldFirst:oldLast,1:nVar)
     integer,intent(in) :: eFirst
     integer,intent(in) :: eLast
     real(prec),intent(out) :: uNew(1:interp%N+1,1:interp%N+1,1:eLast-eFirst+1,1:nVar)
@@ -257,6 +291,12 @@ contains
         ' : Error : ApplyTransferPlanRange called with a range outside 1..nNew.'
       stop 1
     endif
+    if(oldFirst < 1 .or. oldLast > plan%nOld .or. oldLast < oldFirst) then
+      print*,__FILE__,':',__LINE__, &
+        ' : Error : ApplyTransferPlanWindow called with an old-element window outside'// &
+        ' 1..nOld.'
+      stop 1
+    endif
 
     Np = interp%N+1
     allocate(buf(1:Np,1:Np,1:nVar))
@@ -265,6 +305,27 @@ contains
 
     do li = eFirst,eLast
       lo = li-eFirst+1
+
+      ! Every old element this entry reads must lie inside the supplied window. A window that
+      ! does not cover the entry is a routing error (the window was computed from a different
+      ! plan or a different partition), so report it rather than read outside the array. On the
+      ! whole-field path the condition can never fire; the cost is a handful of integer
+      ! comparisons per element, once per adaptation epoch.
+      if(plan%sourceKind(li) == SELF_TRANSFER_RESTRICT) then
+        do c = 1,4
+          if(plan%family(c,li) < oldFirst .or. plan%family(c,li) > oldLast) then
+            print*,__FILE__,':',__LINE__, &
+              ' : Error : new element',li,' restricts from old element',plan%family(c,li), &
+              ' outside the supplied old-element window',oldFirst,oldLast
+            stop 1
+          endif
+        enddo
+      elseif(plan%sourceElem(li) < oldFirst .or. plan%sourceElem(li) > oldLast) then
+        print*,__FILE__,':',__LINE__, &
+          ' : Error : new element',li,' sources old element',plan%sourceElem(li), &
+          ' outside the supplied old-element window',oldFirst,oldLast
+        stop 1
+      endif
 
       if(plan%sourceKind(li) == SELF_TRANSFER_COPY) then
         uNew(1:Np,1:Np,lo,1:nVar) = uOld(1:Np,1:Np,plan%sourceElem(li),1:nVar)
@@ -291,6 +352,6 @@ contains
 
     deallocate(buf,kids,fam)
 
-  endsubroutine ApplyTransferPlanRange
+  endsubroutine ApplyTransferPlanWindow
 
 endmodule SELF_TransferPlan_2D

--- a/src/SELF_TransferPlan_3D.f90
+++ b/src/SELF_TransferPlan_3D.f90
@@ -236,14 +236,48 @@ contains
   subroutine ApplyTransferPlanRange(plan,interp,nVar,uOld,eFirst,eLast,uNew)
     !! Execute the contiguous sub-range eFirst..eLast of a transfer plan: uNew(:,:,:,k,:)
     !! receives the data of new element eFirst+k-1. uOld is the full (global) old field; the
-    !! output is only the requested slice. This is the decomposed-mesh (AMR Stage 5) entry
-    !! point: each rank passes its own contiguous range of the new element ordering and a
-    !! gathered global old solution, and fills exactly its rank-local storage.
+    !! output is only the requested slice. This is the gather-then-slice (AMR Stage-5 v1)
+    !! decomposed-mesh entry point: each rank passes its own contiguous range of the new
+    !! element ordering and a gathered global old solution, and fills exactly its rank-local
+    !! storage. ApplyTransferPlanWindow is the point-to-point (v2) entry point, which needs
+    !! only the sub-range of the old field the requested new range actually references; this
+    !! routine is that one over the whole old field, so the two are bit-identical by
+    !! construction rather than by inspection.
     implicit none
     type(TransferPlan3D),intent(in) :: plan
     type(Lagrange),intent(in) :: interp
     integer,intent(in) :: nVar
     real(prec),intent(in) :: uOld(1:interp%N+1,1:interp%N+1,1:interp%N+1,1:plan%nOld,1:nVar)
+    integer,intent(in) :: eFirst
+    integer,intent(in) :: eLast
+    real(prec),intent(out) :: uNew(1:interp%N+1,1:interp%N+1,1:interp%N+1,1:eLast-eFirst+1,1:nVar)
+
+    call ApplyTransferPlanWindow(plan,interp,nVar,uOld,1,plan%nOld,eFirst,eLast,uNew)
+
+  endsubroutine ApplyTransferPlanRange
+
+  subroutine ApplyTransferPlanWindow(plan,interp,nVar,uOld,oldFirst,oldLast,eFirst,eLast,uNew)
+    !! Execute the contiguous sub-range eFirst..eLast of a transfer plan against a WINDOW of
+    !! the old field: uOld holds old elements oldFirst..oldLast only, indexed in the global old
+    !! element numbering that plan%sourceElem and plan%family use, rather than the whole global
+    !! field. uNew(:,:,:,k,:) receives the data of new element eFirst+k-1.
+    !!
+    !! This is the point-to-point migration (AMR Stage-5 v2) entry point. Because both the old
+    !! and the new partition are contiguous ranges of the same space-filling-curve leaf order,
+    !! the old elements a rank's new range references form a contiguous window that a rank
+    !! computes locally from the (rank-replicated) plan - see PlanWindows in the AMR
+    !! controllers - and receives point-to-point instead of allgathering the global field.
+    !!
+    !! Units and layout are those of MappedScalar3D %interior. The transfer operators are
+    !! unchanged, so the operator identities hold as documented in the module header: exact
+    !! prolongation, conservative L2 restriction.
+    implicit none
+    type(TransferPlan3D),intent(in) :: plan
+    type(Lagrange),intent(in) :: interp
+    integer,intent(in) :: nVar
+    integer,intent(in) :: oldFirst
+    integer,intent(in) :: oldLast
+    real(prec),intent(in) :: uOld(1:interp%N+1,1:interp%N+1,1:interp%N+1,oldFirst:oldLast,1:nVar)
     integer,intent(in) :: eFirst
     integer,intent(in) :: eLast
     real(prec),intent(out) :: uNew(1:interp%N+1,1:interp%N+1,1:interp%N+1,1:eLast-eFirst+1,1:nVar)
@@ -261,6 +295,12 @@ contains
         ' : Error : ApplyTransferPlanRange called with a range outside 1..nNew.'
       stop 1
     endif
+    if(oldFirst < 1 .or. oldLast > plan%nOld .or. oldLast < oldFirst) then
+      print*,__FILE__,':',__LINE__, &
+        ' : Error : ApplyTransferPlanWindow called with an old-element window outside'// &
+        ' 1..nOld.'
+      stop 1
+    endif
 
     Np = interp%N+1
     allocate(buf(1:Np,1:Np,1:Np,1:nVar))
@@ -269,6 +309,27 @@ contains
 
     do li = eFirst,eLast
       lo = li-eFirst+1
+
+      ! Every old element this entry reads must lie inside the supplied window. A window that
+      ! does not cover the entry is a routing error (the window was computed from a different
+      ! plan or a different partition), so report it rather than read outside the array. On the
+      ! whole-field path the condition can never fire; the cost is a handful of integer
+      ! comparisons per element, once per adaptation epoch.
+      if(plan%sourceKind(li) == SELF_TRANSFER_RESTRICT) then
+        do c = 1,8
+          if(plan%family(c,li) < oldFirst .or. plan%family(c,li) > oldLast) then
+            print*,__FILE__,':',__LINE__, &
+              ' : Error : new element',li,' restricts from old element',plan%family(c,li), &
+              ' outside the supplied old-element window',oldFirst,oldLast
+            stop 1
+          endif
+        enddo
+      elseif(plan%sourceElem(li) < oldFirst .or. plan%sourceElem(li) > oldLast) then
+        print*,__FILE__,':',__LINE__, &
+          ' : Error : new element',li,' sources old element',plan%sourceElem(li), &
+          ' outside the supplied old-element window',oldFirst,oldLast
+        stop 1
+      endif
 
       if(plan%sourceKind(li) == SELF_TRANSFER_COPY) then
         uNew(1:Np,1:Np,1:Np,lo,1:nVar) = uOld(1:Np,1:Np,1:Np,plan%sourceElem(li),1:nVar)
@@ -295,6 +356,6 @@ contains
 
     deallocate(buf,kids,fam)
 
-  endsubroutine ApplyTransferPlanRange
+  endsubroutine ApplyTransferPlanWindow
 
 endmodule SELF_TransferPlan_3D

--- a/src/gpu/SELF_DGModel2D.f90
+++ b/src/gpu/SELF_DGModel2D.f90
@@ -507,28 +507,31 @@ contains
 
   endsubroutine StageSolutionForTransfer_DGModel2D
 
-  subroutine ApplyTransferPlan_DGModel2D(this,plan,interp,eFirst,eLast,uGlobal)
+  subroutine ApplyTransferPlan_DGModel2D(this,plan,interp,eFirst,eLast,uGlobal,oldFirst)
     !! Apply the transfer plan on the device (Stage 6a), writing solution%interior_gpu directly
     !! and moving no solution data across the PCIe/xGMI link.
     !!
-    !! uGlobal is the multi-rank escape hatch: when the caller has assembled a global old field
-    !! on the host (the Stage-5 v1 allgather migration), this falls back to the portable host
-    !! path. A device transfer only pays off on several ranks together with a point-to-point
-    !! (Stage-5 v2) migration; on a single rank it stands alone, which is the case optimized
-    !! here.
+    !! uGlobal is the multi-rank escape hatch: when the caller supplies host-side old-field data
+    !! - the whole global field under the Stage-5 v1 allgather migration, or the rank's window
+    !! under the point-to-point (v2) migration - this falls back to the portable host path,
+    !! forwarding oldFirst so the window is indexed correctly. Serving the device transfer from a
+    !! migrated window (a device-side window buffer plus an oldFirst offset in the kernel) is the
+    !! named follow-up to #167; on a single rank the device transfer stands alone, which is the
+    !! case optimized here.
     implicit none
     class(DGModel2D),intent(inout) :: this
     type(TransferPlan2D),intent(in),target :: plan
     type(Lagrange),intent(in) :: interp
     integer,intent(in) :: eFirst
     integer,intent(in) :: eLast
-    real(prec),intent(in),optional :: uGlobal(:,:,:,:)
+    real(prec),intent(in),optional,contiguous :: uGlobal(:,:,:,:)
+    integer,intent(in),optional :: oldFirst
     ! Local
     integer :: nLocal,pathStride
     integer(c_size_t) :: nb
 
     if(present(uGlobal)) then
-      call ApplyTransferPlan_DGModel2D_t(this,plan,interp,eFirst,eLast,uGlobal)
+      call ApplyTransferPlan_DGModel2D_t(this,plan,interp,eFirst,eLast,uGlobal,oldFirst)
       return
     endif
 

--- a/src/gpu/SELF_DGModel3D.f90
+++ b/src/gpu/SELF_DGModel3D.f90
@@ -470,28 +470,31 @@ contains
 
   endsubroutine StageSolutionForTransfer_DGModel3D
 
-  subroutine ApplyTransferPlan_DGModel3D(this,plan,interp,eFirst,eLast,uGlobal)
+  subroutine ApplyTransferPlan_DGModel3D(this,plan,interp,eFirst,eLast,uGlobal,oldFirst)
     !! Apply the transfer plan on the device, writing solution%interior_gpu directly and moving
     !! no solution data across the PCIe/xGMI link.
     !!
-    !! uGlobal is the multi-rank escape hatch: when the caller has assembled a global old field
-    !! on the host (the Stage-5 v1 allgather migration), this falls back to the portable host
-    !! path. A device transfer only pays off on several ranks together with a point-to-point
-    !! (Stage-5 v2) migration; on a single rank it stands alone, which is the case optimized
-    !! here.
+    !! uGlobal is the multi-rank escape hatch: when the caller supplies host-side old-field data
+    !! - the whole global field under the Stage-5 v1 allgather migration, or the rank's window
+    !! under the point-to-point (v2) migration - this falls back to the portable host path,
+    !! forwarding oldFirst so the window is indexed correctly. Serving the device transfer from a
+    !! migrated window (a device-side window buffer plus an oldFirst offset in the kernel) is the
+    !! named follow-up to #167; on a single rank the device transfer stands alone, which is the
+    !! case optimized here.
     implicit none
     class(DGModel3D),intent(inout) :: this
     type(TransferPlan3D),intent(in),target :: plan
     type(Lagrange),intent(in) :: interp
     integer,intent(in) :: eFirst
     integer,intent(in) :: eLast
-    real(prec),intent(in),optional :: uGlobal(:,:,:,:,:)
+    real(prec),intent(in),optional,contiguous :: uGlobal(:,:,:,:,:)
+    integer,intent(in),optional :: oldFirst
     ! Local
     integer :: nLocal,pathStride
     integer(c_size_t) :: nb
 
     if(present(uGlobal)) then
-      call ApplyTransferPlan_DGModel3D_t(this,plan,interp,eFirst,eLast,uGlobal)
+      call ApplyTransferPlan_DGModel3D_t(this,plan,interp,eFirst,eLast,uGlobal,oldFirst)
       return
     endif
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -98,6 +98,10 @@ add_fortran_tests (
     "transfer_plan_3d_guard_unbuilt.f90"
     "transfer_plan_2d_guard_range.f90"
     "transfer_plan_3d_guard_range.f90"
+    "transfer_plan_2d_window.f90"
+    "transfer_plan_3d_window.f90"
+    "transfer_plan_2d_guard_window.f90"
+    "transfer_plan_3d_guard_window.f90"
     "amr_controller_2d_guard_decomp.f90"
     "amr_controller_3d_guard_decomp.f90"
     "lineareuler2d_amr_soundwave.f90"
@@ -323,6 +327,8 @@ set_tests_properties(
     transfer_plan_3d_guard_unbuilt
     transfer_plan_2d_guard_range
     transfer_plan_3d_guard_range
+    transfer_plan_2d_guard_window
+    transfer_plan_3d_guard_window
     amr_controller_2d_guard_decomp
     amr_controller_3d_guard_decomp
     dgmodel2d_regrid_guard_uninit
@@ -360,6 +366,8 @@ add_mpi_fortran_tests( "mappedvectordgdivergence_2d_linear_mpi.f90"
                        "lineareuler3d_mortar_soundwave_mpi.f90"
                        "lineareuler2d_amr_soundwave_mpi.f90"
                        "lineareuler3d_amr_soundwave_mpi.f90"
+                       "amr_migrate_2d_window_mpi.f90"
+                       "amr_migrate_3d_window_mpi.f90"
                        "geometry_2d_reuse_mpi.f90"
                        "advection_diffusion_2d_mortar_mpi.f90"
                        "advection_diffusion_2d_rk3_mpi.f90"
@@ -409,3 +417,77 @@ set_tests_properties(lineareuler3d_amr_soundwave_geom_full PROPERTIES
 add_test(NAME lineareuler3d_amr_soundwave_geom_noreuse COMMAND lineareuler3d_amr_soundwave)
 set_tests_properties(lineareuler3d_amr_soundwave_geom_noreuse PROPERTIES
                      LABELS "serial" ENVIRONMENT "SELF_AMR_GEOM_NO_REUSE=1")
+
+# Multi-rank solution migration (issue #167). The default path is now the point-to-point window
+# exchange, so the MPI AMR tests above already cover it. These re-runs cover the two things the
+# default run cannot show, again with no new sources:
+#
+#  - MIGRATE_VERIFY  runs BOTH migrations in one process and compares the received window against
+#                    the allgathered global old field bit for bit. This is the assertion that the
+#                    point-to-point routing is right, not merely self-consistent.
+#  - MIGRATE_GATHER  keeps the retained v1 allgather path exercised, so the documented fallback
+#                    cannot rot.
+add_test(NAME lineareuler2d_amr_soundwave_mpi_migrate_verify
+         COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${SELF_MPIEXEC_NUMPROCS}
+                 ${SELF_MPIEXEC_OPTIONS} lineareuler2d_amr_soundwave_mpi)
+set_tests_properties(lineareuler2d_amr_soundwave_mpi_migrate_verify PROPERTIES
+                     LABELS "parallel" ENVIRONMENT "SELF_AMR_MIGRATE_VERIFY=1")
+
+add_test(NAME lineareuler3d_amr_soundwave_mpi_migrate_verify
+         COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${SELF_MPIEXEC_NUMPROCS}
+                 ${SELF_MPIEXEC_OPTIONS} lineareuler3d_amr_soundwave_mpi)
+set_tests_properties(lineareuler3d_amr_soundwave_mpi_migrate_verify PROPERTIES
+                     LABELS "parallel" ENVIRONMENT "SELF_AMR_MIGRATE_VERIFY=1")
+
+add_test(NAME lineareuler2d_amr_soundwave_mpi_migrate_gather
+         COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${SELF_MPIEXEC_NUMPROCS}
+                 ${SELF_MPIEXEC_OPTIONS} lineareuler2d_amr_soundwave_mpi)
+set_tests_properties(lineareuler2d_amr_soundwave_mpi_migrate_gather PROPERTIES
+                     LABELS "parallel" ENVIRONMENT "SELF_AMR_MIGRATE_GATHER=1")
+
+add_test(NAME lineareuler3d_amr_soundwave_mpi_migrate_gather
+         COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${SELF_MPIEXEC_NUMPROCS}
+                 ${SELF_MPIEXEC_OPTIONS} lineareuler3d_amr_soundwave_mpi)
+set_tests_properties(lineareuler3d_amr_soundwave_mpi_migrate_gather PROPERTIES
+                     LABELS "parallel" ENVIRONMENT "SELF_AMR_MIGRATE_GATHER=1")
+
+# Two ranks cannot distinguish gather-then-slice from a point-to-point routing bug: with one peer
+# the send and receive runs are forced, and no rank's window can span more than one peer. These
+# entries re-launch the SAME executables on SELF_MPIEXEC_NUMPROCS_MANY ranks, where a window can
+# straddle several peers and a rank can end up with nothing to own.
+add_test(NAME lineareuler2d_amr_soundwave_mpi_np_many
+         COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${SELF_MPIEXEC_NUMPROCS_MANY}
+                 ${SELF_MPIEXEC_OPTIONS} ${SELF_MPIEXEC_OPTIONS_MANY}
+                 lineareuler2d_amr_soundwave_mpi)
+set_tests_properties(lineareuler2d_amr_soundwave_mpi_np_many PROPERTIES
+                     LABELS "parallel" PROCESSORS ${SELF_MPIEXEC_NUMPROCS_MANY})
+
+add_test(NAME lineareuler2d_amr_soundwave_mpi_np_many_migrate_verify
+         COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${SELF_MPIEXEC_NUMPROCS_MANY}
+                 ${SELF_MPIEXEC_OPTIONS} ${SELF_MPIEXEC_OPTIONS_MANY}
+                 lineareuler2d_amr_soundwave_mpi)
+set_tests_properties(lineareuler2d_amr_soundwave_mpi_np_many_migrate_verify PROPERTIES
+                     LABELS "parallel" PROCESSORS ${SELF_MPIEXEC_NUMPROCS_MANY}
+                     ENVIRONMENT "SELF_AMR_MIGRATE_VERIFY=1")
+
+add_test(NAME amr_migrate_2d_window_mpi_np_many
+         COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${SELF_MPIEXEC_NUMPROCS_MANY}
+                 ${SELF_MPIEXEC_OPTIONS} ${SELF_MPIEXEC_OPTIONS_MANY}
+                 amr_migrate_2d_window_mpi)
+set_tests_properties(amr_migrate_2d_window_mpi_np_many PROPERTIES
+                     LABELS "parallel" PROCESSORS ${SELF_MPIEXEC_NUMPROCS_MANY})
+
+add_test(NAME amr_migrate_3d_window_mpi_np_many
+         COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${SELF_MPIEXEC_NUMPROCS_MANY}
+                 ${SELF_MPIEXEC_OPTIONS} ${SELF_MPIEXEC_OPTIONS_MANY}
+                 amr_migrate_3d_window_mpi)
+set_tests_properties(amr_migrate_3d_window_mpi_np_many PROPERTIES
+                     LABELS "parallel" PROCESSORS ${SELF_MPIEXEC_NUMPROCS_MANY})
+
+add_test(NAME lineareuler3d_amr_soundwave_mpi_np_many_migrate_verify
+         COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${SELF_MPIEXEC_NUMPROCS_MANY}
+                 ${SELF_MPIEXEC_OPTIONS} ${SELF_MPIEXEC_OPTIONS_MANY}
+                 lineareuler3d_amr_soundwave_mpi)
+set_tests_properties(lineareuler3d_amr_soundwave_mpi_np_many_migrate_verify PROPERTIES
+                     LABELS "parallel" PROCESSORS ${SELF_MPIEXEC_NUMPROCS_MANY}
+                     ENVIRONMENT "SELF_AMR_MIGRATE_VERIFY=1")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -102,6 +102,10 @@ add_fortran_tests (
     "transfer_plan_3d_window.f90"
     "transfer_plan_2d_guard_window.f90"
     "transfer_plan_3d_guard_window.f90"
+    "transfer_plan_2d_guard_windowbounds.f90"
+    "transfer_plan_3d_guard_windowbounds.f90"
+    "transfer_plan_2d_guard_windowfamily.f90"
+    "transfer_plan_3d_guard_windowfamily.f90"
     "amr_controller_2d_guard_decomp.f90"
     "amr_controller_3d_guard_decomp.f90"
     "lineareuler2d_amr_soundwave.f90"
@@ -329,6 +333,10 @@ set_tests_properties(
     transfer_plan_3d_guard_range
     transfer_plan_2d_guard_window
     transfer_plan_3d_guard_window
+    transfer_plan_2d_guard_windowbounds
+    transfer_plan_3d_guard_windowbounds
+    transfer_plan_2d_guard_windowfamily
+    transfer_plan_3d_guard_windowfamily
     amr_controller_2d_guard_decomp
     amr_controller_3d_guard_decomp
     dgmodel2d_regrid_guard_uninit

--- a/test/amr_migrate_2d_window_mpi.f90
+++ b/test/amr_migrate_2d_window_mpi.f90
@@ -1,0 +1,272 @@
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+!
+! Maintainers : support@fluidnumerics.com
+! Official Repository : https://github.com/FluidNumerics/self/
+!
+! Copyright © 2024 Fluid Numerics LLC
+!
+! Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+!
+! 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+!    the documentation and/or other materials provided with the distribution.
+!
+! 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+!    this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+! HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+! LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+! THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+! THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+!
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+
+program test
+
+  implicit none
+  integer :: exit_code
+
+  exit_code = amr_migrate_2d_window_mpi()
+  if(exit_code /= 0) then
+    stop exit_code
+  endif
+
+contains
+
+  integer function amr_migrate_2d_window_mpi() result(r)
+    !! MPI regression for the point-to-point AMR solution migration (Stage-5 v2): it exercises
+    !! ExchangeOldWindow itself, with old elements that genuinely change rank.
+    !!
+    !! Why this test exists and the AMR soundwave MPI runs are not enough. Under a symmetric
+    !! refinement the contiguous space-filling-curve repartition keeps each rank's new range
+    !! sourced from its own old range, so the window is entirely local, no message is posted at
+    !! all, and the local copy alone produces the right answer. Such a run would still pass
+    !! SELF_AMR_MIGRATE_VERIFY, so it proves nothing about the send/receive schedule. Here the
+    !! adaptation is deliberately ASYMMETRIC - only the first few leaves of the forest refine -
+    !! so the new partition boundaries land inside what used to be another rank's old range and
+    !! elements must actually move. The test asserts that they did.
+    !!
+    !! The old field is analytic and encodes each element's GLOBAL old index in its values, so a
+    !! misrouted element is not merely "different", it names the element that arrived instead.
+    !!
+    !! Assertions:
+    !!  (a) at least one rank received at least one old element from a peer (otherwise the test
+    !!      has stopped testing what it is for, and the migration counters are checked as well);
+    !!  (b) every element of the received window carries exactly the analytic values of that
+    !!      global old element - bit for bit, on every rank;
+    !!  (c) the window covers everything the rank's new range references (this is what
+    !!      ApplyTransferPlanWindow's own guard would catch, asserted here directly);
+    !!  (d) applying the plan from the migrated window reproduces, bit for bit, the result of
+    !!      applying it from the whole global old field.
+    !!
+    !! Runs on any rank count >= 1; with one rank it degenerates to the local-copy path, which is
+    !! still a valid (if weaker) check, and (a) is then skipped.
+    use SELF_Constants
+    use SELF_Lagrange
+    use SELF_Mesh_2D
+    use SELF_QuadTreeMesh_2D
+    use SELF_AdaptiveMesh_2D
+    use SELF_TransferPlan_2D
+    use SELF_AMRController_2D,only:PlanWindows,ExchangeOldWindow, &
+                                    InitForestFromDecomposedMesh
+    use iso_fortran_env,only:int64
+    use mpi
+
+    implicit none
+
+    integer,parameter :: controlDegree = 3
+    integer,parameter :: nvar = 2
+    integer,parameter :: nRefine = 5 !! leaves 1..nRefine refine: deliberately asymmetric
+    type(Lagrange),target :: interp
+    type(Mesh2D),target :: baseMesh
+    type(Mesh2D),pointer :: newMesh
+    type(QuadTreeMesh2D) :: forest
+    type(TransferPlan2D) :: plan
+    integer :: bcids(1:4)
+    integer :: i,j,e,c,iv,nOld,nNew,Np,ierror
+    integer :: nR,rankId,myFirst,myLast,nLocalOld
+    integer :: eFirst,eLast,wFirst,wLast,src
+    integer(int64) :: nBytesRecv,nBytesSent,nElemRemote,nRemoteMax
+    integer,allocatable :: flag(:),oldLeaf(:),winFirst(:),winLast(:)
+    real(prec),allocatable :: uLocal(:,:,:,:),uWin(:,:,:,:)
+    real(prec),allocatable :: uAll(:,:,:,:),uRef(:,:,:,:),uNew(:,:,:,:)
+
+    r = 0
+    Np = controlDegree+1
+    bcids(1:4) = [SELF_BC_PRESCRIBED,SELF_BC_PRESCRIBED,SELF_BC_PRESCRIBED,SELF_BC_PRESCRIBED]
+
+    ! 8 x 8 base mesh: 64 elements, enough that a 2- or 4-rank split leaves several elements per
+    ! rank and the refined band sits inside the first rank's range only.
+    call baseMesh%StructuredMesh(8,8,1,1,0.125_prec,0.125_prec,bcids)
+    call interp%Init(N=controlDegree,controlNodeType=GAUSS,M=controlDegree, &
+                     targetNodeType=UNIFORM)
+
+    nR = baseMesh%decomp%nRanks
+    rankId = baseMesh%decomp%rankId
+    myFirst = baseMesh%decomp%offsetElem(rankId+1)+1
+    myLast = baseMesh%decomp%offsetElem(rankId+2)
+    nLocalOld = myLast-myFirst+1
+
+    ! ---- Rank-replicated forest over the decomposed base mesh ----
+    if(nR > 1) then
+      call InitForestFromDecomposedMesh(forest,baseMesh)
+    else
+      call forest%Init(baseMesh)
+    endif
+
+    nOld = forest%nLeaves
+    if(nOld /= 64) then
+      print*,"FAIL: unexpected old leaf count",nOld
+      r = 1
+    endif
+    allocate(oldLeaf(1:nOld))
+    oldLeaf(1:nOld) = forest%leaf(1:nOld)
+
+    ! ---- One deliberately asymmetric epoch: refine only the first nRefine leaves ----
+    allocate(flag(1:nOld))
+    flag = QUADTREE_KEEP
+    flag(1:nRefine) = QUADTREE_REFINE
+    call forest%AdaptFromFlags(flag)
+    deallocate(flag)
+    call forest%Balance2to1()
+    call BuildTransferPlan(forest,nOld,oldLeaf,plan)
+    nNew = plan%nNew
+    if(rankId == 0) print*,"nOld, nNew :",nOld,nNew
+
+    ! ---- The emitted mesh supplies the new partition, exactly as the controller uses it ----
+    allocate(newMesh)
+    call EmitMesh(forest,baseMesh,newMesh)
+    eFirst = newMesh%decomp%offsetElem(newMesh%decomp%rankId+1)+1
+    eLast = newMesh%decomp%offsetElem(newMesh%decomp%rankId+2)
+
+    allocate(winFirst(1:nR),winLast(1:nR))
+    call PlanWindows(plan,nR,newMesh%decomp%offsetElem,winFirst,winLast)
+    wFirst = winFirst(rankId+1)
+    wLast = winLast(rankId+1)
+    if(eLast < eFirst) then
+      wFirst = 1
+      wLast = 0
+    endif
+
+    ! ---- Analytic old field: the value names the global old element it belongs to ----
+    allocate(uLocal(1:Np,1:Np,1:nLocalOld,1:nvar))
+    do iv = 1,nvar
+      do e = 1,nLocalOld
+        do j = 1,Np
+          do i = 1,Np
+            uLocal(i,j,e,iv) = OldValue(e+myFirst-1,i,j,iv)
+          enddo
+        enddo
+      enddo
+    enddo
+
+    ! ---- Migrate ----
+    nBytesRecv = 0
+    nBytesSent = 0
+    nElemRemote = 0
+    allocate(uWin(1:Np,1:Np,wFirst:wLast,1:nvar))
+    call ExchangeOldWindow(baseMesh%decomp,Np,nvar,nLocalOld,uLocal,winFirst,winLast, &
+                           wFirst,wLast,uWin,nBytesRecv,nBytesSent,nElemRemote)
+
+    ! ---- (a) elements really did cross ranks ----
+    if(nR > 1) then
+      call mpi_allreduce(nElemRemote,nRemoteMax,1,MPI_INTEGER8,MPI_MAX, &
+                         baseMesh%decomp%mpiComm,ierror)
+      if(nRemoteMax <= 0) then
+        print*,"FAIL: no rank received any old element from a peer, so the point-to-point"// &
+          " schedule was never exercised"
+        r = 1
+      endif
+      if(nElemRemote > 0 .and. nBytesRecv <= 0) then
+        print*,"FAIL: rank",rankId," received elements but counted no bytes"
+        r = 1
+      endif
+      print*,"rank",rankId," window",wFirst,wLast," remote elements",nElemRemote, &
+        " bytes recv/sent",nBytesRecv,nBytesSent
+    endif
+
+    ! ---- (b) every window element carries its own analytic values ----
+    do iv = 1,nvar
+      do e = wFirst,wLast
+        do j = 1,Np
+          do i = 1,Np
+            if(uWin(i,j,e,iv) /= OldValue(e,i,j,iv)) then
+              print*,"FAIL: rank",rankId," window element",e," variable",iv, &
+                " node",i,j," holds",uWin(i,j,e,iv)," expected",OldValue(e,i,j,iv)
+              r = 1
+            endif
+          enddo
+        enddo
+      enddo
+    enddo
+
+    ! ---- (c) the window covers every old element the rank's new range references ----
+    do e = eFirst,eLast
+      if(plan%sourceKind(e) == SELF_TRANSFER_RESTRICT) then
+        do c = 1,4
+          src = plan%family(c,e)
+          if(src < wFirst .or. src > wLast) then
+            print*,"FAIL: rank",rankId," window",wFirst,wLast," misses family source",src
+            r = 1
+          endif
+        enddo
+      else
+        src = plan%sourceElem(e)
+        if(src < wFirst .or. src > wLast) then
+          print*,"FAIL: rank",rankId," window",wFirst,wLast," misses source",src
+          r = 1
+        endif
+      endif
+    enddo
+
+    ! ---- (d) transferring from the window matches transferring from the global field ----
+    if(eLast >= eFirst) then
+      allocate(uAll(1:Np,1:Np,1:nOld,1:nvar))
+      do iv = 1,nvar
+        do e = 1,nOld
+          do j = 1,Np
+            do i = 1,Np
+              uAll(i,j,e,iv) = OldValue(e,i,j,iv)
+            enddo
+          enddo
+        enddo
+      enddo
+      allocate(uRef(1:Np,1:Np,1:eLast-eFirst+1,1:nvar))
+      allocate(uNew(1:Np,1:Np,1:eLast-eFirst+1,1:nvar))
+      call ApplyTransferPlanRange(plan,interp,nvar,uAll,eFirst,eLast,uRef)
+      call ApplyTransferPlanWindow(plan,interp,nvar,uWin,wFirst,wLast,eFirst,eLast,uNew)
+      if(any(uNew /= uRef)) then
+        print*,"FAIL: rank",rankId," transfer from the migrated window differs from the"// &
+          " whole-field transfer; max|d| =",maxval(abs(uNew-uRef))
+        r = 1
+      endif
+      deallocate(uAll,uRef,uNew)
+    endif
+
+    if(r == 0 .and. rankId == 0) print*,"AMR MIGRATE 2D WINDOW CHECKS PASSED"
+
+    deallocate(uLocal,uWin,winFirst,winLast,oldLeaf)
+    call plan%Free()
+    call newMesh%Free()
+    deallocate(newMesh)
+    call forest%Free()
+    call interp%Free()
+    call baseMesh%Free()
+
+  endfunction amr_migrate_2d_window_mpi
+
+  pure real(prec) function OldValue(eGlobal,i,j,iv)
+    !! Analytic old-field value: distinct for every (global element, node, variable) and exactly
+    !! representable, so a comparison can be exact and a mismatch names the element that arrived.
+    use SELF_Constants
+    implicit none
+    integer,intent(in) :: eGlobal,i,j,iv
+
+    OldValue = real(1000000*iv+1000*eGlobal+10*i+j,prec)
+
+  endfunction OldValue
+
+endprogram test

--- a/test/amr_migrate_3d_window_mpi.f90
+++ b/test/amr_migrate_3d_window_mpi.f90
@@ -1,0 +1,279 @@
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+!
+! Maintainers : support@fluidnumerics.com
+! Official Repository : https://github.com/FluidNumerics/self/
+!
+! Copyright © 2024 Fluid Numerics LLC
+!
+! Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+!
+! 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+!    the documentation and/or other materials provided with the distribution.
+!
+! 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+!    this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+! HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+! LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+! THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+! THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+!
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+
+program test
+
+  implicit none
+  integer :: exit_code
+
+  exit_code = amr_migrate_3d_window_mpi()
+  if(exit_code /= 0) then
+    stop exit_code
+  endif
+
+contains
+
+  integer function amr_migrate_3d_window_mpi() result(r)
+    !! MPI regression for the point-to-point AMR solution migration (Stage-5 v2): it exercises
+    !! ExchangeOldWindow itself, with old elements that genuinely change rank.
+    !!
+    !! Why this test exists and the AMR soundwave MPI runs are not enough. Under a symmetric
+    !! refinement the contiguous space-filling-curve repartition keeps each rank's new range
+    !! sourced from its own old range, so the window is entirely local, no message is posted at
+    !! all, and the local copy alone produces the right answer. Such a run would still pass
+    !! SELF_AMR_MIGRATE_VERIFY, so it proves nothing about the send/receive schedule. Here the
+    !! adaptation is deliberately ASYMMETRIC - only the first few leaves of the forest refine -
+    !! so the new partition boundaries land inside what used to be another rank's old range and
+    !! elements must actually move. The test asserts that they did.
+    !!
+    !! The old field is analytic and encodes each element's GLOBAL old index in its values, so a
+    !! misrouted element is not merely "different", it names the element that arrived instead.
+    !!
+    !! Assertions:
+    !!  (a) at least one rank received at least one old element from a peer (otherwise the test
+    !!      has stopped testing what it is for, and the migration counters are checked as well);
+    !!  (b) every element of the received window carries exactly the analytic values of that
+    !!      global old element - bit for bit, on every rank;
+    !!  (c) the window covers everything the rank's new range references (this is what
+    !!      ApplyTransferPlanWindow's own guard would catch, asserted here directly);
+    !!  (d) applying the plan from the migrated window reproduces, bit for bit, the result of
+    !!      applying it from the whole global old field.
+    !!
+    !! Runs on any rank count >= 1; with one rank it degenerates to the local-copy path, which is
+    !! still a valid (if weaker) check, and (a) is then skipped.
+    use SELF_Constants
+    use SELF_Lagrange
+    use SELF_Mesh_3D
+    use SELF_OctreeMesh_3D
+    use SELF_AdaptiveMesh_3D
+    use SELF_TransferPlan_3D
+    use SELF_AMRController_3D,only:PlanWindows,ExchangeOldWindow, &
+                                    InitForestFromDecomposedMesh
+    use iso_fortran_env,only:int64
+    use mpi
+
+    implicit none
+
+    integer,parameter :: controlDegree = 3
+    integer,parameter :: nvar = 2
+    integer,parameter :: nRefine = 5 !! leaves 1..nRefine refine: deliberately asymmetric
+    type(Lagrange),target :: interp
+    type(Mesh3D),target :: baseMesh
+    type(Mesh3D),pointer :: newMesh
+    type(OctreeMesh3D) :: forest
+    type(TransferPlan3D) :: plan
+    integer :: bcids(1:6)
+    integer :: i,j,k,e,c,iv,nOld,nNew,Np,ierror
+    integer :: nR,rankId,myFirst,myLast,nLocalOld
+    integer :: eFirst,eLast,wFirst,wLast,src
+    integer(int64) :: nBytesRecv,nBytesSent,nElemRemote,nRemoteMax
+    integer,allocatable :: flag(:),oldLeaf(:),winFirst(:),winLast(:)
+    real(prec),allocatable :: uLocal(:,:,:,:,:),uWin(:,:,:,:,:)
+    real(prec),allocatable :: uAll(:,:,:,:,:),uRef(:,:,:,:,:),uNew(:,:,:,:,:)
+
+    r = 0
+    Np = controlDegree+1
+    bcids(1:6) = [SELF_BC_PRESCRIBED,SELF_BC_PRESCRIBED,SELF_BC_PRESCRIBED, &
+                  SELF_BC_PRESCRIBED,SELF_BC_PRESCRIBED,SELF_BC_PRESCRIBED]
+
+    ! 4 x 4 x 4 base mesh: 64 elements, enough that a 2- or 4-rank split leaves several elements
+    ! per rank and the refined band sits inside the first rank's range only.
+    call baseMesh%StructuredMesh(4,4,4,1,1,1,0.25_prec,0.25_prec,0.25_prec,bcids)
+    call interp%Init(N=controlDegree,controlNodeType=GAUSS,M=controlDegree, &
+                     targetNodeType=UNIFORM)
+
+    nR = baseMesh%decomp%nRanks
+    rankId = baseMesh%decomp%rankId
+    myFirst = baseMesh%decomp%offsetElem(rankId+1)+1
+    myLast = baseMesh%decomp%offsetElem(rankId+2)
+    nLocalOld = myLast-myFirst+1
+
+    ! ---- Rank-replicated forest over the decomposed base mesh ----
+    if(nR > 1) then
+      call InitForestFromDecomposedMesh(forest,baseMesh)
+    else
+      call forest%Init(baseMesh)
+    endif
+
+    nOld = forest%nLeaves
+    if(nOld /= 64) then
+      print*,"FAIL: unexpected old leaf count",nOld
+      r = 1
+    endif
+    allocate(oldLeaf(1:nOld))
+    oldLeaf(1:nOld) = forest%leaf(1:nOld)
+
+    ! ---- One deliberately asymmetric epoch: refine only the first nRefine leaves ----
+    allocate(flag(1:nOld))
+    flag = OCTREE_KEEP
+    flag(1:nRefine) = OCTREE_REFINE
+    call forest%AdaptFromFlags(flag)
+    deallocate(flag)
+    call forest%Balance2to1()
+    call BuildTransferPlan(forest,nOld,oldLeaf,plan)
+    nNew = plan%nNew
+    if(rankId == 0) print*,"nOld, nNew :",nOld,nNew
+
+    ! ---- The emitted mesh supplies the new partition, exactly as the controller uses it ----
+    allocate(newMesh)
+    call EmitMesh(forest,baseMesh,newMesh)
+    eFirst = newMesh%decomp%offsetElem(newMesh%decomp%rankId+1)+1
+    eLast = newMesh%decomp%offsetElem(newMesh%decomp%rankId+2)
+
+    allocate(winFirst(1:nR),winLast(1:nR))
+    call PlanWindows(plan,nR,newMesh%decomp%offsetElem,winFirst,winLast)
+    wFirst = winFirst(rankId+1)
+    wLast = winLast(rankId+1)
+    if(eLast < eFirst) then
+      wFirst = 1
+      wLast = 0
+    endif
+
+    ! ---- Analytic old field: the value names the global old element it belongs to ----
+    allocate(uLocal(1:Np,1:Np,1:Np,1:nLocalOld,1:nvar))
+    do iv = 1,nvar
+      do e = 1,nLocalOld
+        do k = 1,Np
+          do j = 1,Np
+            do i = 1,Np
+              uLocal(i,j,k,e,iv) = OldValue(e+myFirst-1,i,j,k,iv)
+            enddo
+          enddo
+        enddo
+      enddo
+    enddo
+
+    ! ---- Migrate ----
+    nBytesRecv = 0
+    nBytesSent = 0
+    nElemRemote = 0
+    allocate(uWin(1:Np,1:Np,1:Np,wFirst:wLast,1:nvar))
+    call ExchangeOldWindow(baseMesh%decomp,Np,nvar,nLocalOld,uLocal,winFirst,winLast, &
+                           wFirst,wLast,uWin,nBytesRecv,nBytesSent,nElemRemote)
+
+    ! ---- (a) elements really did cross ranks ----
+    if(nR > 1) then
+      call mpi_allreduce(nElemRemote,nRemoteMax,1,MPI_INTEGER8,MPI_MAX, &
+                         baseMesh%decomp%mpiComm,ierror)
+      if(nRemoteMax <= 0) then
+        print*,"FAIL: no rank received any old element from a peer, so the point-to-point"// &
+          " schedule was never exercised"
+        r = 1
+      endif
+      if(nElemRemote > 0 .and. nBytesRecv <= 0) then
+        print*,"FAIL: rank",rankId," received elements but counted no bytes"
+        r = 1
+      endif
+      print*,"rank",rankId," window",wFirst,wLast," remote elements",nElemRemote, &
+        " bytes recv/sent",nBytesRecv,nBytesSent
+    endif
+
+    ! ---- (b) every window element carries its own analytic values ----
+    do iv = 1,nvar
+      do e = wFirst,wLast
+        do k = 1,Np
+          do j = 1,Np
+            do i = 1,Np
+              if(uWin(i,j,k,e,iv) /= OldValue(e,i,j,k,iv)) then
+                print*,"FAIL: rank",rankId," window element",e," variable",iv, &
+                  " node",i,j,k," holds",uWin(i,j,k,e,iv)," expected",OldValue(e,i,j,k,iv)
+                r = 1
+              endif
+            enddo
+          enddo
+        enddo
+      enddo
+    enddo
+
+    ! ---- (c) the window covers every old element the rank's new range references ----
+    do e = eFirst,eLast
+      if(plan%sourceKind(e) == SELF_TRANSFER_RESTRICT) then
+        do c = 1,8
+          src = plan%family(c,e)
+          if(src < wFirst .or. src > wLast) then
+            print*,"FAIL: rank",rankId," window",wFirst,wLast," misses family source",src
+            r = 1
+          endif
+        enddo
+      else
+        src = plan%sourceElem(e)
+        if(src < wFirst .or. src > wLast) then
+          print*,"FAIL: rank",rankId," window",wFirst,wLast," misses source",src
+          r = 1
+        endif
+      endif
+    enddo
+
+    ! ---- (d) transferring from the window matches transferring from the global field ----
+    if(eLast >= eFirst) then
+      allocate(uAll(1:Np,1:Np,1:Np,1:nOld,1:nvar))
+      do iv = 1,nvar
+        do e = 1,nOld
+          do k = 1,Np
+            do j = 1,Np
+              do i = 1,Np
+                uAll(i,j,k,e,iv) = OldValue(e,i,j,k,iv)
+              enddo
+            enddo
+          enddo
+        enddo
+      enddo
+      allocate(uRef(1:Np,1:Np,1:Np,1:eLast-eFirst+1,1:nvar))
+      allocate(uNew(1:Np,1:Np,1:Np,1:eLast-eFirst+1,1:nvar))
+      call ApplyTransferPlanRange(plan,interp,nvar,uAll,eFirst,eLast,uRef)
+      call ApplyTransferPlanWindow(plan,interp,nvar,uWin,wFirst,wLast,eFirst,eLast,uNew)
+      if(any(uNew /= uRef)) then
+        print*,"FAIL: rank",rankId," transfer from the migrated window differs from the"// &
+          " whole-field transfer; max|d| =",maxval(abs(uNew-uRef))
+        r = 1
+      endif
+      deallocate(uAll,uRef,uNew)
+    endif
+
+    if(r == 0 .and. rankId == 0) print*,"AMR MIGRATE 3D WINDOW CHECKS PASSED"
+
+    deallocate(uLocal,uWin,winFirst,winLast,oldLeaf)
+    call plan%Free()
+    call newMesh%Free()
+    deallocate(newMesh)
+    call forest%Free()
+    call interp%Free()
+    call baseMesh%Free()
+
+  endfunction amr_migrate_3d_window_mpi
+
+  pure real(prec) function OldValue(eGlobal,i,j,k,iv)
+    !! Analytic old-field value: distinct for every (global element, node, variable) and exactly
+    !! representable, so a comparison can be exact and a mismatch names the element that arrived.
+    use SELF_Constants
+    implicit none
+    integer,intent(in) :: eGlobal,i,j,k,iv
+
+    OldValue = real(1000000*iv+1000*eGlobal+100*i+10*j+k,prec)
+
+  endfunction OldValue
+
+endprogram test

--- a/test/transfer_plan_2d_guard_window.f90
+++ b/test/transfer_plan_2d_guard_window.f90
@@ -1,0 +1,66 @@
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+!
+! Maintainers : support@fluidnumerics.com
+! Official Repository : https://github.com/FluidNumerics/self/
+!
+! Copyright © 2024 Fluid Numerics LLC
+!
+! Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+!
+! 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+!    the documentation and/or other materials provided with the distribution.
+!
+! 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+!    this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+! HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+! LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+! THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+! THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+!
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+
+! Guard test (expected to abort): ApplyTransferPlanWindow must reject an old-element window that
+! does not cover an old element the requested new range references - the failure mode a wrong
+! point-to-point migration window would produce. Registered with WILL_FAIL in CMake, so `stop 1`
+! is the passing outcome.
+program test
+  use SELF_Constants
+  use SELF_Lagrange
+  use SELF_Mesh_2D
+  use SELF_QuadTreeMesh_2D
+  use SELF_TransferPlan_2D
+  implicit none
+  type(Mesh2D),target :: mesh
+  type(QuadTreeMesh2D) :: forest
+  type(TransferPlan2D) :: plan
+  type(Lagrange),target :: interp
+  integer :: bcids(1:4)
+  integer :: flag(1:4)
+  integer,allocatable :: oldLeaf(:)
+  real(prec),allocatable :: uWin(:,:,:,:),uNew(:,:,:,:)
+
+  bcids(1:4) = [SELF_BC_PRESCRIBED,SELF_BC_PRESCRIBED,SELF_BC_PRESCRIBED,SELF_BC_PRESCRIBED]
+  call mesh%StructuredMesh(2,2,1,1,0.5_prec,0.5_prec,bcids)
+  call interp%Init(N=2,controlNodeType=GAUSS,M=2,targetNodeType=UNIFORM)
+  call forest%Init(mesh)
+
+  ! Refine every root: each new leaf prolongs from the old element it descends from, so the new
+  ! range 1..nNew references every old element 1..4.
+  allocate(oldLeaf(1:forest%nLeaves))
+  oldLeaf = forest%leaf(1:forest%nLeaves)
+  flag = QUADTREE_REFINE
+  call forest%AdaptFromFlags(flag)
+  call BuildTransferPlan(forest,4,oldLeaf,plan)
+
+  ! A window holding only old elements 1..2 cannot serve the whole new range.
+  allocate(uWin(1:3,1:3,1:2,1:1),uNew(1:3,1:3,1:plan%nNew,1:1))
+  uWin = 0.0_prec
+  call ApplyTransferPlanWindow(plan,interp,1,uWin,1,2,1,plan%nNew,uNew) ! must stop 1
+
+  print*,"ERROR: ApplyTransferPlanWindow coverage guard did not trigger"
+endprogram test

--- a/test/transfer_plan_2d_guard_windowbounds.f90
+++ b/test/transfer_plan_2d_guard_windowbounds.f90
@@ -1,0 +1,63 @@
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+!
+! Maintainers : support@fluidnumerics.com
+! Official Repository : https://github.com/FluidNumerics/self/
+!
+! Copyright © 2024 Fluid Numerics LLC
+!
+! Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+!
+! 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+!    the documentation and/or other materials provided with the distribution.
+!
+! 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+!    this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+! HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+! LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+! THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+! THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+!
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+
+! Guard test (expected to abort): ApplyTransferPlanWindow must reject an old-element window that
+! is not inside 1..nOld - the shape of a window computed against the wrong plan or the wrong
+! partition. Registered with WILL_FAIL in CMake, so `stop 1` is the passing outcome.
+program test
+  use SELF_Constants
+  use SELF_Lagrange
+  use SELF_Mesh_2D
+  use SELF_QuadTreeMesh_2D
+  use SELF_TransferPlan_2D
+  implicit none
+  type(Mesh2D),target :: mesh
+  type(QuadTreeMesh2D) :: forest
+  type(TransferPlan2D) :: plan
+  type(Lagrange),target :: interp
+  integer :: bcids(1:4)
+  integer :: flag(1:4)
+  integer,allocatable :: oldLeaf(:)
+  real(prec),allocatable :: uWin(:,:,:,:),uNew(:,:,:,:)
+
+  bcids(1:4) = [SELF_BC_PRESCRIBED,SELF_BC_PRESCRIBED,SELF_BC_PRESCRIBED,SELF_BC_PRESCRIBED]
+  call mesh%StructuredMesh(2,2,1,1,0.5_prec,0.5_prec,bcids)
+  call interp%Init(N=2,controlNodeType=GAUSS,M=2,targetNodeType=UNIFORM)
+  call forest%Init(mesh)
+
+  allocate(oldLeaf(1:forest%nLeaves))
+  oldLeaf = forest%leaf(1:forest%nLeaves)
+  flag = QUADTREE_REFINE
+  call forest%AdaptFromFlags(flag)
+  call BuildTransferPlan(forest,4,oldLeaf,plan)
+
+  ! The window claims to hold old elements 1..nOld+1, one past the end of the old element list.
+  allocate(uWin(1:3,1:3,1:plan%nOld+1,1:1),uNew(1:3,1:3,1:plan%nNew,1:1))
+  uWin = 0.0_prec
+  call ApplyTransferPlanWindow(plan,interp,1,uWin,1,plan%nOld+1,1,plan%nNew,uNew) ! must stop 1
+
+  print*,"ERROR: ApplyTransferPlanWindow bounds guard did not trigger"
+endprogram test

--- a/test/transfer_plan_2d_guard_windowfamily.f90
+++ b/test/transfer_plan_2d_guard_windowfamily.f90
@@ -1,0 +1,75 @@
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+!
+! Maintainers : support@fluidnumerics.com
+! Official Repository : https://github.com/FluidNumerics/self/
+!
+! Copyright © 2024 Fluid Numerics LLC
+!
+! Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+!
+! 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+!    the documentation and/or other materials provided with the distribution.
+!
+! 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+!    this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+! HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+! LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+! THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+! THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+!
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+
+! Guard test (expected to abort): ApplyTransferPlanWindow must reject a window that omits one of
+! the four children of a coarsened family. A family's children can be owned by different ranks
+! before an epoch, so this is the specific way a too-narrow migration window fails on the
+! RESTRICT path. Registered with WILL_FAIL in CMake, so `stop 1` is the passing outcome.
+program test
+  use SELF_Constants
+  use SELF_Lagrange
+  use SELF_Mesh_2D
+  use SELF_QuadTreeMesh_2D
+  use SELF_TransferPlan_2D
+  implicit none
+  type(Mesh2D),target :: mesh
+  type(QuadTreeMesh2D) :: forest
+  type(TransferPlan2D) :: plan
+  type(Lagrange),target :: interp
+  integer :: bcids(1:4)
+  integer :: nOld
+  integer,allocatable :: flag(:),oldLeaf(:)
+  real(prec),allocatable :: uWin(:,:,:,:),uNew(:,:,:,:)
+
+  bcids(1:4) = [SELF_BC_PRESCRIBED,SELF_BC_PRESCRIBED,SELF_BC_PRESCRIBED,SELF_BC_PRESCRIBED]
+  call mesh%StructuredMesh(2,2,1,1,0.5_prec,0.5_prec,bcids)
+  call interp%Init(N=2,controlNodeType=GAUSS,M=2,targetNodeType=UNIFORM)
+  call forest%Init(mesh)
+
+  ! Refine root 1 so the epoch has a complete four-child family to coarsen: old elements 1-4 are
+  ! that family, 5-7 the remaining roots.
+  allocate(flag(1:forest%nLeaves))
+  flag = QUADTREE_KEEP
+  flag(1) = QUADTREE_REFINE
+  call forest%AdaptFromFlags(flag)
+  deallocate(flag)
+
+  nOld = forest%nLeaves
+  allocate(oldLeaf(1:nOld))
+  oldLeaf = forest%leaf(1:nOld)
+  allocate(flag(1:nOld))
+  flag = QUADTREE_KEEP
+  flag(1:4) = QUADTREE_COARSEN
+  call forest%AdaptFromFlags(flag)
+  call BuildTransferPlan(forest,nOld,oldLeaf,plan)
+
+  ! A window starting at old element 2 omits child 1 of the coarsened family.
+  allocate(uWin(1:3,1:3,2:plan%nOld,1:1),uNew(1:3,1:3,1:plan%nNew,1:1))
+  uWin = 0.0_prec
+  call ApplyTransferPlanWindow(plan,interp,1,uWin,2,plan%nOld,1,plan%nNew,uNew) ! must stop 1
+
+  print*,"ERROR: ApplyTransferPlanWindow family-coverage guard did not trigger"
+endprogram test

--- a/test/transfer_plan_2d_window.f90
+++ b/test/transfer_plan_2d_window.f90
@@ -1,0 +1,346 @@
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+!
+! Maintainers : support@fluidnumerics.com
+! Official Repository : https://github.com/FluidNumerics/self/
+!
+! Copyright © 2024 Fluid Numerics LLC
+!
+! Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+!
+! 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+!    the documentation and/or other materials provided with the distribution.
+!
+! 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+!    this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+! HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+! LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+! THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+! THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+!
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+
+program test
+
+  implicit none
+  integer :: exit_code
+
+  exit_code = transfer_plan_2d_window()
+  if(exit_code /= 0) then
+    stop exit_code
+  endif
+
+contains
+
+  integer function transfer_plan_2d_window() result(r)
+    !! Unit test for the routing arithmetic behind the point-to-point AMR solution migration
+    !! (Stage-5 v2): PlanWindows, the peer-overlap decomposition ExchangeOldWindow performs, and
+    !! the windowed apply ApplyTransferPlanWindow. Serial by construction - the whole point of
+    !! the design is that routing is a LOCAL computation on the rank-replicated plan, so every
+    !! rank's decisions can be reproduced and checked in one process, for partitions that a
+    !! 2-rank MPI test could never produce.
+    !!
+    !! One adaptation epoch of a 2 x 2 base forest produces a plan containing all three
+    !! transfer kinds (COPY, PROLONG at depths 1 and 2, RESTRICT of a complete four-child
+    !! family), so the checks below cover the family case, whose four children may straddle a
+    !! partition boundary.
+    !!
+    !! For each of a table of (old partition, new partition) pairs, and for every rank in it:
+    !!
+    !!  (a) Coverage: every old element the rank's new range references lies inside the window
+    !!      PlanWindows returned. This is what correctness requires of the window.
+    !!  (b) Tightness: both window ends are themselves referenced, so the window is the exact
+    !!      hull and the migration moves no more than it must. This is what the performance
+    !!      claim requires.
+    !!  (c) Empty ranges: a rank owning no new elements gets the empty sentinel
+    !!      (winFirst > winLast).
+    !!  (d) Overlap decomposition: the per-peer contiguous runs ExchangeOldWindow derives from
+    !!      the old offsetElem table tile the window exactly once - no gap, no double cover, no
+    !!      off-by-one - and every referenced element is claimed by exactly one owner.
+    !!  (e) Windowed apply: applying the plan to the rank's new range from a window slice
+    !!      reproduces, BIT FOR BIT, what applying it from the whole global old field produces.
+    !!      Exact equality is the bar, not a tolerance: it is the same operands fed to the same
+    !!      operators in the same order, which is the guarantee the migration rests on.
+    use SELF_Constants
+    use SELF_Lagrange
+    use SELF_Mesh_2D
+    use SELF_QuadTreeMesh_2D
+    use SELF_AdaptiveMesh_2D
+    use SELF_TransferPlan_2D
+    use SELF_AMRController_2D,only:PlanWindows,OwnedRun
+
+    implicit none
+
+    integer,parameter :: controlDegree = 3
+    integer,parameter :: nvar = 2
+    integer,parameter :: nCases = 5
+    integer,parameter :: maxRanks = 5
+    type(Lagrange),target :: interp
+    type(Mesh2D),target :: baseMesh
+    type(QuadTreeMesh2D) :: forest
+    type(TransferPlan2D) :: plan
+    integer :: bcids(1:4)
+    integer :: i,j,e,c,iv,rank,icase,nOld,nNew,Np
+    integer :: nRanks,eFirst,eLast,wFirst,wLast,a,b,src
+    integer :: nPeer,nCovered,maxPeers,nAllRemote,nEmptyWindow
+    integer,allocatable :: flag(:),oldLeaf(:)
+    integer,allocatable :: winFirst(:),winLast(:)
+    integer,allocatable :: claimed(:)
+    integer :: oldOff(0:maxRanks),newOff(0:maxRanks)
+    real(prec),allocatable :: uOld(:,:,:,:),uRef(:,:,:,:),uWin(:,:,:,:),uLoc(:,:,:,:)
+    real(prec),allocatable :: uAsm(:,:,:,:)
+
+    r = 0
+    maxPeers = 0
+    nAllRemote = 0
+    nEmptyWindow = 0
+    Np = controlDegree+1
+    bcids(1:4) = [SELF_BC_PRESCRIBED,SELF_BC_PRESCRIBED,SELF_BC_PRESCRIBED,SELF_BC_PRESCRIBED]
+
+    call baseMesh%StructuredMesh(2,2,1,1,0.5_prec,0.5_prec,bcids)
+    call interp%Init(N=controlDegree,controlNodeType=GAUSS,M=controlDegree, &
+                     targetNodeType=UNIFORM)
+
+    ! ---- Pre-epoch state: refine root 1, so the epoch has a family available to coarsen ----
+    call forest%Init(baseMesh)
+    allocate(flag(1:forest%nLeaves))
+    flag = QUADTREE_KEEP
+    flag(1) = QUADTREE_REFINE
+    call forest%AdaptFromFlags(flag)
+    deallocate(flag)
+
+    nOld = forest%nLeaves
+    allocate(oldLeaf(1:nOld))
+    oldLeaf(1:nOld) = forest%leaf(1:nOld)
+
+    ! ---- One adaptation epoch: coarsen root 1's family, refine root 2, re-refine root 1, ----
+    ! ---- refine one grandchild, then 2:1-balance. Yields COPY, PROLONG d1/d2, RESTRICT.  ----
+    allocate(flag(1:nOld))
+    flag = QUADTREE_KEEP
+    flag(1:4) = QUADTREE_COARSEN
+    flag(5) = QUADTREE_REFINE
+    call forest%AdaptFromFlags(flag)
+    deallocate(flag)
+    call forest%RefineNode(1)
+    call forest%RefineNode(forest%child(3,2))
+    call forest%RebuildLeaves()
+    call forest%Balance2to1()
+
+    call BuildTransferPlan(forest,nOld,oldLeaf,plan)
+    nNew = plan%nNew
+    print*,"nOld, nNew :",nOld,nNew
+
+    ! ---- Synthetic old field: whole numbers, so every transfer result is reproducible ----
+    ! exactly and a bitwise comparison is meaningful.
+    allocate(uOld(1:Np,1:Np,1:nOld,1:nvar))
+    do iv = 1,nvar
+      do e = 1,nOld
+        do j = 1,Np
+          do i = 1,Np
+            uOld(i,j,e,iv) = real(100000*iv+1000*e+10*i+j,prec)
+          enddo
+        enddo
+      enddo
+    enddo
+
+    allocate(winFirst(1:maxRanks),winLast(1:maxRanks))
+    allocate(claimed(1:nOld))
+
+    do icase = 1,nCases
+
+      ! Partition tables, in the offsetElem convention: rank q (0-based) owns elements
+      ! off(q)+1 .. off(q+1). Deliberately including cases DomainDecomp would never generate,
+      ! to exercise the routing rather than the balance policy.
+      select case(icase)
+      case(1) ! one rank: the whole field, the degenerate case
+        nRanks = 1
+        oldOff(0:1) = [0,nOld]
+        newOff(0:1) = [0,nNew]
+      case(2) ! four near-equal ranks, as DomainDecomp would split them
+        nRanks = 4
+        oldOff(0:4) = [0,nOld/4,nOld/2,(3*nOld)/4,nOld]
+        newOff(0:4) = [0,nNew/4,nNew/2,(3*nNew)/4,nNew]
+      case(3) ! heavy skew: the new partition bears no resemblance to the old one, so rank 0's
+        ! window spans every old owner - the multi-peer routing a 2-rank run cannot produce
+        nRanks = 5
+        oldOff(0:5) = [0,nOld/5,(2*nOld)/5,(3*nOld)/5,(4*nOld)/5,nOld]
+        newOff(0:5) = [0,nNew-3,nNew-2,nNew-1,nNew,nNew]
+      case(4) ! empty new ranges (ranks 0, 2 and 4 own nothing) and an empty old range
+        nRanks = 5
+        oldOff(0:5) = [0,0,nOld/2,nOld/2,nOld,nOld]
+        newOff(0:5) = [0,0,nNew/2,nNew/2,nNew,nNew]
+      case(5) ! reversed loading: rank 0 takes almost everything new while owning almost
+        ! nothing old, so its window is nearly all remote
+        nRanks = 2
+        oldOff(0:2) = [0,1,nOld]
+        newOff(0:2) = [0,nNew-1,nNew]
+      endselect
+
+      call PlanWindows(plan,nRanks,newOff(0:nRanks),winFirst(1:nRanks),winLast(1:nRanks))
+
+      do rank = 0,nRanks-1
+        eFirst = newOff(rank)+1
+        eLast = newOff(rank+1)
+        wFirst = winFirst(rank+1)
+        wLast = winLast(rank+1)
+
+        ! ---- (c) empty new range -> empty window sentinel ----
+        if(eLast < eFirst) then
+          if(wFirst <= wLast) then
+            print*,"FAIL: case",icase," rank",rank, &
+              " owns no new elements but got a non-empty window",wFirst,wLast
+            r = 1
+          endif
+          ! The exchange normalizes an empty window to (1,0). Every peer overlap must then come
+          ! out empty, so such a rank posts no receives at all - it only serves its peers.
+          nPeer = 0
+          do i = 1,nRanks
+            call OwnedRun(oldOff(0:nRanks),i,1,0,a,b)
+            if(b >= a) nPeer = nPeer+1
+          enddo
+          if(nPeer /= 0) then
+            print*,"FAIL: case",icase," rank",rank, &
+              " would post",nPeer," receives for an empty window"
+            r = 1
+          endif
+          nEmptyWindow = nEmptyWindow+1
+          cycle
+        endif
+
+        if(wFirst < 1 .or. wLast > nOld .or. wLast < wFirst) then
+          print*,"FAIL: case",icase," rank",rank," window out of range",wFirst,wLast
+          r = 1
+          cycle
+        endif
+
+        ! ---- (a) coverage and (b) tightness ----
+        claimed(1:nOld) = 0
+        do e = eFirst,eLast
+          if(plan%sourceKind(e) == SELF_TRANSFER_RESTRICT) then
+            do c = 1,4
+              src = plan%family(c,e)
+              if(src < wFirst .or. src > wLast) then
+                print*,"FAIL: case",icase," rank",rank," family source",src, &
+                  " outside window",wFirst,wLast
+                r = 1
+              else
+                claimed(src) = 1
+              endif
+            enddo
+          else
+            src = plan%sourceElem(e)
+            if(src < wFirst .or. src > wLast) then
+              print*,"FAIL: case",icase," rank",rank," source",src, &
+                " outside window",wFirst,wLast
+              r = 1
+            else
+              claimed(src) = 1
+            endif
+          endif
+        enddo
+        if(claimed(wFirst) == 0 .or. claimed(wLast) == 0) then
+          print*,"FAIL: case",icase," rank",rank," window",wFirst,wLast, &
+            " is not tight (an end is never referenced)"
+          r = 1
+        endif
+
+        ! ---- (d) the peer-overlap decomposition tiles the window exactly once ----
+        ! Driving OwnedRun, the routine ExchangeOldWindow itself uses for both its receive runs
+        ! and its send runs, so this checks that code rather than a copy of its formula.
+        nPeer = 0
+        nCovered = 0
+        do i = 1,nRanks
+          call OwnedRun(oldOff(0:nRanks),i,wFirst,wLast,a,b)
+          if(b < a) cycle
+          nCovered = nCovered+(b-a+1)
+          if(i-1 /= rank) nPeer = nPeer+1
+        enddo
+        if(nCovered /= wLast-wFirst+1) then
+          print*,"FAIL: case",icase," rank",rank," peer runs cover",nCovered, &
+            " of",wLast-wFirst+1," window elements"
+          r = 1
+        endif
+        maxPeers = max(maxPeers,nPeer)
+        call OwnedRun(oldOff(0:nRanks),rank+1,wFirst,wLast,a,b)
+        if(b < a) nAllRemote = nAllRemote+1
+
+        ! ---- (e) windowed apply is bit-identical to the whole-field apply ----
+        allocate(uRef(1:Np,1:Np,1:eLast-eFirst+1,1:nvar))
+        allocate(uWin(1:Np,1:Np,1:eLast-eFirst+1,1:nvar))
+        call ApplyTransferPlanRange(plan,interp,nvar,uOld,eFirst,eLast,uRef)
+        call ApplyTransferPlanWindow(plan,interp,nvar,uOld(:,:,wFirst:wLast,:), &
+                                     wFirst,wLast,eFirst,eLast,uWin)
+        if(any(uWin /= uRef)) then
+          print*,"FAIL: case",icase," rank",rank, &
+            " windowed apply differs from the whole-field apply; max|d| =", &
+            maxval(abs(uWin-uRef))
+          r = 1
+        endif
+        deallocate(uRef,uWin)
+
+      enddo
+    enddo
+
+    ! ---- The table above must actually have reached the interesting configurations ----
+    if(maxPeers < 3) then
+      print*,"FAIL: no case produced a window spanning 3 or more peers (maxPeers =",maxPeers,")"
+      r = 1
+    endif
+    if(nAllRemote == 0) then
+      print*,"FAIL: no case produced a rank whose window is entirely remote"
+      r = 1
+    endif
+    if(nEmptyWindow == 0) then
+      print*,"FAIL: no case produced a rank owning no new elements"
+      r = 1
+    endif
+    print*,"max peers, all-remote windows, empty windows :",maxPeers,nAllRemote,nEmptyWindow
+
+    ! ---- A window assembled the way ExchangeOldWindow assembles it transfers identically ----
+    ! Same routing as case 3 rank 0, but the window is filled run by run from per-rank local
+    ! slices rather than sliced out of a global array, which is what the exchange does.
+    nRanks = 5
+    oldOff(0:5) = [0,nOld/5,(2*nOld)/5,(3*nOld)/5,(4*nOld)/5,nOld]
+    newOff(0:5) = [0,nNew-3,nNew-2,nNew-1,nNew,nNew]
+    call PlanWindows(plan,nRanks,newOff(0:nRanks),winFirst(1:nRanks),winLast(1:nRanks))
+    wFirst = winFirst(1)
+    wLast = winLast(1)
+    eFirst = 1
+    eLast = newOff(1)
+    allocate(uWin(1:Np,1:Np,wFirst:wLast,1:nvar))
+    uWin = 0.0_prec
+    do i = 1,nRanks
+      a = max(wFirst,oldOff(i-1)+1)
+      b = min(wLast,oldOff(i))
+      if(b < a) cycle
+      ! rank i-1's own storage: its old elements, indexed from 1
+      allocate(uLoc(1:Np,1:Np,1:oldOff(i)-oldOff(i-1),1:nvar))
+      uLoc(:,:,:,:) = uOld(:,:,oldOff(i-1)+1:oldOff(i),:)
+      uWin(:,:,a:b,:) = uLoc(:,:,a-oldOff(i-1):b-oldOff(i-1),:)
+      deallocate(uLoc)
+    enddo
+    allocate(uRef(1:Np,1:Np,1:eLast-eFirst+1,1:nvar))
+    allocate(uAsm(1:Np,1:Np,1:eLast-eFirst+1,1:nvar))
+    call ApplyTransferPlanRange(plan,interp,nvar,uOld,eFirst,eLast,uRef)
+    call ApplyTransferPlanWindow(plan,interp,nvar,uWin,wFirst,wLast,eFirst,eLast,uAsm)
+    if(any(uAsm /= uRef)) then
+      print*,"FAIL: run-by-run assembled window differs from the whole-field apply"
+      r = 1
+    endif
+    deallocate(uRef,uAsm,uWin)
+
+    if(r == 0) print*,"TRANSFER PLAN 2D WINDOW CHECKS PASSED"
+
+    call plan%Free()
+    call forest%Free()
+    deallocate(uOld,winFirst,winLast,claimed,oldLeaf)
+    call interp%Free()
+    call baseMesh%Free()
+
+  endfunction transfer_plan_2d_window
+
+endprogram test

--- a/test/transfer_plan_3d_guard_window.f90
+++ b/test/transfer_plan_3d_guard_window.f90
@@ -1,0 +1,67 @@
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+!
+! Maintainers : support@fluidnumerics.com
+! Official Repository : https://github.com/FluidNumerics/self/
+!
+! Copyright © 2024 Fluid Numerics LLC
+!
+! Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+!
+! 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+!    the documentation and/or other materials provided with the distribution.
+!
+! 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+!    this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+! HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+! LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+! THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+! THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+!
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+
+! Guard test (expected to abort): ApplyTransferPlanWindow must reject an old-element window that
+! does not cover an old element the requested new range references - the failure mode a wrong
+! point-to-point migration window would produce. Registered with WILL_FAIL in CMake, so `stop 1`
+! is the passing outcome.
+program test
+  use SELF_Constants
+  use SELF_Lagrange
+  use SELF_Mesh_3D
+  use SELF_OctreeMesh_3D
+  use SELF_TransferPlan_3D
+  implicit none
+  type(Mesh3D),target :: mesh
+  type(OctreeMesh3D) :: forest
+  type(TransferPlan3D) :: plan
+  type(Lagrange),target :: interp
+  integer :: bcids(1:6)
+  integer :: flag(1:8)
+  integer,allocatable :: oldLeaf(:)
+  real(prec),allocatable :: uWin(:,:,:,:,:),uNew(:,:,:,:,:)
+
+  bcids(1:6) = [SELF_BC_PRESCRIBED,SELF_BC_PRESCRIBED,SELF_BC_PRESCRIBED, &
+                SELF_BC_PRESCRIBED,SELF_BC_PRESCRIBED,SELF_BC_PRESCRIBED]
+  call mesh%StructuredMesh(2,2,2,1,1,1,0.5_prec,0.5_prec,0.5_prec,bcids)
+  call interp%Init(N=2,controlNodeType=GAUSS,M=2,targetNodeType=UNIFORM)
+  call forest%Init(mesh)
+
+  ! Refine every root: each new leaf prolongs from the old element it descends from, so the new
+  ! range 1..nNew references every old element 1..8.
+  allocate(oldLeaf(1:forest%nLeaves))
+  oldLeaf = forest%leaf(1:forest%nLeaves)
+  flag = OCTREE_REFINE
+  call forest%AdaptFromFlags(flag)
+  call BuildTransferPlan(forest,8,oldLeaf,plan)
+
+  ! A window holding only old elements 1..4 cannot serve the whole new range.
+  allocate(uWin(1:3,1:3,1:3,1:4,1:1),uNew(1:3,1:3,1:3,1:plan%nNew,1:1))
+  uWin = 0.0_prec
+  call ApplyTransferPlanWindow(plan,interp,1,uWin,1,4,1,plan%nNew,uNew) ! must stop 1
+
+  print*,"ERROR: ApplyTransferPlanWindow coverage guard did not trigger"
+endprogram test

--- a/test/transfer_plan_3d_guard_windowbounds.f90
+++ b/test/transfer_plan_3d_guard_windowbounds.f90
@@ -1,0 +1,64 @@
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+!
+! Maintainers : support@fluidnumerics.com
+! Official Repository : https://github.com/FluidNumerics/self/
+!
+! Copyright © 2024 Fluid Numerics LLC
+!
+! Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+!
+! 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+!    the documentation and/or other materials provided with the distribution.
+!
+! 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+!    this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+! HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+! LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+! THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+! THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+!
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+
+! Guard test (expected to abort): ApplyTransferPlanWindow must reject an old-element window that
+! is not inside 1..nOld - the shape of a window computed against the wrong plan or the wrong
+! partition. Registered with WILL_FAIL in CMake, so `stop 1` is the passing outcome.
+program test
+  use SELF_Constants
+  use SELF_Lagrange
+  use SELF_Mesh_3D
+  use SELF_OctreeMesh_3D
+  use SELF_TransferPlan_3D
+  implicit none
+  type(Mesh3D),target :: mesh
+  type(OctreeMesh3D) :: forest
+  type(TransferPlan3D) :: plan
+  type(Lagrange),target :: interp
+  integer :: bcids(1:6)
+  integer :: flag(1:8)
+  integer,allocatable :: oldLeaf(:)
+  real(prec),allocatable :: uWin(:,:,:,:,:),uNew(:,:,:,:,:)
+
+  bcids(1:6) = [SELF_BC_PRESCRIBED,SELF_BC_PRESCRIBED,SELF_BC_PRESCRIBED, &
+                SELF_BC_PRESCRIBED,SELF_BC_PRESCRIBED,SELF_BC_PRESCRIBED]
+  call mesh%StructuredMesh(2,2,2,1,1,1,0.5_prec,0.5_prec,0.5_prec,bcids)
+  call interp%Init(N=2,controlNodeType=GAUSS,M=2,targetNodeType=UNIFORM)
+  call forest%Init(mesh)
+
+  allocate(oldLeaf(1:forest%nLeaves))
+  oldLeaf = forest%leaf(1:forest%nLeaves)
+  flag = OCTREE_REFINE
+  call forest%AdaptFromFlags(flag)
+  call BuildTransferPlan(forest,8,oldLeaf,plan)
+
+  ! The window claims to hold old elements 1..nOld+1, one past the end of the old element list.
+  allocate(uWin(1:3,1:3,1:3,1:plan%nOld+1,1:1),uNew(1:3,1:3,1:3,1:plan%nNew,1:1))
+  uWin = 0.0_prec
+  call ApplyTransferPlanWindow(plan,interp,1,uWin,1,plan%nOld+1,1,plan%nNew,uNew) ! must stop 1
+
+  print*,"ERROR: ApplyTransferPlanWindow bounds guard did not trigger"
+endprogram test

--- a/test/transfer_plan_3d_guard_windowfamily.f90
+++ b/test/transfer_plan_3d_guard_windowfamily.f90
@@ -1,0 +1,76 @@
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+!
+! Maintainers : support@fluidnumerics.com
+! Official Repository : https://github.com/FluidNumerics/self/
+!
+! Copyright © 2024 Fluid Numerics LLC
+!
+! Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+!
+! 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+!    the documentation and/or other materials provided with the distribution.
+!
+! 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+!    this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+! HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+! LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+! THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+! THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+!
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+
+! Guard test (expected to abort): ApplyTransferPlanWindow must reject a window that omits one of
+! the eight children of a coarsened family. A family's children can be owned by different ranks
+! before an epoch, so this is the specific way a too-narrow migration window fails on the
+! RESTRICT path. Registered with WILL_FAIL in CMake, so `stop 1` is the passing outcome.
+program test
+  use SELF_Constants
+  use SELF_Lagrange
+  use SELF_Mesh_3D
+  use SELF_OctreeMesh_3D
+  use SELF_TransferPlan_3D
+  implicit none
+  type(Mesh3D),target :: mesh
+  type(OctreeMesh3D) :: forest
+  type(TransferPlan3D) :: plan
+  type(Lagrange),target :: interp
+  integer :: bcids(1:6)
+  integer :: nOld
+  integer,allocatable :: flag(:),oldLeaf(:)
+  real(prec),allocatable :: uWin(:,:,:,:,:),uNew(:,:,:,:,:)
+
+  bcids(1:6) = [SELF_BC_PRESCRIBED,SELF_BC_PRESCRIBED,SELF_BC_PRESCRIBED, &
+                SELF_BC_PRESCRIBED,SELF_BC_PRESCRIBED,SELF_BC_PRESCRIBED]
+  call mesh%StructuredMesh(2,2,2,1,1,1,0.5_prec,0.5_prec,0.5_prec,bcids)
+  call interp%Init(N=2,controlNodeType=GAUSS,M=2,targetNodeType=UNIFORM)
+  call forest%Init(mesh)
+
+  ! Refine root 1 so the epoch has a complete eight-child family to coarsen: old elements 1-8 are
+  ! that family, 9-15 the remaining roots.
+  allocate(flag(1:forest%nLeaves))
+  flag = OCTREE_KEEP
+  flag(1) = OCTREE_REFINE
+  call forest%AdaptFromFlags(flag)
+  deallocate(flag)
+
+  nOld = forest%nLeaves
+  allocate(oldLeaf(1:nOld))
+  oldLeaf = forest%leaf(1:nOld)
+  allocate(flag(1:nOld))
+  flag = OCTREE_KEEP
+  flag(1:8) = OCTREE_COARSEN
+  call forest%AdaptFromFlags(flag)
+  call BuildTransferPlan(forest,nOld,oldLeaf,plan)
+
+  ! A window starting at old element 2 omits child 1 of the coarsened family.
+  allocate(uWin(1:3,1:3,1:3,2:plan%nOld,1:1),uNew(1:3,1:3,1:3,1:plan%nNew,1:1))
+  uWin = 0.0_prec
+  call ApplyTransferPlanWindow(plan,interp,1,uWin,2,plan%nOld,1,plan%nNew,uNew) ! must stop 1
+
+  print*,"ERROR: ApplyTransferPlanWindow family-coverage guard did not trigger"
+endprogram test

--- a/test/transfer_plan_3d_window.f90
+++ b/test/transfer_plan_3d_window.f90
@@ -1,0 +1,349 @@
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+!
+! Maintainers : support@fluidnumerics.com
+! Official Repository : https://github.com/FluidNumerics/self/
+!
+! Copyright © 2024 Fluid Numerics LLC
+!
+! Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+!
+! 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in
+!    the documentation and/or other materials provided with the distribution.
+!
+! 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from
+!    this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+! HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+! LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+! THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+! THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+!
+! //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// !
+
+program test
+
+  implicit none
+  integer :: exit_code
+
+  exit_code = transfer_plan_3d_window()
+  if(exit_code /= 0) then
+    stop exit_code
+  endif
+
+contains
+
+  integer function transfer_plan_3d_window() result(r)
+    !! Unit test for the routing arithmetic behind the point-to-point AMR solution migration
+    !! (Stage-5 v2): PlanWindows, the peer-overlap decomposition ExchangeOldWindow performs, and
+    !! the windowed apply ApplyTransferPlanWindow. Serial by construction - the whole point of
+    !! the design is that routing is a LOCAL computation on the rank-replicated plan, so every
+    !! rank's decisions can be reproduced and checked in one process, for partitions that a
+    !! 2-rank MPI test could never produce.
+    !!
+    !! One adaptation epoch of a 2 x 2 x 2 base forest produces a plan containing all three
+    !! transfer kinds (COPY, PROLONG at depths 1 and 2, RESTRICT of a complete eight-child
+    !! family), so the checks below cover the family case, whose eight children may straddle a
+    !! partition boundary.
+    !!
+    !! For each of a table of (old partition, new partition) pairs, and for every rank in it:
+    !!
+    !!  (a) Coverage: every old element the rank's new range references lies inside the window
+    !!      PlanWindows returned. This is what correctness requires of the window.
+    !!  (b) Tightness: both window ends are themselves referenced, so the window is the exact
+    !!      hull and the migration moves no more than it must. This is what the performance
+    !!      claim requires.
+    !!  (c) Empty ranges: a rank owning no new elements gets the empty sentinel
+    !!      (winFirst > winLast).
+    !!  (d) Overlap decomposition: the per-peer contiguous runs ExchangeOldWindow derives from
+    !!      the old offsetElem table tile the window exactly once - no gap, no double cover, no
+    !!      off-by-one - and every referenced element is claimed by exactly one owner.
+    !!  (e) Windowed apply: applying the plan to the rank's new range from a window slice
+    !!      reproduces, BIT FOR BIT, what applying it from the whole global old field produces.
+    !!      Exact equality is the bar, not a tolerance: it is the same operands fed to the same
+    !!      operators in the same order, which is the guarantee the migration rests on.
+    use SELF_Constants
+    use SELF_Lagrange
+    use SELF_Mesh_3D
+    use SELF_OctreeMesh_3D
+    use SELF_AdaptiveMesh_3D
+    use SELF_TransferPlan_3D
+    use SELF_AMRController_3D,only:PlanWindows,OwnedRun
+
+    implicit none
+
+    integer,parameter :: controlDegree = 3
+    integer,parameter :: nvar = 2
+    integer,parameter :: nCases = 5
+    integer,parameter :: maxRanks = 5
+    type(Lagrange),target :: interp
+    type(Mesh3D),target :: baseMesh
+    type(OctreeMesh3D) :: forest
+    type(TransferPlan3D) :: plan
+    integer :: bcids(1:6)
+    integer :: i,j,k,e,c,iv,rank,icase,nOld,nNew,Np
+    integer :: nRanks,eFirst,eLast,wFirst,wLast,a,b,src
+    integer :: nPeer,nCovered,maxPeers,nAllRemote,nEmptyWindow
+    integer,allocatable :: flag(:),oldLeaf(:)
+    integer,allocatable :: winFirst(:),winLast(:)
+    integer,allocatable :: claimed(:)
+    integer :: oldOff(0:maxRanks),newOff(0:maxRanks)
+    real(prec),allocatable :: uOld(:,:,:,:,:),uRef(:,:,:,:,:),uWin(:,:,:,:,:),uLoc(:,:,:,:,:)
+    real(prec),allocatable :: uAsm(:,:,:,:,:)
+
+    r = 0
+    maxPeers = 0
+    nAllRemote = 0
+    nEmptyWindow = 0
+    Np = controlDegree+1
+    bcids(1:6) = [SELF_BC_PRESCRIBED,SELF_BC_PRESCRIBED,SELF_BC_PRESCRIBED, &
+                  SELF_BC_PRESCRIBED,SELF_BC_PRESCRIBED,SELF_BC_PRESCRIBED]
+
+    call baseMesh%StructuredMesh(2,2,2,1,1,1,0.5_prec,0.5_prec,0.5_prec,bcids)
+    call interp%Init(N=controlDegree,controlNodeType=GAUSS,M=controlDegree, &
+                     targetNodeType=UNIFORM)
+
+    ! ---- Pre-epoch state: refine root 1, so the epoch has a family available to coarsen ----
+    call forest%Init(baseMesh)
+    allocate(flag(1:forest%nLeaves))
+    flag = OCTREE_KEEP
+    flag(1) = OCTREE_REFINE
+    call forest%AdaptFromFlags(flag)
+    deallocate(flag)
+
+    nOld = forest%nLeaves
+    allocate(oldLeaf(1:nOld))
+    oldLeaf(1:nOld) = forest%leaf(1:nOld)
+
+    ! ---- One adaptation epoch: coarsen root 1's family, refine root 2, re-refine root 1, ----
+    ! ---- refine one grandchild, then 2:1-balance. Yields COPY, PROLONG d1/d2, RESTRICT.  ----
+    allocate(flag(1:nOld))
+    flag = OCTREE_KEEP
+    flag(1:8) = OCTREE_COARSEN
+    flag(9) = OCTREE_REFINE
+    call forest%AdaptFromFlags(flag)
+    deallocate(flag)
+    call forest%RefineNode(1)
+    call forest%RefineNode(forest%child(3,2))
+    call forest%RebuildLeaves()
+    call forest%Balance2to1()
+
+    call BuildTransferPlan(forest,nOld,oldLeaf,plan)
+    nNew = plan%nNew
+    print*,"nOld, nNew :",nOld,nNew
+
+    ! ---- Synthetic old field: whole numbers, so every transfer result is reproducible ----
+    ! exactly and a bitwise comparison is meaningful.
+    allocate(uOld(1:Np,1:Np,1:Np,1:nOld,1:nvar))
+    do iv = 1,nvar
+      do e = 1,nOld
+        do k = 1,Np
+          do j = 1,Np
+            do i = 1,Np
+              uOld(i,j,k,e,iv) = real(100000*iv+1000*e+100*i+10*j+k,prec)
+            enddo
+          enddo
+        enddo
+      enddo
+    enddo
+
+    allocate(winFirst(1:maxRanks),winLast(1:maxRanks))
+    allocate(claimed(1:nOld))
+
+    do icase = 1,nCases
+
+      ! Partition tables, in the offsetElem convention: rank q (0-based) owns elements
+      ! off(q)+1 .. off(q+1). Deliberately including cases DomainDecomp would never generate,
+      ! to exercise the routing rather than the balance policy.
+      select case(icase)
+      case(1) ! one rank: the whole field, the degenerate case
+        nRanks = 1
+        oldOff(0:1) = [0,nOld]
+        newOff(0:1) = [0,nNew]
+      case(2) ! four near-equal ranks, as DomainDecomp would split them
+        nRanks = 4
+        oldOff(0:4) = [0,nOld/4,nOld/2,(3*nOld)/4,nOld]
+        newOff(0:4) = [0,nNew/4,nNew/2,(3*nNew)/4,nNew]
+      case(3) ! heavy skew: the new partition bears no resemblance to the old one, so rank 0's
+        ! window spans every old owner - the multi-peer routing a 2-rank run cannot produce
+        nRanks = 5
+        oldOff(0:5) = [0,nOld/5,(2*nOld)/5,(3*nOld)/5,(4*nOld)/5,nOld]
+        newOff(0:5) = [0,nNew-3,nNew-2,nNew-1,nNew,nNew]
+      case(4) ! empty new ranges (ranks 0, 2 and 4 own nothing) and an empty old range
+        nRanks = 5
+        oldOff(0:5) = [0,0,nOld/2,nOld/2,nOld,nOld]
+        newOff(0:5) = [0,0,nNew/2,nNew/2,nNew,nNew]
+      case(5) ! reversed loading: rank 0 takes almost everything new while owning almost
+        ! nothing old, so its window is nearly all remote
+        nRanks = 2
+        oldOff(0:2) = [0,1,nOld]
+        newOff(0:2) = [0,nNew-1,nNew]
+      endselect
+
+      call PlanWindows(plan,nRanks,newOff(0:nRanks),winFirst(1:nRanks),winLast(1:nRanks))
+
+      do rank = 0,nRanks-1
+        eFirst = newOff(rank)+1
+        eLast = newOff(rank+1)
+        wFirst = winFirst(rank+1)
+        wLast = winLast(rank+1)
+
+        ! ---- (c) empty new range -> empty window sentinel ----
+        if(eLast < eFirst) then
+          if(wFirst <= wLast) then
+            print*,"FAIL: case",icase," rank",rank, &
+              " owns no new elements but got a non-empty window",wFirst,wLast
+            r = 1
+          endif
+          ! The exchange normalizes an empty window to (1,0). Every peer overlap must then come
+          ! out empty, so such a rank posts no receives at all - it only serves its peers.
+          nPeer = 0
+          do i = 1,nRanks
+            call OwnedRun(oldOff(0:nRanks),i,1,0,a,b)
+            if(b >= a) nPeer = nPeer+1
+          enddo
+          if(nPeer /= 0) then
+            print*,"FAIL: case",icase," rank",rank, &
+              " would post",nPeer," receives for an empty window"
+            r = 1
+          endif
+          nEmptyWindow = nEmptyWindow+1
+          cycle
+        endif
+
+        if(wFirst < 1 .or. wLast > nOld .or. wLast < wFirst) then
+          print*,"FAIL: case",icase," rank",rank," window out of range",wFirst,wLast
+          r = 1
+          cycle
+        endif
+
+        ! ---- (a) coverage and (b) tightness ----
+        claimed(1:nOld) = 0
+        do e = eFirst,eLast
+          if(plan%sourceKind(e) == SELF_TRANSFER_RESTRICT) then
+            do c = 1,8
+              src = plan%family(c,e)
+              if(src < wFirst .or. src > wLast) then
+                print*,"FAIL: case",icase," rank",rank," family source",src, &
+                  " outside window",wFirst,wLast
+                r = 1
+              else
+                claimed(src) = 1
+              endif
+            enddo
+          else
+            src = plan%sourceElem(e)
+            if(src < wFirst .or. src > wLast) then
+              print*,"FAIL: case",icase," rank",rank," source",src, &
+                " outside window",wFirst,wLast
+              r = 1
+            else
+              claimed(src) = 1
+            endif
+          endif
+        enddo
+        if(claimed(wFirst) == 0 .or. claimed(wLast) == 0) then
+          print*,"FAIL: case",icase," rank",rank," window",wFirst,wLast, &
+            " is not tight (an end is never referenced)"
+          r = 1
+        endif
+
+        ! ---- (d) the peer-overlap decomposition tiles the window exactly once ----
+        ! Driving OwnedRun, the routine ExchangeOldWindow itself uses for both its receive runs
+        ! and its send runs, so this checks that code rather than a copy of its formula.
+        nPeer = 0
+        nCovered = 0
+        do i = 1,nRanks
+          call OwnedRun(oldOff(0:nRanks),i,wFirst,wLast,a,b)
+          if(b < a) cycle
+          nCovered = nCovered+(b-a+1)
+          if(i-1 /= rank) nPeer = nPeer+1
+        enddo
+        if(nCovered /= wLast-wFirst+1) then
+          print*,"FAIL: case",icase," rank",rank," peer runs cover",nCovered, &
+            " of",wLast-wFirst+1," window elements"
+          r = 1
+        endif
+        maxPeers = max(maxPeers,nPeer)
+        call OwnedRun(oldOff(0:nRanks),rank+1,wFirst,wLast,a,b)
+        if(b < a) nAllRemote = nAllRemote+1
+
+        ! ---- (e) windowed apply is bit-identical to the whole-field apply ----
+        allocate(uRef(1:Np,1:Np,1:Np,1:eLast-eFirst+1,1:nvar))
+        allocate(uWin(1:Np,1:Np,1:Np,1:eLast-eFirst+1,1:nvar))
+        call ApplyTransferPlanRange(plan,interp,nvar,uOld,eFirst,eLast,uRef)
+        call ApplyTransferPlanWindow(plan,interp,nvar,uOld(:,:,:,wFirst:wLast,:), &
+                                     wFirst,wLast,eFirst,eLast,uWin)
+        if(any(uWin /= uRef)) then
+          print*,"FAIL: case",icase," rank",rank, &
+            " windowed apply differs from the whole-field apply; max|d| =", &
+            maxval(abs(uWin-uRef))
+          r = 1
+        endif
+        deallocate(uRef,uWin)
+
+      enddo
+    enddo
+
+    ! ---- The table above must actually have reached the interesting configurations ----
+    if(maxPeers < 3) then
+      print*,"FAIL: no case produced a window spanning 3 or more peers (maxPeers =",maxPeers,")"
+      r = 1
+    endif
+    if(nAllRemote == 0) then
+      print*,"FAIL: no case produced a rank whose window is entirely remote"
+      r = 1
+    endif
+    if(nEmptyWindow == 0) then
+      print*,"FAIL: no case produced a rank owning no new elements"
+      r = 1
+    endif
+    print*,"max peers, all-remote windows, empty windows :",maxPeers,nAllRemote,nEmptyWindow
+
+    ! ---- A window assembled the way ExchangeOldWindow assembles it transfers identically ----
+    ! Same routing as case 3 rank 0, but the window is filled run by run from per-rank local
+    ! slices rather than sliced out of a global array, which is what the exchange does.
+    nRanks = 5
+    oldOff(0:5) = [0,nOld/5,(2*nOld)/5,(3*nOld)/5,(4*nOld)/5,nOld]
+    newOff(0:5) = [0,nNew-3,nNew-2,nNew-1,nNew,nNew]
+    call PlanWindows(plan,nRanks,newOff(0:nRanks),winFirst(1:nRanks),winLast(1:nRanks))
+    wFirst = winFirst(1)
+    wLast = winLast(1)
+    eFirst = 1
+    eLast = newOff(1)
+    allocate(uWin(1:Np,1:Np,1:Np,wFirst:wLast,1:nvar))
+    uWin = 0.0_prec
+    do i = 1,nRanks
+      a = max(wFirst,oldOff(i-1)+1)
+      b = min(wLast,oldOff(i))
+      if(b < a) cycle
+      ! rank i-1's own storage: its old elements, indexed from 1
+      allocate(uLoc(1:Np,1:Np,1:Np,1:oldOff(i)-oldOff(i-1),1:nvar))
+      uLoc(:,:,:,:,:) = uOld(:,:,:,oldOff(i-1)+1:oldOff(i),:)
+      uWin(:,:,:,a:b,:) = uLoc(:,:,:,a-oldOff(i-1):b-oldOff(i-1),:)
+      deallocate(uLoc)
+    enddo
+    allocate(uRef(1:Np,1:Np,1:Np,1:eLast-eFirst+1,1:nvar))
+    allocate(uAsm(1:Np,1:Np,1:Np,1:eLast-eFirst+1,1:nvar))
+    call ApplyTransferPlanRange(plan,interp,nvar,uOld,eFirst,eLast,uRef)
+    call ApplyTransferPlanWindow(plan,interp,nvar,uWin,wFirst,wLast,eFirst,eLast,uAsm)
+    if(any(uAsm /= uRef)) then
+      print*,"FAIL: run-by-run assembled window differs from the whole-field apply"
+      r = 1
+    endif
+    deallocate(uRef,uAsm,uWin)
+
+    if(r == 0) print*,"TRANSFER PLAN 3D WINDOW CHECKS PASSED"
+
+    call plan%Free()
+    call forest%Free()
+    deallocate(uOld,winFirst,winLast,claimed,oldLeaf)
+    call interp%Free()
+    call baseMesh%Free()
+
+  endfunction transfer_plan_3d_window
+
+endprogram test


### PR DESCRIPTION
Closes #167 (Stage 1). Point-to-point AMR solution migration in **both 2-D and 3-D**.

## The problem

Every adapting epoch allgathered the **entire global old solution field** onto every rank and sliced out that rank's new contiguous SFC range, so per-rank memory and communication were O(global DOF), on the host, once per epoch. At `maxLevel = 3` the 3-D example field is 125 MB; at four ranks each rank received ~94 MB per adapting epoch and allocated a second full field beside the live one.

## The idea

The forest and the transfer plan are **rank-replicated**, and both the old and the new partition are contiguous ranges of the *same* space-filling-curve leaf order. Therefore:

- the old elements a rank's new range reads form a contiguous **window** of the old element list — `PlanWindows` takes the min/max hull of the referenced indices in one pass over the plan;
- a rank derives its own window **and every peer's** locally, so send runs (my old range ∩ peer's window) and receive runs (my window ∩ peer's old range) are the same intersection evaluated on both ends (`OwnedRun`) and match by construction — **no count exchange, no handshake, no collective**;
- **nothing is packed**: a run of elements at a fixed variable is contiguous in both `solution%interior` and the window, so each `MPI_Isend`/`MPI_Irecv` reads and writes the real storage. One message per (peer, variable).

Correctness does not depend on the leaf ordering being monotone — a non-monotone ordering only widens the hull, worst case the whole old list, which is what the old path moved anyway. Locality is what the SFC buys.

`ApplyTransferPlanRange` now delegates to a new `ApplyTransferPlanWindow` over the whole field, so the two paths share one body and are **bit-identical by construction**. `SELF_AMR_MIGRATE_GATHER=1` restores the v1 collective (retained, not deleted, per CLAUDE.md §10); `SELF_AMR_MIGRATE_VERIFY=1` runs both in one process and compares value by value.

The exchange runs **before** `Regrid`, where both partitions are known and the sends can read the still-live pre-regrid solution, so no traffic is in flight while `Regrid` rebuilds mesh state on the same communicator. Nothing is added to the time-stepping loop; the single-rank path is untouched.

## Measured

Per-rank totals over a run. Both paths use the same counters, both runs of a pair have identical `nAdaptEpochs`/`nElemFinal`, and final pressure extrema agree to every printed digit.

| case | ranks | received, v1 | received, v2 | remote elements |
|---|---|---|---|---|
| 3-D | 2 | 35.9 MB | **0** | 5988 → 0 |
| 3-D | 4 | 53.9 MB | **0.95 MB** | 8982 → 159 |
| 3-D | 8 | 62.9 MB | **1.80 MB** | 10479 → 300 |
| 2-D | 4 | 16.3 MB | **0.55 MB** | 6363 → 215 |

Adaptation time on one B300 node (4 GPUs, one rank per GPU, 4 reps with the two paths interleaved per rep), median seconds per *adapting* epoch:

| ranks | v1 gather | v2 p2p |
|---|---|---|
| 1 | 0.982 [0.914, 0.985] | 0.965 [0.961, 0.988] |
| 2 | 0.538 [0.525, 0.558] | 0.553 [0.528, 0.558] |
| 4 | 0.332 [0.296, 0.340] | 0.287 [0.286, 0.302] |

At one rank the two are the same code path and measure the same — that is the check that the windowed apply and its bounds guard cost nothing where nothing migrates. At two ranks removing 123 MB/rank of on-node collective buys no measurable time (adaptation is geometry-dominated). At four ranks the ranges no longer overlap: ~13% faster per adapting epoch. `tForwardStep` is unchanged at every rank count. **The volume reduction is the durable result; the time is what that volume happened to cost at this scale.** Peak RSS is not a usable signal at example size — the removed buffer is smaller than the noise against a footprint set by the replicated forest and geometry buffers.

## Tests

- `transfer_plan_{2,3}d_window` (serial): drives `PlanWindows`/`OwnedRun` over partitions a 2-rank run cannot produce — empty new ranges, empty old ranges, a window spanning four peers, an all-remote window — checking coverage, **tightness** (both window ends are actually referenced, so nothing surplus moves), and bitwise agreement with the whole-field apply. Fails if the table stops reaching those configurations.
- `transfer_plan_{2,3}d_guard_window` (`WILL_FAIL`): a window that misses a referenced source must `stop 1`.
- `amr_migrate_{2,3}d_window_mpi` (2 and 4 ranks): the real `ExchangeOldWindow` on a deliberately **asymmetric** adaptation, with an analytic field encoding each element's global index so a misrouted element names itself — and an assertion that elements really did cross ranks. This matters: a *symmetric* refinement leaves every rank's window inside its own old range (0 bytes moved), so a verify run would pass without the schedule ever posting a message.
- `MIGRATE_VERIFY` / `MIGRATE_GATHER` re-runs of the existing AMR MPI regressions, plus 4-rank variants (`SELF_MPIEXEC_NUMPROCS_MANY`, default 4) — two ranks cannot distinguish gather-then-slice from a routing bug.

274/274 pass on CPU (release); 42 serial + 34 MPI AMR/transfer/migration tests pass on a B300 GPU build (CUDA sm_103) at 2 and 4 ranks.

## Docs

`AMR3D-Design.md` gains the **MPI section it never had** (§4): ordering, replication, the window, why routing is communication-free, tags, sequencing, coarsened families straddling a boundary, degenerate cases, memory bound, bit-identity — and it reconciles `AMR2D-Design.md` §7, which had specified `MPI_Alltoallv`. The Learning page's Stage 5 gains sub-stage 5d, and §6.5/§6.6 are rewritten around what is now done and what remains: the device transfer on more than one rank (the window lands in host memory), and the distributed forest (#167 Stage 2, deliberately deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)